### PR TITLE
Fix piped stdin hang in init and migrate (issue #39)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -317,13 +317,15 @@ void CmdInit()
 
     // Challenge first YubiKey
     Console.WriteLine("Insert YubiKey #1 and press Enter...");
-    Console.ReadLine();
+    if (!Console.IsInputRedirected)
+        Console.ReadLine();
     var serial1 = GetYubiKey();
     var k1 = ChallengeYubiKey(serial1, unlockChallenge);
 
     // Challenge second YubiKey
     Console.WriteLine("\nRemove YubiKey #1, insert YubiKey #2, press Enter...");
-    Console.ReadLine();
+    if (!Console.IsInputRedirected)
+        Console.ReadLine();
     var serial2 = GetYubiKey();
 
     if (serial1 == serial2)

--- a/TswapTests/ProgramTests.cs
+++ b/TswapTests/ProgramTests.cs
@@ -548,6 +548,20 @@ public class ProgramTests : IDisposable
         Assert.Equal("system", config.RngMode); // test mode uses default
     }
 
+    // Regression test for issue #39: init must not hang when stdin is piped.
+    // The "Insert YubiKey and press Enter" pauses are TTY-only; when stdin is
+    // redirected they must be skipped so that piped "yes" answers only the
+    // reinitialise prompt and the command completes normally.
+    [Fact]
+    public void Init_Reinit_PipedYes_DoesNotHang()
+    {
+        RunTswap("init");
+        // "yes\n" answers the "Already initialized. Reinitialize?" prompt.
+        var (exit, stdout, _) = RunTswapWithStdin("yes\n", "init");
+        Assert.Equal(0, exit);
+        Assert.Contains("test mode", stdout);
+    }
+
     // --- Export / Import ---
 
     [Fact]
@@ -689,6 +703,20 @@ public class ProgramTests : IDisposable
 
         Assert.Equal(0, exit);
         Assert.Contains("up to date", stdout);
+    }
+
+    // Regression test for issue #39: migrate must not hang when stdin is piped.
+    // Synthetic init leaves RequiresTouch=null → needsTouchMigration=true → the
+    // "Show detailed re-initialization instructions? (yes/no):" prompt is shown.
+    // Piped "no\n" must answer it without blocking and the command must exit 0.
+    [Fact]
+    public void Migrate_PipedNo_DoesNotHang()
+    {
+        RunTswap("init");
+        // Default synthetic config: RngMode="system", UnlockChallenge=set, RequiresTouch=null
+        // → needsReInit=true (touch migration required) → yes/no prompt is shown
+        var (exit, _, _) = RunTswapWithStdin("no\n", "migrate");
+        Assert.Equal(0, exit);
     }
 
     // --- tocomment: security ---

--- a/tswap.cs
+++ b/tswap.cs
@@ -455,13 +455,15 @@ void CmdInit()
 
     // Challenge first YubiKey
     Console.WriteLine("Insert YubiKey #1 and press Enter...");
-    Console.ReadLine();
+    if (!Console.IsInputRedirected)
+        Console.ReadLine();
     var serial1 = GetYubiKey();
     var k1 = ChallengeYubiKey(serial1, unlockChallenge);
 
     // Challenge second YubiKey
     Console.WriteLine("\nRemove YubiKey #1, insert YubiKey #2, press Enter...");
-    Console.ReadLine();
+    if (!Console.IsInputRedirected)
+        Console.ReadLine();
     var serial2 = GetYubiKey();
 
     if (serial1 == serial2)


### PR DESCRIPTION
## Summary

- Guard the two "Insert/Remove YubiKey… press Enter" `Console.ReadLine()` calls in `CmdInit` with `!Console.IsInputRedirected`, matching the pattern already used in `ReadPassword()`
- Apply the same fix to `tswap.cs` (dotnet-script entry point)
- Add regression tests `Init_Reinit_PipedYes_DoesNotHang` and `Migrate_PipedNo_DoesNotHang` that directly reproduce the issue's `echo "yes" | tswap init` and `echo "no" | tswap migrate` cases

## Root cause

The "Insert YubiKey #1 and press Enter…" / "Remove YubiKey #1…" prompts are TTY-only courtesy pauses that give the user time to physically swap hardware before `ykman` is called. When stdin is redirected (piped), `Console.ReadLine()` at those points silently consumes bytes from the pipe that were intended for other prompts. Afterwards, the YubiKey challenge that follows can block indefinitely if the HMAC slot requires a button press — producing the hang described in #39.

`add`, `export`, and `import` already work correctly because `ReadPassword()` checks `Console.IsInputRedirected` before calling `Console.ReadKey()`. The fix brings `init`'s hardware-swap pauses into line with that pattern.

`migrate` has no "press Enter" waits and was already correct; the new test confirms it stays that way.

## Test plan

- [x] `Init_Reinit_PipedYes_DoesNotHang` — piped `"yes\n"` re-initialises the vault and exits 0
- [x] `Migrate_PipedNo_DoesNotHang` — piped `"no\n"` declines reinit instructions and exits 0
- [x] Full test suite passes: 198 tests, 0 failures

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)