### PR TITLE
Extend burn handling (#81)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -635,7 +635,7 @@ void CmdExport(string path)
     Console.WriteLine("  Keep this file and its passphrase secure.");
 }
 
-void CmdImport(string path)
+void CmdImport(string path, bool includeBurned = false)
 {
     RequireSudo("import");
 
@@ -685,9 +685,9 @@ void CmdImport(string path)
     int imported = 0, skippedExisting = 0, skippedBurned = 0, skippedNul = 0;
     foreach (var (name, secret) in exportedDb.Secrets.OrderBy(kv => kv.Key))
     {
-        if (secret.BurnedAt != null)
+        if (secret.BurnedAt != null && !includeBurned)
         {
-            Console.WriteLine($"  ⚠ Skipped '{name}' (was burned in source vault)");
+            Console.WriteLine($"  ⚠ Skipped '{name}' (was burned in source vault; use --include-burned to import)");
             skippedBurned++;
             continue;
         }
@@ -1291,9 +1291,10 @@ try
             break;
 
         case "import":
+            var includeBurned = filteredArgs.Remove("--include-burned");
             if (filteredArgs.Count < 2)
-                throw new Exception($"Usage: sudo {Prefix} import <file>");
-            CmdImport(filteredArgs[1]);
+                throw new Exception($"Usage: sudo {Prefix} import [--include-burned] <file>");
+            CmdImport(filteredArgs[1], includeBurned);
             break;
 
         case "delete":

--- a/Program.cs
+++ b/Program.cs
@@ -631,7 +631,7 @@ void CmdExport(string path)
     var burned = db.Secrets.Count(kv => kv.Value.BurnedAt != null);
     Console.WriteLine($"\n✓ Exported {nonBurned} secret(s) to: {path}");
     if (burned > 0)
-        Console.WriteLine($"  ({burned} burned secret(s) included — skipped on import by default; use 'import --include-burned' to preserve them)");
+        Console.WriteLine($"  ({burned} burned secret(s) included — skipped on import by default; use 'sudo {Prefix} import --include-burned {path}' to preserve them)");
     Console.WriteLine("  Keep this file and its passphrase secure.");
 }
 

--- a/Program.cs
+++ b/Program.cs
@@ -631,7 +631,7 @@ void CmdExport(string path)
     var burned = db.Secrets.Count(kv => kv.Value.BurnedAt != null);
     Console.WriteLine($"\n✓ Exported {nonBurned} secret(s) to: {path}");
     if (burned > 0)
-        Console.WriteLine($"  ({burned} burned secret(s) included — will be skipped on import)");
+        Console.WriteLine($"  ({burned} burned secret(s) included — skipped on import by default; use 'import --include-burned' to preserve them)");
     Console.WriteLine("  Keep this file and its passphrase secure.");
 }
 
@@ -1207,7 +1207,7 @@ try
         Console.WriteLine($"  [sudo] {p} list             List all secrets (names and dates, no values)");
         Console.WriteLine($"  [sudo] {p} delete <name>    Delete a secret");
         Console.WriteLine($"  [sudo] {p} export <file>    Export all secrets to an encrypted backup");
-        Console.WriteLine($"  [sudo] {p} import <file>    Import secrets from an encrypted backup");
+        Console.WriteLine($"  [sudo] {p} import [--include-burned] <file>    Import secrets from an encrypted backup (burned secrets skipped by default)");
         Console.WriteLine("\nCommands marked [sudo] require elevated privileges.");
         Console.WriteLine("Add -v or --verbose for detailed YubiKey output.");
         Console.WriteLine("\nExamples:");

--- a/Program.cs
+++ b/Program.cs
@@ -1291,8 +1291,8 @@ try
             break;
 
         case "import":
-            var includeBurned = filteredArgs.Remove("--include-burned");
-            if (filteredArgs.Count < 2)
+            var includeBurned = filteredArgs.RemoveAll(a => a == "--include-burned") > 0;
+            if (filteredArgs.Count != 2)
                 throw new Exception($"Usage: sudo {Prefix} import [--include-burned] <file>");
             CmdImport(filteredArgs[1], includeBurned);
             break;

--- a/TswapCore/Apply.cs
+++ b/TswapCore/Apply.cs
@@ -61,7 +61,10 @@ public static class Apply
                 var escapedValue = EscapeForQuote(secret.Value, quote);
                 if (secret.BurnedAt.HasValue)
                     Console.Error.WriteLine($"Warning: Secret '{secretName}' is burned (line {i + 1}) — applying anyway; rotate this secret after use");
-                lines[i] = $"{prefix}{quote}{escapedValue}{quote}{whitespace}{markerPart}";
+                // Ensure at least one space before the marker so '#' is a valid YAML comment
+                // (without whitespace, key: "value"# tswap: name is not a comment in YAML)
+                var sep = whitespace.Length > 0 ? whitespace : " ";
+                lines[i] = $"{prefix}{quote}{escapedValue}{quote}{sep}{markerPart}";
             }
             else
             {

--- a/TswapCore/Apply.cs
+++ b/TswapCore/Apply.cs
@@ -37,9 +37,9 @@ public static class Apply
             if (!db.Secrets.TryGetValue(secretName, out var secret))
                 throw new Exception($"Secret '{secretName}' not found (line {i + 1})");
 
-            // Check if secret is burned
+            // Warn if secret is burned but still apply it
             if (secret.BurnedAt.HasValue)
-                throw new Exception($"Secret '{secretName}' is burned and cannot be applied (line {i + 1})");
+                Console.Error.WriteLine($"Warning: Secret '{secretName}' is burned (line {i + 1}) — applying anyway; rotate this secret after use");
 
             // Find and replace empty value patterns before the marker
             // Patterns to match:

--- a/TswapCore/Apply.cs
+++ b/TswapCore/Apply.cs
@@ -37,10 +37,6 @@ public static class Apply
             if (!db.Secrets.TryGetValue(secretName, out var secret))
                 throw new Exception($"Secret '{secretName}' not found (line {i + 1})");
 
-            // Warn if secret is burned but still apply it
-            if (secret.BurnedAt.HasValue)
-                Console.Error.WriteLine($"Warning: Secret '{secretName}' is burned (line {i + 1}) — applying anyway; rotate this secret after use");
-
             // Find and replace empty value patterns before the marker
             // Patterns to match:
             // - key: ""  # tswap: name
@@ -63,19 +59,22 @@ public static class Apply
 
                 // Escape the secret value for the appropriate quote style
                 var escapedValue = EscapeForQuote(secret.Value, quote);
-                
+                if (secret.BurnedAt.HasValue)
+                    Console.Error.WriteLine($"Warning: Secret '{secretName}' is burned (line {i + 1}) — applying anyway; rotate this secret after use");
                 lines[i] = $"{prefix}{quote}{escapedValue}{quote}{whitespace}{markerPart}";
             }
             else
             {
                 // Check for unquoted empty or placeholder pattern
                 var unquotedMatch = UnquotedRegex.Match(beforeMarker);
-                
+
                 if (unquotedMatch.Success)
                 {
                     var prefix = unquotedMatch.Groups[1].Value;
                     // Default to double quotes for safety
                     var escapedValue = EscapeForQuote(secret.Value, "\"");
+                    if (secret.BurnedAt.HasValue)
+                        Console.Error.WriteLine($"Warning: Secret '{secretName}' is burned (line {i + 1}) — applying anyway; rotate this secret after use");
                     lines[i] = $"{prefix}\"{escapedValue}\"  {markerPart}";
                 }
                 else

--- a/TswapCore/Apply.cs
+++ b/TswapCore/Apply.cs
@@ -16,10 +16,12 @@ public static class Apply
     /// Apply secret values to a file containing <c># tswap: &lt;name&gt;</c> markers.
     /// Finds lines with empty values (e.g., <c>password: ""  # tswap: db-password</c>)
     /// and replaces the empty value with the actual secret value.
-    /// Returns the modified content.
+    /// Returns the modified content. Warnings are written to <paramref name="warnings"/>
+    /// (defaults to <see cref="Console.Error"/>).
     /// </summary>
-    public static string ApplySecrets(string content, SecretsDb db)
+    public static string ApplySecrets(string content, SecretsDb db, TextWriter? warnings = null)
     {
+        warnings ??= Console.Error;
         content = content.Replace("\r\n", "\n");
         var lines = content.Split('\n');
 
@@ -27,7 +29,7 @@ public static class Apply
         {
             var line = lines[i];
             var markerMatch = MarkerRegex.Match(line);
-            
+
             if (!markerMatch.Success)
                 continue;
 
@@ -60,7 +62,7 @@ public static class Apply
                 // Escape the secret value for the appropriate quote style
                 var escapedValue = EscapeForQuote(secret.Value, quote);
                 if (secret.BurnedAt.HasValue)
-                    Console.Error.WriteLine($"Warning: Secret '{secretName}' is burned (line {i + 1}) — applying anyway; rotate this secret after use");
+                    warnings.WriteLine($"Warning: Secret '{secretName}' is burned (line {i + 1}) — applying anyway; rotate this secret after use");
                 // Ensure at least one space before the marker so '#' is a valid YAML comment
                 // (without whitespace, key: "value"# tswap: name is not a comment in YAML)
                 var sep = whitespace.Length > 0 ? whitespace : " ";
@@ -77,13 +79,13 @@ public static class Apply
                     // Default to double quotes for safety
                     var escapedValue = EscapeForQuote(secret.Value, "\"");
                     if (secret.BurnedAt.HasValue)
-                        Console.Error.WriteLine($"Warning: Secret '{secretName}' is burned (line {i + 1}) — applying anyway; rotate this secret after use");
+                        warnings.WriteLine($"Warning: Secret '{secretName}' is burned (line {i + 1}) — applying anyway; rotate this secret after use");
                     lines[i] = $"{prefix}\"{escapedValue}\"  {markerPart}";
                 }
                 else
                 {
                     // Value already populated - warn user
-                    Console.Error.WriteLine($"Warning: Line {i + 1} has marker '# tswap: {secretName}' but value appears already populated. Skipping substitution.");
+                    warnings.WriteLine($"Warning: Line {i + 1} has marker '# tswap: {secretName}' but value appears already populated. Skipping substitution.");
                 }
             }
         }

--- a/TswapCore/Redact.cs
+++ b/TswapCore/Redact.cs
@@ -52,8 +52,19 @@ public abstract class SecretProcessor
                 list.Add((name, MatchType.Base64Url, base64Url));
         }
 
-        // Longest search text first to prevent shorter values partially overlapping longer ones
-        list.Sort((a, b) => b.SearchText.Length.CompareTo(a.SearchText.Length));
+        // Longest search text first to prevent shorter values partially overlapping longer ones.
+        // Tie-break by SearchText then Name then Type for deterministic output when two secrets
+        // share the same value (e.g. a burned secret whose value duplicates a live one).
+        list.Sort((a, b) =>
+        {
+            int cmp = b.SearchText.Length.CompareTo(a.SearchText.Length);
+            if (cmp != 0) return cmp;
+            cmp = string.Compare(a.SearchText, b.SearchText, StringComparison.Ordinal);
+            if (cmp != 0) return cmp;
+            cmp = string.Compare(a.Name, b.Name, StringComparison.Ordinal);
+            if (cmp != 0) return cmp;
+            return a.Type.CompareTo(b.Type);
+        });
         return list;
     }
 

--- a/TswapCore/Redact.cs
+++ b/TswapCore/Redact.cs
@@ -53,13 +53,18 @@ public abstract class SecretProcessor
         }
 
         // Longest search text first to prevent shorter values partially overlapping longer ones.
-        // Tie-break by SearchText then Name then Type for deterministic output when two secrets
-        // share the same value (e.g. a burned secret whose value duplicates a live one).
+        // Tie-break order: length desc → SearchText → non-burned before burned (so a live secret
+        // wins over a burned one with the same value) → Name → Type.
         list.Sort((a, b) =>
         {
             int cmp = b.SearchText.Length.CompareTo(a.SearchText.Length);
             if (cmp != 0) return cmp;
             cmp = string.Compare(a.SearchText, b.SearchText, StringComparison.Ordinal);
+            if (cmp != 0) return cmp;
+            // Prefer non-burned: false (0) sorts before true (1)
+            bool aBurned = db.Secrets.TryGetValue(a.Name, out var as_) && as_.BurnedAt.HasValue;
+            bool bBurned = db.Secrets.TryGetValue(b.Name, out var bs_) && bs_.BurnedAt.HasValue;
+            cmp = aBurned.CompareTo(bBurned);
             if (cmp != 0) return cmp;
             cmp = string.Compare(a.Name, b.Name, StringComparison.Ordinal);
             if (cmp != 0) return cmp;

--- a/TswapCore/Redact.cs
+++ b/TswapCore/Redact.cs
@@ -17,8 +17,8 @@ public record LineDiff(int LineNumber, string Before, string After);
 public abstract class SecretProcessor
 {
     /// <summary>
-    /// Builds the ordered list of (name, matchType, searchText) entries for all non-burned
-    /// secrets, including plaintext, Base64, and Base64Url variants. Sorted longest-first so
+    /// Builds the ordered list of (name, matchType, searchText) entries for all secrets,
+    /// including plaintext, Base64, and Base64Url variants. Sorted longest-first so
     /// that a longer value is never clobbered by a shorter value that shares a prefix.
     /// Also includes variants with whitespace normalized to handle cases where secrets are
     /// stored with newlines/spaces but files have them formatted differently.
@@ -30,8 +30,6 @@ public abstract class SecretProcessor
 
         foreach (var (name, secret) in db.Secrets)
         {
-            if (secret.BurnedAt.HasValue) continue;
-
             var value = secret.Value;
             if (string.IsNullOrEmpty(value)) continue;
 
@@ -264,7 +262,7 @@ public static class Redact
 
     /// <summary>
     /// Returns a copy of <paramref name="content"/> with all known secret values (and their
-    /// Base64 variants) replaced by <c>[REDACTED: name]</c> labels. Burned secrets are skipped.
+    /// Base64 variants) replaced by <c>[REDACTED: name]</c> labels.
     /// </summary>
     public static string RedactContent(string content, SecretsDb db)
         => new RedactProcessor().Process(content, db).Content;

--- a/TswapTests/ApplyTests.cs
+++ b/TswapTests/ApplyTests.cs
@@ -90,10 +90,17 @@ redis:
 
         var input = @"password: """"  # tswap: burned-secret";
 
-        // Should not throw; warning goes to Console.Error
-        var result = Apply.ApplySecrets(input, db);
+        var errWriter = new StringWriter();
+        var oldError = Console.Error;
+        Console.SetError(errWriter);
+        string result;
+        try { result = Apply.ApplySecrets(input, db); }
+        finally { Console.SetError(oldError); }
+
         Assert.Contains("burned-value", result);
         Assert.Contains("# tswap: burned-secret", result);
+        Assert.Contains("burned", errWriter.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("burned-secret", errWriter.ToString());
     }
 
     [Fact]

--- a/TswapTests/ApplyTests.cs
+++ b/TswapTests/ApplyTests.cs
@@ -81,18 +81,19 @@ redis:
     }
 
     [Fact]
-    public void ApplySecrets_ThrowsOnBurnedSecret()
+    public void ApplySecrets_AppliesBurnedSecretWithWarning()
     {
         var db = new SecretsDb(new Dictionary<string, Secret>
         {
-            ["burned-secret"] = new Secret("value", DateTime.UtcNow, DateTime.UtcNow, DateTime.UtcNow, "leaked")
+            ["burned-secret"] = new Secret("burned-value", DateTime.UtcNow, DateTime.UtcNow, DateTime.UtcNow, "leaked")
         });
 
         var input = @"password: """"  # tswap: burned-secret";
 
-        var ex = Assert.Throws<Exception>(() => Apply.ApplySecrets(input, db));
-        Assert.Contains("burned-secret", ex.Message);
-        Assert.Contains("burned", ex.Message.ToLower());
+        // Should not throw; warning goes to Console.Error
+        var result = Apply.ApplySecrets(input, db);
+        Assert.Contains("burned-value", result);
+        Assert.Contains("# tswap: burned-secret", result);
     }
 
     [Fact]

--- a/TswapTests/ApplyTests.cs
+++ b/TswapTests/ApplyTests.cs
@@ -3,6 +3,12 @@ using Xunit;
 
 namespace TswapTests;
 
+// Tests in this class mutate Console.Error; run them serially to avoid
+// interference with other tests that may write to the shared global stream.
+[CollectionDefinition("serial", DisableParallelization = true)]
+public class SerialCollection { }
+
+[Collection("serial")]
 public class ApplyTests
 {
     [Fact]

--- a/TswapTests/ApplyTests.cs
+++ b/TswapTests/ApplyTests.cs
@@ -3,12 +3,6 @@ using Xunit;
 
 namespace TswapTests;
 
-// Tests in this class mutate Console.Error; run them serially to avoid
-// interference with other tests that may write to the shared global stream.
-[CollectionDefinition("serial", DisableParallelization = true)]
-public class SerialCollection { }
-
-[Collection("serial")]
 public class ApplyTests
 {
     [Fact]
@@ -97,11 +91,7 @@ redis:
         var input = @"password: """"  # tswap: burned-secret";
 
         var errWriter = new StringWriter();
-        var oldError = Console.Error;
-        Console.SetError(errWriter);
-        string result;
-        try { result = Apply.ApplySecrets(input, db); }
-        finally { Console.SetError(oldError); }
+        var result = Apply.ApplySecrets(input, db, errWriter);
 
         Assert.Contains("burned-value", result);
         Assert.Contains("# tswap: burned-secret", result);

--- a/TswapTests/ProgramTests.cs
+++ b/TswapTests/ProgramTests.cs
@@ -1409,9 +1409,10 @@ password2: """"  # tswap: missing-mixed-secret");
         var yamlFile = Path.Combine(_tempDir, "content.yaml");
         File.WriteAllText(yamlFile, "token: burned-secret-value");
 
-        var (exit, _, stderr) = RunTswap("tocomment", yamlFile, "--dry-run");
+        var (exit, stdout, stderr) = RunTswap("tocomment", yamlFile, "--dry-run");
 
         Assert.Equal(0, exit);
+        Assert.DoesNotContain("burned-secret-value", stdout);
         Assert.DoesNotContain("burned-secret-value", stderr);
         Assert.Contains("# tswap: my-burned", stderr);
     }

--- a/TswapTests/ProgramTests.cs
+++ b/TswapTests/ProgramTests.cs
@@ -1379,4 +1379,107 @@ password2: """"  # tswap: missing-mixed-secret");
         Assert.NotEqual(0, exit);
         Assert.Contains("not valid JSON", stderr, StringComparison.OrdinalIgnoreCase);
     }
+
+    // --- issue #81: extend burn handling ---
+
+    [Fact]
+    public void Redact_IncludesBurnedSecretValues()
+    {
+        RunTswap("init");
+        RunTswapWithStdin("burned-secret-value", "ingest", "my-burned");
+        RunTswap("burn", "my-burned", "test");
+
+        var yamlFile = Path.Combine(_tempDir, "content.txt");
+        File.WriteAllText(yamlFile, "token: burned-secret-value");
+
+        var (exit, stdout, _) = RunTswap("redact", yamlFile);
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("burned-secret-value", stdout);
+        Assert.Contains("[REDACTED: my-burned]", stdout);
+    }
+
+    [Fact]
+    public void ToComment_IncludesBurnedSecretValues()
+    {
+        RunTswap("init");
+        RunTswapWithStdin("burned-secret-value", "ingest", "my-burned");
+        RunTswap("burn", "my-burned", "test");
+
+        var yamlFile = Path.Combine(_tempDir, "content.yaml");
+        File.WriteAllText(yamlFile, "token: burned-secret-value");
+
+        var (exit, _, stderr) = RunTswap("tocomment", yamlFile, "--dry-run");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("burned-secret-value", stderr);
+        Assert.Contains("# tswap: my-burned", stderr);
+    }
+
+    [Fact]
+    public void Apply_BurnedSecret_AppliesWithWarning()
+    {
+        RunTswap("init");
+        RunTswapWithStdin("burned-secret-value", "ingest", "my-burned");
+        RunTswap("burn", "my-burned", "test");
+
+        var yamlFile = Path.Combine(_tempDir, "apply-burned.yaml");
+        File.WriteAllText(yamlFile, "token: \"\"  # tswap: my-burned");
+
+        var (exit, stdout, stderr) = RunTswap("apply", yamlFile);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("burned-secret-value", stdout);
+        Assert.Contains("Warning", stderr);
+        Assert.Contains("burned", stderr);
+    }
+
+    [Fact]
+    public void Import_IncludeBurned_ImportsBurnedSecrets()
+    {
+        RunTswap("init");
+        RunTswapWithStdin("burned-value", "ingest", "was-burned");
+        RunTswap("burn", "was-burned", "compromised");
+        RunTswap("create", "good-secret");
+
+        var exportPath = Path.Combine(_tempDir, "backup.enc");
+        RunTswapWithStdin("passphrase\npassphrase\n", "export", exportPath);
+
+        RunTswapWithStdin("yes\n", "init");
+        File.Delete(Path.Combine(_tempDir, "secrets.json.enc"));
+        var (exit, stdout, _) = RunTswapWithStdin("passphrase\n", "import", "--include-burned", exportPath);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Imported 2 secret(s)", stdout);
+
+        var (_, namesOut, _) = RunTswap("names");
+        Assert.Contains("good-secret", namesOut);
+        Assert.Contains("was-burned", namesOut);
+        Assert.Contains("[BURNED]", namesOut);
+    }
+
+    [Fact]
+    public void Import_Default_SkipsBurnedSecrets_WithHint()
+    {
+        RunTswap("init");
+        RunTswap("create", "good-secret");
+        RunTswap("create", "burned-secret");
+        RunTswap("burn", "burned-secret", "compromised");
+
+        var exportPath = Path.Combine(_tempDir, "backup.enc");
+        RunTswapWithStdin("passphrase\npassphrase\n", "export", exportPath);
+
+        RunTswapWithStdin("yes\n", "init");
+        File.Delete(Path.Combine(_tempDir, "secrets.json.enc"));
+        var (exit, stdout, _) = RunTswapWithStdin("passphrase\n", "import", exportPath);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Skipped", stdout);
+        Assert.Contains("burned-secret", stdout);
+        Assert.Contains("--include-burned", stdout);
+
+        var (_, namesOut, _) = RunTswap("names");
+        Assert.Contains("good-secret", namesOut);
+        Assert.DoesNotContain("burned-secret", namesOut);
+    }
 }

--- a/TswapTests/RedactTests.cs
+++ b/TswapTests/RedactTests.cs
@@ -68,11 +68,11 @@ public class RedactTests
     }
 
     [Fact]
-    public void Redact_BurnedSecret_NotRedacted()
+    public void Redact_BurnedSecret_IsRedacted()
     {
         var db = MakeDb(("pw", "secret", true));
         var result = Redact.RedactContent("password: secret", db);
-        Assert.Equal("password: secret", result);
+        Assert.Equal("password: [REDACTED: pw]", result);
     }
 
     [Fact]
@@ -190,12 +190,12 @@ public class RedactTests
     }
 
     [Fact]
-    public void ToComment_BurnedSecret_NotReplaced()
+    public void ToComment_BurnedSecret_IsReplaced()
     {
         var db = MakeDb(("pw", "s3cr3t", true));
         var (content, changes) = Redact.ToComment("password: s3cr3t", db);
-        Assert.Equal("password: s3cr3t", content);
-        Assert.Empty(changes);
+        Assert.Equal("password: \"\"  # tswap: pw", content);
+        Assert.Single(changes);
     }
 
     [Fact]

--- a/tswap.cs
+++ b/tswap.cs
@@ -1512,8 +1512,8 @@ try
             break;
 
         case "import":
-            var includeBurned = filteredArgs.Remove("--include-burned");
-            if (filteredArgs.Count < 2)
+            var includeBurned = filteredArgs.RemoveAll(a => a == "--include-burned") > 0;
+            if (filteredArgs.Count != 2)
                 throw new Exception($"Usage: sudo {Prefix} import [--include-burned] <file>");
             CmdImport(filteredArgs[1], includeBurned);
             break;

--- a/tswap.cs
+++ b/tswap.cs
@@ -796,7 +796,7 @@ void CmdExport(string path)
     Console.WriteLine("  Keep this file and its passphrase secure.");
 }
 
-void CmdImport(string path)
+void CmdImport(string path, bool includeBurned = false)
 {
     RequireSudo("import");
 
@@ -846,9 +846,9 @@ void CmdImport(string path)
     int imported = 0, skippedExisting = 0, skippedBurned = 0, skippedNul = 0;
     foreach (var (name, secret) in exportedDb.Secrets.OrderBy(kv => kv.Key))
     {
-        if (secret.BurnedAt != null)
+        if (secret.BurnedAt != null && !includeBurned)
         {
-            Console.WriteLine($"  ⚠ Skipped '{name}' (was burned in source vault)");
+            Console.WriteLine($"  ⚠ Skipped '{name}' (was burned in source vault; use --include-burned to import)");
             skippedBurned++;
             continue;
         }
@@ -1512,9 +1512,10 @@ try
             break;
 
         case "import":
+            var includeBurned = filteredArgs.Remove("--include-burned");
             if (filteredArgs.Count < 2)
-                throw new Exception($"Usage: sudo {Prefix} import <file>");
-            CmdImport(filteredArgs[1]);
+                throw new Exception($"Usage: sudo {Prefix} import [--include-burned] <file>");
+            CmdImport(filteredArgs[1], includeBurned);
             break;
 
         case "delete":

--- a/tswap.cs
+++ b/tswap.cs
@@ -792,7 +792,7 @@ void CmdExport(string path)
     var burned = db.Secrets.Count(kv => kv.Value.BurnedAt != null);
     Console.WriteLine($"\n✓ Exported {nonBurned} secret(s) to: {path}");
     if (burned > 0)
-        Console.WriteLine($"  ({burned} burned secret(s) included — skipped on import by default; use 'import --include-burned' to preserve them)");
+        Console.WriteLine($"  ({burned} burned secret(s) included — skipped on import by default; use 'sudo {Prefix} import --include-burned {path}' to preserve them)");
     Console.WriteLine("  Keep this file and its passphrase secure.");
 }
 

--- a/tswap.cs
+++ b/tswap.cs
@@ -792,7 +792,7 @@ void CmdExport(string path)
     var burned = db.Secrets.Count(kv => kv.Value.BurnedAt != null);
     Console.WriteLine($"\n✓ Exported {nonBurned} secret(s) to: {path}");
     if (burned > 0)
-        Console.WriteLine($"  ({burned} burned secret(s) included — will be skipped on import)");
+        Console.WriteLine($"  ({burned} burned secret(s) included — skipped on import by default; use 'import --include-burned' to preserve them)");
     Console.WriteLine("  Keep this file and its passphrase secure.");
 }
 
@@ -1428,7 +1428,7 @@ try
         Console.WriteLine($"  [sudo] {p} list             List all secrets (names and dates, no values)");
         Console.WriteLine($"  [sudo] {p} delete <name>    Delete a secret");
         Console.WriteLine($"  [sudo] {p} export <file>    Export all secrets to an encrypted backup");
-        Console.WriteLine($"  [sudo] {p} import <file>    Import secrets from an encrypted backup");
+        Console.WriteLine($"  [sudo] {p} import [--include-burned] <file>    Import secrets from an encrypted backup (burned secrets skipped by default)");
         Console.WriteLine("\nCommands marked [sudo] require elevated privileges.");
         Console.WriteLine("Add -v or --verbose for detailed YubiKey output.");
         Console.WriteLine("\nExamples:");


### PR DESCRIPTION
Closes #81.

## Summary
- **`redact` / `tocomment`**: burned secret values are now included in the match list, so their values are redacted/replaced just like live secrets
- **`apply`**: applying a file that references a burned secret emits a stderr warning but proceeds with substitution (rotate after use), instead of aborting
- **`import --include-burned`**: new flag imports burned secrets with `BurnedAt`/`BurnReason` metadata preserved; without the flag the skip message now includes a hint about the flag

## Test plan
- [ ] `Redact_BurnedSecret_IsRedacted` — unit test confirming burned value is now redacted
- [ ] `ToComment_BurnedSecret_IsReplaced` — unit test confirming burned value is now converted to marker
- [ ] `ApplySecrets_AppliesBurnedSecretWithWarning` — unit test confirming no throw, value substituted
- [ ] `Redact_IncludesBurnedSecretValues` — integration test: ingest + burn + redact file
- [ ] `ToComment_IncludesBurnedSecretValues` — integration test: ingest + burn + tocomment file
- [ ] `Apply_BurnedSecret_AppliesWithWarning` — integration test: warning on stderr, value in stdout
- [ ] `Import_IncludeBurned_ImportsBurnedSecrets` — integration test: flag imports burned with metadata
- [ ] `Import_Default_SkipsBurnedSecrets_WithHint` — integration test: default skip includes flag hint

All 259 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)