### PR TITLE
tswap prompt outputs SKILL.md format (#83)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,14 @@ Agents can mark secrets as burned (compromised/seen) via `burn <name> [reason]`.
 
 ### Agent Prompt (`prompt` / `prompt-hash` commands)
 
-Self-documenting agent instructions. `prompt` outputs usage instructions, `prompt-hash` outputs their SHA-256 hash for cache validation. Neither requires YubiKey or sudo. Instructions auto-detect invocation mode (compiled binary vs script) and show correct command syntax.
+`prompt` outputs a complete, ready-to-use SKILL.md file (YAML frontmatter + usage instructions). Install it once so your agent loads it automatically when relevant:
+
+```bash
+mkdir -p .claude/skills/tswap
+tswap prompt > .claude/skills/tswap/SKILL.md
+```
+
+The install path varies by agent — Claude Code uses `.claude/skills/`, other tools (Copilot, Cursor, Gemini CLI, Codex CLI) differ; consult your agent's documentation. `prompt-hash` outputs the SHA-256 hash of the full output for cache validation. Neither command requires YubiKey or sudo. Instructions auto-detect invocation mode (compiled binary vs script) and show correct command syntax.
 
 ### Token Substitution (`run` command)
 
@@ -102,8 +109,8 @@ The script file is organized into logical sections:
 
 When working in this repository and tswap is initialized (YubiKey present), follow these rules:
 
-1. **Get instructions**: Run `tswap prompt` at the start of a session to get current usage instructions. Follow them.
-2. **Check for updates**: Run `tswap prompt-hash` periodically (e.g., at the start of each session) and compare against the last known hash. If it changed, re-read the full prompt.
+1. **Install the skill** (one-time, per project): `mkdir -p .claude/skills/tswap && tswap prompt > .claude/skills/tswap/SKILL.md`. After installation the SKILL.md is loaded automatically by your agent when relevant — no need to run `tswap prompt` at session start.
+2. **Keep it current**: Re-run the install command whenever `tswap prompt-hash` changes so your skill file stays up to date.
 3. **Never use sudo commands** — they expose secret values. Use `create`, `ingest`, `names`, `run`, `burn`, `burned`, `check`, `apply`, `redact`, `tocomment`, `prompt`, `prompt-hash`, and `migrate` only.
 4. **Use `{{token}}` substitution** via `run` to pass secrets to commands without seeing them.
 5. **Burn immediately** if you accidentally see a plaintext secret: `tswap burn <name> "<reason>"`.

--- a/README.md
+++ b/README.md
@@ -257,7 +257,14 @@ if ! echo "$1" | grep -qE "^($ALLOWED_COMMANDS)$"; then
 fi
 ```
 
-For Claude Code specifically, the `prompt` command provides the agent with usage instructions that include these boundaries. The agent should run `tswap prompt` at session start and follow the rules it contains.
+The `prompt` command outputs a complete SKILL.md file (YAML frontmatter + usage instructions). Install it once per project so your agent loads it automatically when working with secrets:
+
+```bash
+mkdir -p .claude/skills/tswap
+tswap prompt > .claude/skills/tswap/SKILL.md
+```
+
+The install path varies by agent — Claude Code uses `.claude/skills/`, other tools (Copilot, Cursor, Gemini CLI, Codex CLI) differ. Re-run the command whenever `tswap prompt-hash` changes to keep the skill file current.
 
 ## Burn & Rotate Playbook
 

--- a/TswapCore/Prompt.cs
+++ b/TswapCore/Prompt.cs
@@ -5,7 +5,12 @@ namespace TswapCore;
 
 public static class Prompt
 {
-    public const string Template = @"# tswap - AI Agent Secret Management Instructions
+    public const string Template = @"---
+name: tswap
+description: Must use when working with secrets, credentials, passwords, API keys, or any sensitive values; when running authenticated commands; or when storing, retrieving, rotating, or burning secrets.
+---
+
+# tswap - AI Agent Secret Management Instructions
 
 You are working with tswap, a hardware-backed secret manager. Your role is to
 manage secrets WITHOUT ever seeing their plaintext values.

--- a/TswapTests/ProgramTests.cs
+++ b/TswapTests/ProgramTests.cs
@@ -428,6 +428,10 @@ public class ProgramTests : IDisposable
         Assert.Equal(0, exit);
         Assert.Contains("tswap", stdout);
         Assert.Contains("AI Agent", stdout);
+        // SKILL.md frontmatter
+        Assert.Contains("---", stdout);
+        Assert.Contains("name: tswap", stdout);
+        Assert.Contains("must use when", stdout, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tswap.cs
+++ b/tswap.cs
@@ -93,56 +93,6 @@ else
 var ConfigFile = Path.Combine(ConfigDir, "config.json");
 var SecretsFile = Path.Combine(ConfigDir, "secrets.json.enc");
 
-const string PromptTemplate = @"# tswap - AI Agent Secret Management Instructions
-
-You are working with tswap, a hardware-backed secret manager. Your role is to
-manage secrets WITHOUT ever seeing their plaintext values.
-
-## Commands you SHOULD use (no sudo required):
-- `%CMD% create <name> [length]` — Generate a new random secret (value is never displayed)
-- `%CMD% ingest <name>` — Pipe a secret from an external source: `<source> | %CMD% ingest <name>`
-- `%CMD% names` — List all secret names (no values shown)
-- `%CMD% run <command>` — Execute a command with {{secret-name}} token substitution
-- `%CMD% burn <name> [reason]` — Mark a secret as burned if you accidentally see its value
-- `%CMD% burned` — List all burned secrets that need rotation
-- `%CMD% check <path>` — Scan a file or directory for `# tswap:` markers; exits non-zero if any referenced secret is missing
-- `%CMD% redact <file>` — Print file to stdout with all known secret values replaced by [REDACTED] labels
-- `%CMD% tocomment <file> [--dry-run]` — Replace inline secret values with empty values plus `# tswap: <name>` markers
-- `%CMD% prompt` — Display these instructions
-- `%CMD% prompt-hash` — Get hash of current instructions (to check if your cached copy is current)
-
-## Commands you must NEVER use (require sudo, expose values):
-- `sudo %CMD% add <name>` — Only for human interactive use
-- `sudo %CMD% get <name>` — Exposes plaintext value
-- `sudo %CMD% list` — Lists secrets with metadata
-- `sudo %CMD% delete <name>` — Removes a secret
-
-## Key rules:
-1. NEVER use sudo commands — they expose secret values
-2. NEVER generate, invent, or hardcode secret values yourself — always use `%CMD% create <name>` to
-   generate secrets, then tell the user the name you chose so they can find it
-3. Use {{secret-name}} tokens in `run` commands to use secrets without seeing them
-4. If you see a plaintext secret value in ANY context (file contents, command output,
-   log messages, error messages), you MUST IMMEDIATELY run `%CMD% burn <name> <reason>`
-   BEFORE continuing any other work. Do not finish your current task first.
-   Check `%CMD% names` to find the matching secret name if needed.
-5. To import secrets from external systems, pipe them directly — NEVER use intermediate variables or
-   echo. For Kubernetes, use jq (not jsonpath, which has shell quoting issues with dots/underscores):
-   `kubectl get secret <secret> -n <ns> -o json | jq -r '.data[""<key>""] // empty' | base64 -d | %CMD% ingest <name>`
-6. Check `%CMD% names` to see available secrets before constructing commands
-7. Burned secrets should be rotated — check with `%CMD% burned`
-8. When you create or ingest a secret, always inform the user of the secret name you used
-9. Check `%CMD% burned` at the start of each session and inform the user of any pending rotations
-
-## Keeping secrets out of config files:
-- In Helm values.yaml and similar config files, replace plaintext secrets with empty
-  values and a tswap comment: `password: """"  # tswap: k8s-namespace-secret-name`
-- Use `%CMD% tocomment <file>` to automatically replace inline secret values with `# tswap:` markers
-- Use `%CMD% check <path>` to verify that all `# tswap:` markers reference secrets that exist in the vault
-- When deploying, scan for `# tswap:` comments and construct `%CMD% run` commands
-  with `--set` flags using `{{token}}` substitution
-- This allows agents to freely read config files without seeing secret values";
-var PromptText = PromptTemplate.Replace("%CMD%", Prefix);
 
 // ============================================================================
 // DATA STRUCTURES
@@ -990,13 +940,12 @@ void CmdBurned()
 
 void CmdPrompt()
 {
-    Console.WriteLine(PromptText);
+    Console.WriteLine(Prompt.GetText(Prefix));
 }
 
 void CmdPromptHash()
 {
-    var hash = SHA256.HashData(Encoding.UTF8.GetBytes(PromptText));
-    Console.WriteLine(Convert.ToHexString(hash).ToLower());
+    Console.WriteLine(Prompt.GetHash(Prefix));
 }
 
 void CmdRun(string[] args)


### PR DESCRIPTION
Closes #83.

## Summary
- **`Prompt.cs`**: prepend YAML frontmatter to `Template` so `tswap prompt` outputs a complete, ready-to-use SKILL.md. Description uses `Must use when` phrasing for reliable automatic triggering across agents (Claude Code, Copilot, Cursor, Gemini CLI, Codex CLI).
- **`prompt-hash`**: no change needed — `GetHash` already hashes the full `GetText` output, which now includes the frontmatter.
- **`AGENTS.md` + `README.md`**: replace "run `tswap prompt` at session start" with the one-time install pattern; note install path varies by agent.

## Install pattern (new guidance)
```bash
mkdir -p .claude/skills/tswap
tswap prompt > .claude/skills/tswap/SKILL.md
```
Re-run whenever `tswap prompt-hash` changes.

## Test plan
- [ ] `Prompt_OutputsInstructions` — asserts `---`, `name: tswap`, `must use when` present in output
- [ ] `PromptHash_OutputsHash` — unchanged; still verifies 64-char lowercase hex

🤖 Generated with [Claude Code](https://claude.com/claude-code)