### PR TITLE
Fix test hang in Export_Import_RoundTrip and Import_SkipsBurnedSecrets

### DIFF
--- a/TswapTests/ProgramTests.cs
+++ b/TswapTests/ProgramTests.cs
@@ -578,7 +578,8 @@ public class ProgramTests : IDisposable
 
         // Re-init clears the vault (also delete secrets.json.enc — test key is constant
         // so the old encrypted file remains readable if not explicitly removed)
-        RunTswap("init");
+        // "yes\n" answers the "Already initialized. Reinitialize?" prompt via stdin.
+        RunTswapWithStdin("yes\n", "init");
         File.Delete(Path.Combine(_tempDir, "secrets.json.enc"));
         var (exit, stdout, _) = RunTswapWithStdin("strongpassphrase\n", "import", exportPath);
 
@@ -601,7 +602,7 @@ public class ProgramTests : IDisposable
         var exportPath = Path.Combine(_tempDir, "backup.enc");
         RunTswapWithStdin("passphrase\npassphrase\n", "export", exportPath);
 
-        RunTswap("init");
+        RunTswapWithStdin("yes\n", "init");
         File.Delete(Path.Combine(_tempDir, "secrets.json.enc"));
         var (exit, stdout, _) = RunTswapWithStdin("passphrase\n", "import", exportPath);
 


### PR DESCRIPTION
## Summary

- Fixes #53
- Both `Export_Import_RoundTrip` and `Import_SkipsBurnedSecrets` called `RunTswap("init")` on an already-initialised vault, causing an infinite hang
- `CmdInit` detects an existing config and calls `Console.ReadLine()` for a "Reinitialize?" prompt; since `RunTswap` doesn't redirect stdin, the child inherited the terminal and blocked forever while the parent was simultaneously blocked on `ReadToEnd()`
- Fix: replace with `RunTswapWithStdin("yes\n", "init")` so the prompt is answered via the redirected stdin pipe

## Test plan

- [x] `Export_Import_RoundTrip` now passes (previously hung until 20s timeout)
- [x] `Import_SkipsBurnedSecrets` now passes
- [x] Full suite: 196/196 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)