### PR TITLE
Fix five v0.0.3 quick-win bugs (#29, #41, #67, #68, #69)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -402,19 +402,27 @@ void CmdInit()
         unlockChallenge
     );
 
-    storage.SaveConfig(config);
     // Re-initialisation generates a new master key (new challenge + new XOR share), so any
-    // existing vault is no longer decryptable with it. Rename the old file to a timestamped
-    // backup so it remains recoverable (by restoring the old config alongside it), then
-    // create a fresh empty vault under the canonical name.
+    // existing vault is no longer decryptable with it. Back up both files before writing
+    // new ones so recovery (restore both .bak files together) remains possible.
+    // Config is backed up first — if anything fails mid-init the old config still matches
+    // the old vault backup.
+    var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
     var newVaultKey = Crypto.DeriveKey(k1, k2);
+    if (File.Exists(storage.ConfigFile))
+    {
+        var configBackup = storage.ConfigFile + ".bak-" + timestamp;
+        File.Copy(storage.ConfigFile, configBackup);
+    }
+    storage.SaveConfig(config);
     if (File.Exists(storage.SecretsFile))
     {
-        var backupPath = storage.SecretsFile + ".bak-" + DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmss'Z'");
-        File.Move(storage.SecretsFile, backupPath);
+        var vaultBackup = storage.SecretsFile + ".bak-" + timestamp;
+        File.Move(storage.SecretsFile, vaultBackup);
         Console.ForegroundColor = ConsoleColor.Yellow;
-        Console.WriteLine($"\nExisting vault moved to backup: {backupPath}");
-        Console.WriteLine("To recover old secrets: restore that file together with the previous config.json.");
+        Console.WriteLine($"\nExisting vault moved to backup: {vaultBackup}");
+        Console.WriteLine("Previous config backed up alongside it. To recover old secrets:");
+        Console.WriteLine("  restore both .bak files under their original names.");
         Console.ResetColor();
     }
     storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), newVaultKey);

--- a/Program.cs
+++ b/Program.cs
@@ -221,8 +221,9 @@ byte[] UnlockWithYubiKey(Config config, bool warnIfNoTouch = true)
     if (TestKey != null)
         return TestKey; // Bypass YubiKey entirely — use test key as master key
 
-    // Warn about missing touch requirement (suppressed for read-only metadata commands
-    // that never expose secret values: names, burned, burn, check).
+    // Warn about missing touch requirement (suppressed for commands that never expose
+    // secret values on stdout/stderr, even though they still decrypt the vault:
+    // names, burned, burn, check).
     if (warnIfNoTouch)
         YubiKey.WarnIfNoTouch(config);
 
@@ -259,8 +260,12 @@ byte[] UnlockWithYubiKey(Config config, bool warnIfNoTouch = true)
 // HELPER FUNCTIONS
 // ============================================================================
 
-string ReadPassword()
+// echo: stream that receives masking feedback (*, backspace, newline).
+// Defaults to Console.Out for vault-mutation commands; pass Console.Error for
+// export/import so stdout stays clean when the output is piped or redirected.
+string ReadPassword(TextWriter? echo = null)
 {
+    echo ??= Console.Out;
     // When stdin is redirected (e.g. in tests or piped input) skip interactive masking
     if (Console.IsInputRedirected)
         return Console.ReadLine() ?? "";
@@ -271,18 +276,18 @@ string ReadPassword()
         var key = Console.ReadKey(true);
         if (key.Key == ConsoleKey.Enter)
         {
-            Console.WriteLine();
+            echo.WriteLine();
             break;
         }
         if (key.Key == ConsoleKey.Backspace && password.Length > 0)
         {
             password.Remove(password.Length - 1, 1);
-            Console.Write("\b \b");
+            echo.Write("\b \b");
         }
         else if (!char.IsControl(key.KeyChar))
         {
             password.Append(key.KeyChar);
-            Console.Write("*");
+            echo.Write("*");
         }
     }
     return password.ToString();
@@ -572,9 +577,9 @@ void CmdExport(string path)
     }
 
     Console.Error.Write("Export passphrase: ");
-    var passphrase = ReadPassword();
+    var passphrase = ReadPassword(Console.Error);
     Console.Error.Write("Confirm passphrase: ");
-    var confirm = ReadPassword();
+    var confirm = ReadPassword(Console.Error);
     if (passphrase != confirm)
         throw new Exception("Passphrases don't match");
 
@@ -611,7 +616,7 @@ void CmdImport(string path)
         throw new Exception($"Export file not found: {path}");
 
     Console.Error.Write("Import passphrase: ");
-    var passphrase = ReadPassword();
+    var passphrase = ReadPassword(Console.Error);
 
     ExportFile exportFile;
     try
@@ -635,8 +640,16 @@ void CmdImport(string path)
     catch (CryptographicException) { throw new Exception("Decryption failed — wrong passphrase or file tampered"); }
     catch (FormatException) { throw new Exception("Export file is corrupted (base64 decode failed)"); }
 
-    var exportedDb = JsonSerializer.Deserialize(Encoding.UTF8.GetString(plaintext), TswapJsonContext.Default.SecretsDb)
-        ?? throw new Exception("Invalid export data");
+    SecretsDb exportedDb;
+    try
+    {
+        exportedDb = JsonSerializer.Deserialize(Encoding.UTF8.GetString(plaintext), TswapJsonContext.Default.SecretsDb)
+            ?? throw new Exception("Invalid export data");
+    }
+    catch (JsonException ex)
+    {
+        throw new Exception($"Export data is corrupted (decrypted payload is not valid JSON): {ex.Message}");
+    }
 
     var config = storage.LoadConfig();
     var key = UnlockWithYubiKey(config);

--- a/Program.cs
+++ b/Program.cs
@@ -403,12 +403,21 @@ void CmdInit()
     );
 
     storage.SaveConfig(config);
-    // Create an empty encrypted vault only when one does not already exist.
-    // On re-initialisation the old vault is encrypted with a now-unreachable key;
-    // leaving the file in place lets a user recover it from backup alongside the
-    // old config, rather than destroying the ciphertext entirely.
-    if (!File.Exists(storage.SecretsFile))
-        storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), Crypto.DeriveKey(k1, k2));
+    // Re-initialisation generates a new master key (new challenge + new XOR share), so any
+    // existing vault is no longer decryptable with it. Rename the old file to a timestamped
+    // backup so it remains recoverable (by restoring the old config alongside it), then
+    // create a fresh empty vault under the canonical name.
+    var newVaultKey = Crypto.DeriveKey(k1, k2);
+    if (File.Exists(storage.SecretsFile))
+    {
+        var backupPath = storage.SecretsFile + ".bak-" + DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmss'Z'");
+        File.Move(storage.SecretsFile, backupPath);
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine($"\nExisting vault moved to backup: {backupPath}");
+        Console.WriteLine("To recover old secrets: restore that file together with the previous config.json.");
+        Console.ResetColor();
+    }
+    storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), newVaultKey);
 
     Console.WriteLine("\n╔════════════════════════════════════════╗");
     Console.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");
@@ -580,7 +589,9 @@ void CmdExport(string path)
     if (File.Exists(path))
     {
         Console.Error.Write($"File '{path}' already exists. Overwrite? (yes/no): ");
-        if (Console.ReadLine()?.ToLower() != "yes")
+        var overwriteResponse = Console.ReadLine();
+        if (Console.IsInputRedirected) Console.Error.WriteLine();
+        if (overwriteResponse?.ToLower() != "yes")
             throw new Exception("Export cancelled.");
     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -266,9 +266,15 @@ byte[] UnlockWithYubiKey(Config config, bool warnIfNoTouch = true)
 string ReadPassword(TextWriter? echo = null)
 {
     echo ??= Console.Out;
-    // When stdin is redirected (e.g. in tests or piped input) skip interactive masking
+    // When stdin is redirected (e.g. in tests or piped input) skip interactive masking.
+    // Write a newline to echo so the next line of stderr output starts on a fresh line
+    // (the caller writes the prompt with Write, not WriteLine).
     if (Console.IsInputRedirected)
-        return Console.ReadLine() ?? "";
+    {
+        var line = Console.ReadLine() ?? "";
+        echo.WriteLine();
+        return line;
+    }
 
     var password = new StringBuilder();
     while (true)

--- a/Program.cs
+++ b/Program.cs
@@ -332,7 +332,8 @@ void CmdInit()
             Convert.ToHexString(RandomNumberGenerator.GetBytes(32))
         );
         storage.SaveConfig(testConfig);
-        storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), TestKey);
+        if (!File.Exists(storage.SecretsFile))
+            storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), TestKey);
         Console.WriteLine("Initialized (test mode)");
         return;
     }
@@ -396,11 +397,12 @@ void CmdInit()
     );
 
     storage.SaveConfig(config);
-    // Create an empty encrypted vault so the file exists from the start.
-    // This prevents LoadSecrets from logging a "vault not found" warning on the
-    // first vault-touching command and makes it clear the file was intentionally
-    // created (rather than being accidentally lost).
-    storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), Crypto.DeriveKey(k1, k2));
+    // Create an empty encrypted vault only when one does not already exist.
+    // On re-initialisation the old vault is encrypted with a now-unreachable key;
+    // leaving the file in place lets a user recover it from backup alongside the
+    // old config, rather than destroying the ciphertext entirely.
+    if (!File.Exists(storage.SecretsFile))
+        storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), Crypto.DeriveKey(k1, k2));
 
     Console.WriteLine("\n╔════════════════════════════════════════╗");
     Console.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");

--- a/Program.cs
+++ b/Program.cs
@@ -216,13 +216,15 @@ int GetYubiKey(int? requiredSerial = null)
     return serials[0];
 }
 
-byte[] UnlockWithYubiKey(Config config)
+byte[] UnlockWithYubiKey(Config config, bool warnIfNoTouch = true)
 {
     if (TestKey != null)
         return TestKey; // Bypass YubiKey entirely — use test key as master key
 
-    // Warn about missing touch requirement
-    YubiKey.WarnIfNoTouch(config);
+    // Warn about missing touch requirement (suppressed for read-only metadata commands
+    // that never expose secret values: names, burned, burn, check).
+    if (warnIfNoTouch)
+        YubiKey.WarnIfNoTouch(config);
 
     var serial = GetYubiKey();
 
@@ -325,6 +327,7 @@ void CmdInit()
             Convert.ToHexString(RandomNumberGenerator.GetBytes(32))
         );
         storage.SaveConfig(testConfig);
+        storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), TestKey);
         Console.WriteLine("Initialized (test mode)");
         return;
     }
@@ -388,6 +391,11 @@ void CmdInit()
     );
 
     storage.SaveConfig(config);
+    // Create an empty encrypted vault so the file exists from the start.
+    // This prevents LoadSecrets from logging a "vault not found" warning on the
+    // first vault-touching command and makes it clear the file was intentionally
+    // created (rather than being accidentally lost).
+    storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), Crypto.DeriveKey(k1, k2));
 
     Console.WriteLine("\n╔════════════════════════════════════════╗");
     Console.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");
@@ -558,13 +566,14 @@ void CmdExport(string path)
 
     if (File.Exists(path))
     {
-        Console.Write($"File '{path}' already exists. Overwrite? (yes/no): ");
-        if (Console.ReadLine()?.ToLower() != "yes") return;
+        Console.Error.Write($"File '{path}' already exists. Overwrite? (yes/no): ");
+        if (Console.ReadLine()?.ToLower() != "yes")
+            throw new Exception("Export cancelled.");
     }
 
-    Console.Write("Export passphrase: ");
+    Console.Error.Write("Export passphrase: ");
     var passphrase = ReadPassword();
-    Console.Write("Confirm passphrase: ");
+    Console.Error.Write("Confirm passphrase: ");
     var confirm = ReadPassword();
     if (passphrase != confirm)
         throw new Exception("Passphrases don't match");
@@ -601,11 +610,19 @@ void CmdImport(string path)
     if (!File.Exists(path))
         throw new Exception($"Export file not found: {path}");
 
-    Console.Write("Import passphrase: ");
+    Console.Error.Write("Import passphrase: ");
     var passphrase = ReadPassword();
 
-    var exportFile = JsonSerializer.Deserialize(File.ReadAllText(path), TswapJsonContext.Default.ExportFile)
-        ?? throw new Exception("Invalid export file");
+    ExportFile exportFile;
+    try
+    {
+        exportFile = JsonSerializer.Deserialize(File.ReadAllText(path), TswapJsonContext.Default.ExportFile)
+            ?? throw new Exception("Invalid export file");
+    }
+    catch (JsonException ex)
+    {
+        throw new Exception($"Export file is not valid JSON: {ex.Message}");
+    }
 
     if (exportFile.Version != "tswap-export-v1")
         throw new Exception($"Unsupported export version: {exportFile.Version}");
@@ -663,7 +680,7 @@ void CmdImport(string path)
 void CmdNames()
 {
     var config = storage.LoadConfig();
-    var key = UnlockWithYubiKey(config);
+    var key = UnlockWithYubiKey(config, warnIfNoTouch: false);
     var db = storage.LoadSecrets(key);
 
     if (db.Secrets.Count == 0)
@@ -708,7 +725,7 @@ void CmdBurn(string name, string? reason)
 {
     Validation.ValidateName(name);
     var config = storage.LoadConfig();
-    var key = UnlockWithYubiKey(config);
+    var key = UnlockWithYubiKey(config, warnIfNoTouch: false);
     var db = storage.LoadSecrets(key);
 
     if (!db.Secrets.ContainsKey(name))
@@ -731,7 +748,7 @@ void CmdBurn(string name, string? reason)
 void CmdBurned()
 {
     var config = storage.LoadConfig();
-    var key = UnlockWithYubiKey(config);
+    var key = UnlockWithYubiKey(config, warnIfNoTouch: false);
     var db = storage.LoadSecrets(key);
 
     var burned = db.Secrets
@@ -879,7 +896,7 @@ void CmdCheck(string path)
     }
 
     var config = storage.LoadConfig();
-    var key = UnlockWithYubiKey(config);
+    var key = UnlockWithYubiKey(config, warnIfNoTouch: false);
     var db = storage.LoadSecrets(key);
 
     var results = Check.CheckMarkers(markers, db);

--- a/TswapCore/Storage.cs
+++ b/TswapCore/Storage.cs
@@ -36,7 +36,10 @@ public class Storage
     public SecretsDb LoadSecrets(byte[] key)
     {
         if (!File.Exists(SecretsFile))
+        {
+            Console.Error.WriteLine($"Warning: vault file not found ({SecretsFile}). Starting with empty vault.");
             return new SecretsDb(new Dictionary<string, Secret>());
+        }
 
         var encrypted = File.ReadAllBytes(SecretsFile);
         var decrypted = Crypto.Decrypt(encrypted, key);

--- a/TswapCore/Storage.cs
+++ b/TswapCore/Storage.cs
@@ -44,14 +44,16 @@ public class Storage
         {
             Console.Error.WriteLine(
                 $"Warning: vault file not found ({SecretsFile}). Starting with empty vault. " +
-                "Restore secrets.json.enc from backup or run 'tswap init'.");
+                "To recover: restore secrets.json.enc alongside its original config.json from backup. " +
+                "To start fresh: run 'tswap init' (this will overwrite config.json).");
             return new SecretsDb(new Dictionary<string, Secret>());
         }
         catch (DirectoryNotFoundException)
         {
             Console.Error.WriteLine(
                 $"Warning: config directory not found ({ConfigDir}). Starting with empty vault. " +
-                "Restore secrets.json.enc from backup or run 'tswap init'.");
+                "To recover: restore the config directory from backup. " +
+                "To start fresh: run 'tswap init' (this will overwrite config.json).");
             return new SecretsDb(new Dictionary<string, Secret>());
         }
         var decrypted = Crypto.Decrypt(encrypted, key);

--- a/TswapCore/Storage.cs
+++ b/TswapCore/Storage.cs
@@ -35,13 +35,25 @@ public class Storage
 
     public SecretsDb LoadSecrets(byte[] key)
     {
-        if (!File.Exists(SecretsFile))
+        byte[] encrypted;
+        try
         {
-            Console.Error.WriteLine($"Warning: vault file not found ({SecretsFile}). Starting with empty vault.");
+            encrypted = File.ReadAllBytes(SecretsFile);
+        }
+        catch (FileNotFoundException)
+        {
+            Console.Error.WriteLine(
+                $"Warning: vault file not found ({SecretsFile}). Starting with empty vault. " +
+                "Restore secrets.json.enc from backup or run 'tswap init'.");
             return new SecretsDb(new Dictionary<string, Secret>());
         }
-
-        var encrypted = File.ReadAllBytes(SecretsFile);
+        catch (DirectoryNotFoundException)
+        {
+            Console.Error.WriteLine(
+                $"Warning: config directory not found ({ConfigDir}). Starting with empty vault. " +
+                "Restore secrets.json.enc from backup or run 'tswap init'.");
+            return new SecretsDb(new Dictionary<string, Secret>());
+        }
         var decrypted = Crypto.Decrypt(encrypted, key);
         var json = Encoding.UTF8.GetString(decrypted);
         return JsonSerializer.Deserialize(json, TswapJsonContext.Default.SecretsDb)

--- a/TswapTests/ProgramTests.cs
+++ b/TswapTests/ProgramTests.cs
@@ -1315,6 +1315,19 @@ password2: """"  # tswap: missing-mixed-secret");
             "init should create an empty secrets.json.enc so subsequent commands do not warn about a missing vault");
     }
 
+    [Fact]
+    public void Names_WarnsMissingVaultOnStderr()
+    {
+        RunTswap("init");
+        File.Delete(Path.Combine(_tempDir, "secrets.json.enc"));
+
+        var (exit, _, stderr) = RunTswap("names");
+
+        // Command succeeds (empty vault) and emits a warning on stderr
+        Assert.Equal(0, exit);
+        Assert.Contains("vault file not found", stderr, StringComparison.OrdinalIgnoreCase);
+    }
+
     // --- issue #67: export prompts go to stderr ---
 
     [Fact]

--- a/TswapTests/ProgramTests.cs
+++ b/TswapTests/ProgramTests.cs
@@ -1302,4 +1302,68 @@ password2: """"  # tswap: missing-mixed-secret");
         Assert.DoesNotContain("supersecretvalue123", stdout);
         Assert.DoesNotContain("supersecretvalue123", stderr);
     }
+
+    // --- issue #69: init creates vault file ---
+
+    [Fact]
+    public void Init_CreatesVaultFile()
+    {
+        var (exit, _, _) = RunTswap("init");
+
+        Assert.Equal(0, exit);
+        Assert.True(File.Exists(Path.Combine(_tempDir, "secrets.json.enc")),
+            "init should create an empty secrets.json.enc so subsequent commands do not warn about a missing vault");
+    }
+
+    // --- issue #67: export prompts go to stderr ---
+
+    [Fact]
+    public void Export_PromptsAreOnStderr()
+    {
+        RunTswap("init");
+        var exportPath = Path.Combine(_tempDir, "backup.enc");
+        var (exit, stdout, stderr) = RunTswapWithStdin("testpass\ntestpass\n", "export", exportPath);
+
+        Assert.Equal(0, exit);
+        // The interactive prompt "Export passphrase:" must not pollute stdout
+        // (stdout is the redirect target when the user pipes export output).
+        Assert.DoesNotContain("Export passphrase:", stdout);
+        Assert.DoesNotContain("Confirm passphrase:", stdout);
+        // Prompts must appear on stderr so the user sees them when stdout is redirected
+        Assert.Contains("Export passphrase:", stderr);
+        Assert.Contains("Confirm passphrase:", stderr);
+    }
+
+    // --- issue #68: export cancel exits with non-zero code ---
+
+    [Fact]
+    public void Export_Cancel_ExitsWithError()
+    {
+        RunTswap("init");
+        var exportPath = Path.Combine(_tempDir, "backup.enc");
+        File.WriteAllText(exportPath, "existing"); // trigger the overwrite prompt
+
+        // Answer "no" to the overwrite question — should cancel and exit non-zero
+        var (exit, _, stderr) = RunTswapWithStdin("no\n", "export", exportPath);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("cancelled", stderr, StringComparison.OrdinalIgnoreCase);
+        // File must not be modified
+        Assert.Equal("existing", File.ReadAllText(exportPath));
+    }
+
+    // --- issue #29: import with invalid JSON gives friendly error ---
+
+    [Fact]
+    public void Import_InvalidJson_GivesFriendlyError()
+    {
+        RunTswap("init");
+        var badFile = Path.Combine(_tempDir, "bad.enc");
+        File.WriteAllText(badFile, "this is not json at all {{{");
+
+        var (exit, _, stderr) = RunTswapWithStdin("anypassphrase\n", "import", badFile);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("not valid JSON", stderr, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tswap.cs
+++ b/tswap.cs
@@ -547,8 +547,12 @@ void CmdInit()
     );
     
     SaveConfig(config);
-    // Create an empty encrypted vault so the file exists from the start.
-    SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), Crypto.DeriveKey(k1, k2));
+    // Create an empty encrypted vault only when one does not already exist.
+    // On re-initialisation the old vault is encrypted with a now-unreachable key;
+    // leaving the file in place lets a user recover it from backup alongside the
+    // old config, rather than destroying the ciphertext entirely.
+    if (!File.Exists(SecretsFile))
+        SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), Crypto.DeriveKey(k1, k2));
 
     Console.WriteLine("\n╔════════════════════════════════════════╗");
     Console.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");

--- a/tswap.cs
+++ b/tswap.cs
@@ -566,19 +566,24 @@ void CmdInit()
         unlockChallenge
     );
     
-    SaveConfig(config);
     // Re-initialisation generates a new master key (new challenge + new XOR share), so any
-    // existing vault is no longer decryptable with it. Rename the old file to a timestamped
-    // backup so it remains recoverable (by restoring the old config alongside it), then
-    // create a fresh empty vault under the canonical name.
+    // existing vault is no longer decryptable with it. Back up both files before writing
+    // new ones so recovery (restore both .bak files together) remains possible.
+    // Config is backed up first — if anything fails mid-init the old config still matches
+    // the old vault backup.
+    var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
     var newVaultKey = Crypto.DeriveKey(k1, k2);
+    if (File.Exists(ConfigFile))
+        File.Copy(ConfigFile, ConfigFile + ".bak-" + timestamp);
+    SaveConfig(config);
     if (File.Exists(SecretsFile))
     {
-        var backupPath = SecretsFile + ".bak-" + DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmss'Z'");
-        File.Move(SecretsFile, backupPath);
+        var vaultBackup = SecretsFile + ".bak-" + timestamp;
+        File.Move(SecretsFile, vaultBackup);
         Console.ForegroundColor = ConsoleColor.Yellow;
-        Console.WriteLine($"\nExisting vault moved to backup: {backupPath}");
-        Console.WriteLine("To recover old secrets: restore that file together with the previous config.json.");
+        Console.WriteLine($"\nExisting vault moved to backup: {vaultBackup}");
+        Console.WriteLine("Previous config backed up alongside it. To recover old secrets:");
+        Console.WriteLine("  restore both .bak files under their original names.");
         Console.ResetColor();
     }
     SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), newVaultKey);

--- a/tswap.cs
+++ b/tswap.cs
@@ -365,13 +365,25 @@ void SaveConfig(Config config)
 
 SecretsDb LoadSecrets(byte[] key)
 {
-    if (!File.Exists(SecretsFile))
+    byte[] encrypted;
+    try
     {
-        Console.Error.WriteLine($"Warning: vault file not found ({SecretsFile}). Starting with empty vault.");
+        encrypted = File.ReadAllBytes(SecretsFile);
+    }
+    catch (FileNotFoundException)
+    {
+        Console.Error.WriteLine(
+            $"Warning: vault file not found ({SecretsFile}). Starting with empty vault. " +
+            $"Restore secrets.json.enc from backup or run '{Prefix} init'.");
         return new SecretsDb(new Dictionary<string, Secret>());
     }
-    
-    var encrypted = File.ReadAllBytes(SecretsFile);
+    catch (DirectoryNotFoundException)
+    {
+        Console.Error.WriteLine(
+            $"Warning: config directory not found ({ConfigDir}). Starting with empty vault. " +
+            $"Restore secrets.json.enc from backup or run '{Prefix} init'.");
+        return new SecretsDb(new Dictionary<string, Secret>());
+    }
     var decrypted = Decrypt(encrypted, key);
     var json = Encoding.UTF8.GetString(decrypted);
     return JsonSerializer.Deserialize<SecretsDb>(json) 
@@ -434,9 +446,15 @@ byte[] UnlockWithYubiKey(Config config, bool warnIfNoTouch = true)
 string ReadPassword(TextWriter? echo = null)
 {
     echo ??= Console.Out;
-    // When stdin is redirected (e.g. in tests or piped input) skip interactive masking
+    // When stdin is redirected (e.g. in tests or piped input) skip interactive masking.
+    // Write a newline to echo so the next line of stderr output starts on a fresh line
+    // (the caller writes the prompt with Write, not WriteLine).
     if (Console.IsInputRedirected)
-        return Console.ReadLine() ?? "";
+    {
+        var line = Console.ReadLine() ?? "";
+        echo.WriteLine();
+        return line;
+    }
 
     var password = new StringBuilder();
     while (true)

--- a/tswap.cs
+++ b/tswap.cs
@@ -389,8 +389,9 @@ void SaveSecrets(SecretsDb db, byte[] key)
 
 byte[] UnlockWithYubiKey(Config config, bool warnIfNoTouch = true)
 {
-    // Warn about missing touch requirement (suppressed for read-only metadata commands
-    // that never expose secret values: names, burned, burn, check).
+    // Warn about missing touch requirement (suppressed for commands that never expose
+    // secret values on stdout/stderr, even though they still decrypt the vault:
+    // names, burned, burn, check).
     if (warnIfNoTouch)
         YubiKey.WarnIfNoTouch(config);
 
@@ -427,8 +428,12 @@ byte[] UnlockWithYubiKey(Config config, bool warnIfNoTouch = true)
 // HELPER FUNCTIONS
 // ============================================================================
 
-string ReadPassword()
+// echo: stream that receives masking feedback (*, backspace, newline).
+// Defaults to Console.Out for vault-mutation commands; pass Console.Error for
+// export/import so stdout stays clean when the output is piped or redirected.
+string ReadPassword(TextWriter? echo = null)
 {
+    echo ??= Console.Out;
     // When stdin is redirected (e.g. in tests or piped input) skip interactive masking
     if (Console.IsInputRedirected)
         return Console.ReadLine() ?? "";
@@ -439,18 +444,18 @@ string ReadPassword()
         var key = Console.ReadKey(true);
         if (key.Key == ConsoleKey.Enter)
         {
-            Console.WriteLine();
+            echo.WriteLine();
             break;
         }
         if (key.Key == ConsoleKey.Backspace && password.Length > 0)
         {
             password.Remove(password.Length - 1, 1);
-            Console.Write("\b \b");
+            echo.Write("\b \b");
         }
         else if (!char.IsControl(key.KeyChar))
         {
             password.Append(key.KeyChar);
-            Console.Write("*");
+            echo.Write("*");
         }
     }
     return password.ToString();
@@ -720,9 +725,9 @@ void CmdExport(string path)
     }
 
     Console.Error.Write("Export passphrase: ");
-    var passphrase = ReadPassword();
+    var passphrase = ReadPassword(Console.Error);
     Console.Error.Write("Confirm passphrase: ");
-    var confirm = ReadPassword();
+    var confirm = ReadPassword(Console.Error);
     if (passphrase != confirm)
         throw new Exception("Passphrases don't match");
 
@@ -759,7 +764,7 @@ void CmdImport(string path)
         throw new Exception($"Export file not found: {path}");
 
     Console.Error.Write("Import passphrase: ");
-    var passphrase = ReadPassword();
+    var passphrase = ReadPassword(Console.Error);
 
     ExportFile exportFile;
     try
@@ -783,8 +788,16 @@ void CmdImport(string path)
     catch (CryptographicException) { throw new Exception("Decryption failed — wrong passphrase or file tampered"); }
     catch (FormatException) { throw new Exception("Export file is corrupted (base64 decode failed)"); }
 
-    var exportedDb = JsonSerializer.Deserialize(Encoding.UTF8.GetString(plaintext), TswapJsonContext.Default.SecretsDb)
-        ?? throw new Exception("Invalid export data");
+    SecretsDb exportedDb;
+    try
+    {
+        exportedDb = JsonSerializer.Deserialize(Encoding.UTF8.GetString(plaintext), TswapJsonContext.Default.SecretsDb)
+            ?? throw new Exception("Invalid export data");
+    }
+    catch (JsonException ex)
+    {
+        throw new Exception($"Export data is corrupted (decrypted payload is not valid JSON): {ex.Message}");
+    }
 
     var config = LoadConfig();
     var key = UnlockWithYubiKey(config);

--- a/tswap.cs
+++ b/tswap.cs
@@ -374,14 +374,16 @@ SecretsDb LoadSecrets(byte[] key)
     {
         Console.Error.WriteLine(
             $"Warning: vault file not found ({SecretsFile}). Starting with empty vault. " +
-            $"Restore secrets.json.enc from backup or run '{Prefix} init'.");
+            $"To recover: restore secrets.json.enc alongside its original config.json from backup. " +
+            $"To start fresh: run '{Prefix} init' (this will overwrite config.json).");
         return new SecretsDb(new Dictionary<string, Secret>());
     }
     catch (DirectoryNotFoundException)
     {
         Console.Error.WriteLine(
             $"Warning: config directory not found ({ConfigDir}). Starting with empty vault. " +
-            $"Restore secrets.json.enc from backup or run '{Prefix} init'.");
+            $"To recover: restore the config directory from backup. " +
+            $"To start fresh: run '{Prefix} init' (this will overwrite config.json).");
         return new SecretsDb(new Dictionary<string, Secret>());
     }
     var decrypted = Decrypt(encrypted, key);
@@ -565,12 +567,21 @@ void CmdInit()
     );
     
     SaveConfig(config);
-    // Create an empty encrypted vault only when one does not already exist.
-    // On re-initialisation the old vault is encrypted with a now-unreachable key;
-    // leaving the file in place lets a user recover it from backup alongside the
-    // old config, rather than destroying the ciphertext entirely.
-    if (!File.Exists(SecretsFile))
-        SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), Crypto.DeriveKey(k1, k2));
+    // Re-initialisation generates a new master key (new challenge + new XOR share), so any
+    // existing vault is no longer decryptable with it. Rename the old file to a timestamped
+    // backup so it remains recoverable (by restoring the old config alongside it), then
+    // create a fresh empty vault under the canonical name.
+    var newVaultKey = Crypto.DeriveKey(k1, k2);
+    if (File.Exists(SecretsFile))
+    {
+        var backupPath = SecretsFile + ".bak-" + DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmss'Z'");
+        File.Move(SecretsFile, backupPath);
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine($"\nExisting vault moved to backup: {backupPath}");
+        Console.WriteLine("To recover old secrets: restore that file together with the previous config.json.");
+        Console.ResetColor();
+    }
+    SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), newVaultKey);
 
     Console.WriteLine("\n╔════════════════════════════════════════╗");
     Console.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");
@@ -742,7 +753,9 @@ void CmdExport(string path)
     if (File.Exists(path))
     {
         Console.Error.Write($"File '{path}' already exists. Overwrite? (yes/no): ");
-        if (Console.ReadLine()?.ToLower() != "yes")
+        var overwriteResponse = Console.ReadLine();
+        if (Console.IsInputRedirected) Console.Error.WriteLine();
+        if (overwriteResponse?.ToLower() != "yes")
             throw new Exception("Export cancelled.");
     }
 

--- a/tswap.cs
+++ b/tswap.cs
@@ -366,7 +366,10 @@ void SaveConfig(Config config)
 SecretsDb LoadSecrets(byte[] key)
 {
     if (!File.Exists(SecretsFile))
+    {
+        Console.Error.WriteLine($"Warning: vault file not found ({SecretsFile}). Starting with empty vault.");
         return new SecretsDb(new Dictionary<string, Secret>());
+    }
     
     var encrypted = File.ReadAllBytes(SecretsFile);
     var decrypted = Decrypt(encrypted, key);
@@ -384,10 +387,12 @@ void SaveSecrets(SecretsDb db, byte[] key)
     File.WriteAllBytes(SecretsFile, encrypted);
 }
 
-byte[] UnlockWithYubiKey(Config config)
+byte[] UnlockWithYubiKey(Config config, bool warnIfNoTouch = true)
 {
-    // Warn about missing touch requirement
-    YubiKey.WarnIfNoTouch(config);
+    // Warn about missing touch requirement (suppressed for read-only metadata commands
+    // that never expose secret values: names, burned, burn, check).
+    if (warnIfNoTouch)
+        YubiKey.WarnIfNoTouch(config);
 
     var serial = GetYubiKey();
 
@@ -537,7 +542,9 @@ void CmdInit()
     );
     
     SaveConfig(config);
-    
+    // Create an empty encrypted vault so the file exists from the start.
+    SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), Crypto.DeriveKey(k1, k2));
+
     Console.WriteLine("\n╔════════════════════════════════════════╗");
     Console.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");
     Console.WriteLine("╚════════════════════════════════════════╝\n");
@@ -707,13 +714,14 @@ void CmdExport(string path)
 
     if (File.Exists(path))
     {
-        Console.Write($"File '{path}' already exists. Overwrite? (yes/no): ");
-        if (Console.ReadLine()?.ToLower() != "yes") return;
+        Console.Error.Write($"File '{path}' already exists. Overwrite? (yes/no): ");
+        if (Console.ReadLine()?.ToLower() != "yes")
+            throw new Exception("Export cancelled.");
     }
 
-    Console.Write("Export passphrase: ");
+    Console.Error.Write("Export passphrase: ");
     var passphrase = ReadPassword();
-    Console.Write("Confirm passphrase: ");
+    Console.Error.Write("Confirm passphrase: ");
     var confirm = ReadPassword();
     if (passphrase != confirm)
         throw new Exception("Passphrases don't match");
@@ -750,11 +758,19 @@ void CmdImport(string path)
     if (!File.Exists(path))
         throw new Exception($"Export file not found: {path}");
 
-    Console.Write("Import passphrase: ");
+    Console.Error.Write("Import passphrase: ");
     var passphrase = ReadPassword();
 
-    var exportFile = JsonSerializer.Deserialize(File.ReadAllText(path), TswapJsonContext.Default.ExportFile)
-        ?? throw new Exception("Invalid export file");
+    ExportFile exportFile;
+    try
+    {
+        exportFile = JsonSerializer.Deserialize(File.ReadAllText(path), TswapJsonContext.Default.ExportFile)
+            ?? throw new Exception("Invalid export file");
+    }
+    catch (JsonException ex)
+    {
+        throw new Exception($"Export file is not valid JSON: {ex.Message}");
+    }
 
     if (exportFile.Version != "tswap-export-v1")
         throw new Exception($"Unsupported export version: {exportFile.Version}");
@@ -812,7 +828,7 @@ void CmdImport(string path)
 void CmdNames()
 {
     var config = LoadConfig();
-    var key = UnlockWithYubiKey(config);
+    var key = UnlockWithYubiKey(config, warnIfNoTouch: false);
     var db = LoadSecrets(key);
 
     if (db.Secrets.Count == 0)
@@ -857,7 +873,7 @@ void CmdBurn(string name, string? reason)
 {
     Validation.ValidateName(name);
     var config = LoadConfig();
-    var key = UnlockWithYubiKey(config);
+    var key = UnlockWithYubiKey(config, warnIfNoTouch: false);
     var db = LoadSecrets(key);
 
     if (!db.Secrets.ContainsKey(name))
@@ -880,7 +896,7 @@ void CmdBurn(string name, string? reason)
 void CmdBurned()
 {
     var config = LoadConfig();
-    var key = UnlockWithYubiKey(config);
+    var key = UnlockWithYubiKey(config, warnIfNoTouch: false);
     var db = LoadSecrets(key);
 
     var burned = db.Secrets
@@ -1085,7 +1101,7 @@ void CmdCheck(string path)
     }
 
     var config = LoadConfig();
-    var key = UnlockWithYubiKey(config);
+    var key = UnlockWithYubiKey(config, warnIfNoTouch: false);
     var db = LoadSecrets(key);
 
     var byFile = markers.GroupBy(m => m.FilePath).OrderBy(g => g.Key);


### PR DESCRIPTION
## Summary

- **#29** — `import` with a corrupt/non-JSON file now prints `Export file is not valid JSON: …` instead of throwing a raw `JsonException` stack trace.
- **#41** — YubiKey touch-requirement banner suppressed for metadata-only vault commands (`names`, `burned`, `burn`, `check`) that never expose secret values; `UnlockWithYubiKey` gains a `warnIfNoTouch` parameter (default `true`).
- **#67** — `export` interactive prompts (overwrite, passphrase, confirm; `import` passphrase prompt) now write to `Console.Error` so stdout is clean when the operator pipes export output.
- **#68** — Declining the `export` overwrite prompt now throws `Exception("Export cancelled.")` and exits non-zero instead of silently returning 0.
- **#69** — `init` creates an empty encrypted `secrets.json.enc` immediately so the vault file always exists post-init. `LoadSecrets` now warns to stderr when the file is missing rather than silently returning an empty vault.

## Test plan

- [ ] All 249 existing tests pass (`dotnet test TswapTests/TswapTests.csproj`)
- [ ] 4 new integration tests added and passing:
  - `Init_CreatesVaultFile`
  - `Export_PromptsAreOnStderr`
  - `Export_Cancel_ExitsWithError`
  - `Import_InvalidJson_GivesFriendlyError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)