### PR TITLE
Prevent duplicate tswap markers when processing apply output

### DIFF
--- a/TswapCore/Redact.cs
+++ b/TswapCore/Redact.cs
@@ -231,7 +231,13 @@ public sealed class ToCommentProcessor : SecretProcessor
     protected override string GetSearchPattern(string searchText)
     {
         var escaped = Regex.Escape(searchText);
-        return $"(?:(?<![-\\w])\"{escaped}\"(?![-\\w])|(?<![-\\w])'{escaped}'(?![-\\w])|(?<![-\\w]){escaped}(?![-\\w]))";
+        // Optionally consume an existing tswap marker immediately following the value.
+        // This prevents duplication when processing `tswap apply` output, which emits lines
+        // like: key: "actual-secret"  # tswap: secret-name
+        // Without this, the marker would survive as a YAML comment and tocomment would
+        // append a second one, producing: key: ""  # tswap: secret-name  # tswap: secret-name
+        var existingMarker = @"(?:\s*#\s*tswap\s*:\s*[a-zA-Z0-9_-]+)?";
+        return $"(?:(?<![-\\w])\"{escaped}\"{existingMarker}(?![-\\w])|(?<![-\\w])'{escaped}'{existingMarker}(?![-\\w])|(?<![-\\w]){escaped}{existingMarker}(?![-\\w]))";
     }
 
     protected override string GetReplacement(string secretName, MatchType matchType)

--- a/TswapTests/RedactTests.cs
+++ b/TswapTests/RedactTests.cs
@@ -393,6 +393,52 @@ label: myapp-prod";
     }
 
     // -------------------------------------------------------------------------
+    // Redact.ToComment — duplicate marker prevention (apply output round-trip)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ToComment_ApplyOutputWithMatchingMarker_DoesNotDuplicateMarker()
+    {
+        // tswap apply produces: key: "s3cr3t"  # tswap: pw
+        // tocomment on that output must NOT produce: key: ""  # tswap: pw  # tswap: pw
+        var db = MakeDb(("pw", "s3cr3t"));
+        var applyOutput = "password: \"s3cr3t\"  # tswap: pw";
+        var (content, changes) = Redact.ToComment(applyOutput, db);
+        Assert.Equal("password: \"\"  # tswap: pw", content);
+        Assert.Single(changes);
+    }
+
+    [Fact]
+    public void ToComment_ApplyOutputUnquotedWithMatchingMarker_DoesNotDuplicateMarker()
+    {
+        // Unquoted variant: password: s3cr3t  # tswap: pw
+        var db = MakeDb(("pw", "s3cr3t"));
+        var (content, changes) = Redact.ToComment("password: s3cr3t  # tswap: pw", db);
+        Assert.Equal("password: \"\"  # tswap: pw", content);
+        Assert.Single(changes);
+    }
+
+    [Fact]
+    public void ToComment_ApplyOutputWithWrongMarker_ReplacesWithCorrectMarker()
+    {
+        // If the existing marker names a different secret, the correct secret wins.
+        // The stale marker is consumed and replaced with the one matching the actual value.
+        var db = MakeDb(("pw", "s3cr3t"));
+        var (content, changes) = Redact.ToComment("password: \"s3cr3t\"  # tswap: old-name", db);
+        Assert.Equal("password: \"\"  # tswap: pw", content);
+        Assert.Single(changes);
+    }
+
+    [Fact]
+    public void ToComment_ApplyOutputWithMarkerAndTrailingComment_PreservesTrailingComment()
+    {
+        // Marker is consumed; any trailing comments after the marker are unaffected.
+        var db = MakeDb(("pw", "s3cr3t"));
+        var (content, _) = Redact.ToComment("password: \"s3cr3t\"  # tswap: pw  # set at deploy", db);
+        Assert.Equal("password: \"\"  # tswap: pw  # set at deploy", content);
+    }
+
+    // -------------------------------------------------------------------------
     // Redact.FindUnknownSecrets
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Fixed an issue where running `tswap tocomment` on the output of `tswap apply` would duplicate the secret markers in YAML comments. When `tswap apply` emits lines like `key: "secret"  # tswap: name`, running `tocomment` on that output would previously produce `key: ""  # tswap: name  # tswap: name` instead of the correct `key: ""  # tswap: name`.

## Changes
- **Updated `ToCommentProcessor.GetSearchPattern()`** to optionally consume existing tswap markers immediately following secret values. The regex now matches and removes any existing `# tswap: secret-name` comment that directly follows the secret value before appending the correct marker.
  
- **Added comprehensive test coverage** for the duplicate marker prevention:
  - `ToComment_ApplyOutputWithMatchingMarker_DoesNotDuplicateMarker()` — quoted secret with matching marker
  - `ToComment_ApplyOutputUnquotedWithMatchingMarker_DoesNotDuplicateMarker()` — unquoted secret with matching marker
  - `ToComment_ApplyOutputWithWrongMarker_ReplacesWithCorrectMarker()` — stale/incorrect marker is replaced with the correct one
  - `ToComment_ApplyOutputWithMarkerAndTrailingComment_PreservesTrailingComment()` — trailing comments after the marker are preserved

## Implementation Details
The regex pattern now includes an optional non-capturing group `(?:\s*#\s*tswap\s*:\s*[a-zA-Z0-9_-]+)?` that matches and consumes existing tswap markers. This allows the processor to handle round-trip scenarios where output from `apply` is fed back into `tocomment`, while also handling cases where the marker name doesn't match the actual secret (replacing it with the correct one).

https://claude.ai/code/session_01S7K13cTw8Naqoyf5zZ67jp