### PR TITLE
docs: document ~/.agents/skills/ as cross-tool global skill location

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ if ! echo "$1" | grep -qE "^($ALLOWED_COMMANDS)$"; then
 fi
 ```
 
-The `prompt` command outputs a complete SKILL.md file (YAML frontmatter + usage instructions). Install it once globally and GitHub Copilot, OpenAI Codex CLI, and Claude Code will pick it up automatically.
+The `prompt` command outputs a complete SKILL.md file (YAML frontmatter + usage instructions). Install it once globally and GitHub Copilot and OpenAI Codex CLI will pick it up automatically. Claude Code requires an additional symlink step (see below).
 
 ### Global install (recommended)
 
@@ -273,7 +273,7 @@ tswap prompt > ~/.agents/skills/tswap/SKILL.md
 # Claude Code — symlink so all tools share one file
 # Remove an existing real directory first (ln -sfn only replaces symlinks)
 mkdir -p ~/.claude/skills
-[ -d ~/.claude/skills/tswap ] && ! [ -L ~/.claude/skills/tswap ] && rm -rf ~/.claude/skills/tswap
+[ -e ~/.claude/skills/tswap ] && ! [ -L ~/.claude/skills/tswap ] && rm -rf ~/.claude/skills/tswap
 ln -sfn ~/.agents/skills/tswap ~/.claude/skills/tswap
 ```
 
@@ -282,7 +282,8 @@ ln -sfn ~/.agents/skills/tswap ~/.claude/skills/tswap
 ```powershell
 # Install to shared global location
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.agents\skills\tswap"
-tswap prompt | Out-File -Encoding utf8 "$env:USERPROFILE\.agents\skills\tswap\SKILL.md"
+# Out-File -Encoding utf8 writes a BOM in PowerShell 5.1; use WriteAllLines for UTF-8 without BOM
+[System.IO.File]::WriteAllLines("$env:USERPROFILE\.agents\skills\tswap\SKILL.md", (tswap prompt))
 
 # Claude Code — directory symlink (requires Developer Mode or admin)
 # Remove existing directory or link first — mklink /D fails if path exists

--- a/README.md
+++ b/README.md
@@ -257,14 +257,41 @@ if ! echo "$1" | grep -qE "^($ALLOWED_COMMANDS)$"; then
 fi
 ```
 
-The `prompt` command outputs a complete SKILL.md file (YAML frontmatter + usage instructions). Install it once per project so your agent loads it automatically when working with secrets:
+The `prompt` command outputs a complete SKILL.md file (YAML frontmatter + usage instructions). Install it once globally and all supported agents will pick it up automatically.
+
+### Global install (recommended)
+
+`~/.agents/skills/` is a cross-tool standard read natively by GitHub Copilot and OpenAI Codex CLI. Claude Code reads from `~/.claude/skills/`, which can be a symlink:
 
 ```bash
-mkdir -p .claude/skills/tswap
-tswap prompt > .claude/skills/tswap/SKILL.md
+# Install to shared global location
+mkdir -p ~/.agents/skills/tswap
+tswap prompt > ~/.agents/skills/tswap/SKILL.md
+
+# Claude Code — symlink so all tools share one file
+ln -s ~/.agents/skills/tswap ~/.claude/skills/tswap
 ```
 
-The install path varies by agent — Claude Code uses `.claude/skills/`, other tools (Copilot, Cursor, Gemini CLI, Codex CLI) differ. Re-run the command whenever `tswap prompt-hash` changes to keep the skill file current.
+| Tool | Reads from |
+|------|-----------|
+| GitHub Copilot | `~/.agents/skills/tswap/SKILL.md` |
+| OpenAI Codex CLI | `~/.agents/skills/tswap/SKILL.md` |
+| Claude Code | `~/.claude/skills/tswap/SKILL.md` (symlink → `~/.agents/skills/tswap`) |
+
+### Per-project install (fallback)
+
+If you work in a project where the global skill isn't available, install it at the repo level:
+
+```bash
+mkdir -p .agents/skills/tswap
+tswap prompt > .agents/skills/tswap/SKILL.md
+```
+
+Codex CLI walks up from `$CWD` looking for `.agents/skills/`, so this also works for project-specific overrides. Claude Code equivalent is `.claude/skills/tswap/SKILL.md`.
+
+### Keeping the skill current
+
+Re-run the install command whenever `tswap prompt-hash` changes to pick up updated instructions.
 
 ## Burn & Rotate Playbook
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ mkdir -p ~/.agents/skills/tswap
 tswap prompt > ~/.agents/skills/tswap/SKILL.md
 
 # Claude Code — symlink so all tools share one file
-ln -s ~/.agents/skills/tswap ~/.claude/skills/tswap
+mkdir -p ~/.claude/skills
+ln -sf ~/.agents/skills/tswap ~/.claude/skills/tswap
 ```
 
 | Tool | Reads from |

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ ln -sfn ~/.agents/skills/tswap ~/.claude/skills/tswap
 ```powershell
 # Install to shared global location
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.agents\skills\tswap"
-tswap prompt > "$env:USERPROFILE\.agents\skills\tswap\SKILL.md"
+tswap prompt | Out-File -Encoding utf8 "$env:USERPROFILE\.agents\skills\tswap\SKILL.md"
 
 # Claude Code — directory symlink (requires Developer Mode or admin)
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills"

--- a/README.md
+++ b/README.md
@@ -263,21 +263,36 @@ The `prompt` command outputs a complete SKILL.md file (YAML frontmatter + usage 
 
 `~/.agents/skills/` is a cross-tool standard read natively by GitHub Copilot and OpenAI Codex CLI. Claude Code reads from `~/.claude/skills/`, which can be a symlink:
 
+**Linux / macOS**
+
 ```bash
 # Install to shared global location
 mkdir -p ~/.agents/skills/tswap
 tswap prompt > ~/.agents/skills/tswap/SKILL.md
 
 # Claude Code — symlink so all tools share one file
+# -n ensures an existing symlink-to-directory is replaced, not nested
 mkdir -p ~/.claude/skills
-ln -sf ~/.agents/skills/tswap ~/.claude/skills/tswap
+ln -sfn ~/.agents/skills/tswap ~/.claude/skills/tswap
 ```
 
-| Tool | Reads from |
-|------|-----------|
-| GitHub Copilot | `~/.agents/skills/tswap/SKILL.md` |
-| OpenAI Codex CLI | `~/.agents/skills/tswap/SKILL.md` |
-| Claude Code | `~/.claude/skills/tswap/SKILL.md` (symlink → `~/.agents/skills/tswap`) |
+**Windows**
+
+```powershell
+# Install to shared global location
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.agents\skills\tswap"
+tswap prompt > "$env:USERPROFILE\.agents\skills\tswap\SKILL.md"
+
+# Claude Code — directory symlink (requires Developer Mode or admin)
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills"
+cmd /c mklink /D "$env:USERPROFILE\.claude\skills\tswap" "$env:USERPROFILE\.agents\skills\tswap"
+```
+
+| Tool | Linux / macOS | Windows |
+|------|--------------|---------|
+| GitHub Copilot | `~/.agents/skills/tswap/SKILL.md` | `%USERPROFILE%\.agents\skills\tswap\SKILL.md` |
+| OpenAI Codex CLI | `~/.agents/skills/tswap/SKILL.md` | `%USERPROFILE%\.agents\skills\tswap\SKILL.md` |
+| Claude Code | `~/.claude/skills/tswap/` (symlink) | `%USERPROFILE%\.claude\skills\tswap\` (symlink, optional) |
 
 ### Per-project install (fallback)
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ if ! echo "$1" | grep -qE "^($ALLOWED_COMMANDS)$"; then
 fi
 ```
 
-The `prompt` command outputs a complete SKILL.md file (YAML frontmatter + usage instructions). Install it once globally and all supported agents will pick it up automatically.
+The `prompt` command outputs a complete SKILL.md file (YAML frontmatter + usage instructions). Install it once globally and GitHub Copilot, OpenAI Codex CLI, and Claude Code will pick it up automatically.
 
 ### Global install (recommended)
 
@@ -292,7 +292,7 @@ cmd /c mklink /D "$env:USERPROFILE\.claude\skills\tswap" "$env:USERPROFILE\.agen
 |------|--------------|---------|
 | GitHub Copilot | `~/.agents/skills/tswap/SKILL.md` | `%USERPROFILE%\.agents\skills\tswap\SKILL.md` |
 | OpenAI Codex CLI | `~/.agents/skills/tswap/SKILL.md` | `%USERPROFILE%\.agents\skills\tswap\SKILL.md` |
-| Claude Code | `~/.claude/skills/tswap/` (symlink) | `%USERPROFILE%\.claude\skills\tswap\` (symlink, optional) |
+| Claude Code | `~/.claude/skills/tswap/SKILL.md` (symlink) | `%USERPROFILE%\.claude\skills\tswap\SKILL.md` (symlink, optional) |
 
 ### Per-project install (fallback)
 

--- a/README.md
+++ b/README.md
@@ -271,8 +271,9 @@ mkdir -p ~/.agents/skills/tswap
 tswap prompt > ~/.agents/skills/tswap/SKILL.md
 
 # Claude Code — symlink so all tools share one file
-# -n ensures an existing symlink-to-directory is replaced, not nested
+# Remove an existing real directory first (ln -sfn only replaces symlinks)
 mkdir -p ~/.claude/skills
+[ -d ~/.claude/skills/tswap ] && ! [ -L ~/.claude/skills/tswap ] && rm -rf ~/.claude/skills/tswap
 ln -sfn ~/.agents/skills/tswap ~/.claude/skills/tswap
 ```
 
@@ -284,8 +285,11 @@ New-Item -ItemType Directory -Force "$env:USERPROFILE\.agents\skills\tswap"
 tswap prompt | Out-File -Encoding utf8 "$env:USERPROFILE\.agents\skills\tswap\SKILL.md"
 
 # Claude Code — directory symlink (requires Developer Mode or admin)
+# Remove existing directory or link first — mklink /D fails if path exists
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills"
-cmd /c mklink /D "$env:USERPROFILE\.claude\skills\tswap" "$env:USERPROFILE\.agents\skills\tswap"
+$claudeLink = "$env:USERPROFILE\.claude\skills\tswap"
+if (Test-Path $claudeLink) { Remove-Item -Recurse -Force $claudeLink }
+cmd /c mklink /D "$claudeLink" "$env:USERPROFILE\.agents\skills\tswap"
 ```
 
 | Tool | Linux / macOS | Windows |

--- a/TswapCore/Prompt.cs
+++ b/TswapCore/Prompt.cs
@@ -7,7 +7,7 @@ public static class Prompt
 {
     public const string Template = @"---
 name: tswap
-description: Must use when working with secrets, credentials, passwords, API keys, or any sensitive values; when running authenticated commands; or when storing, retrieving, rotating, or when a secret value has been seen in cleartext or any trivially decodable form.
+description: Must use when working with secrets, credentials, passwords, API keys, or any sensitive values; when running authenticated commands; when storing, retrieving, or rotating secrets; or when a secret value has been seen in cleartext or any trivially decodable form.
 ---
 
 # tswap - AI Agent Secret Management Instructions

--- a/TswapCore/Prompt.cs
+++ b/TswapCore/Prompt.cs
@@ -7,7 +7,7 @@ public static class Prompt
 {
     public const string Template = @"---
 name: tswap
-description: Must use when working with secrets, credentials, passwords, API keys, or any sensitive values; when running authenticated commands; or when storing, retrieving, rotating, or when a plaintext secret has been accidentally viewed in unencrypted form.
+description: Must use when working with secrets, credentials, passwords, API keys, or any sensitive values; when running authenticated commands; or when storing, retrieving, rotating, or when a secret value has been seen in cleartext or any trivially decodable form.
 ---
 
 # tswap - AI Agent Secret Management Instructions

--- a/TswapCore/Prompt.cs
+++ b/TswapCore/Prompt.cs
@@ -7,7 +7,7 @@ public static class Prompt
 {
     public const string Template = @"---
 name: tswap
-description: Must use when working with secrets, credentials, passwords, API keys, or any sensitive values; when running authenticated commands; or when storing, retrieving, rotating, or burning secrets.
+description: Must use when working with secrets, credentials, passwords, API keys, or any sensitive values; when running authenticated commands; or when storing, retrieving, rotating, or when a plaintext secret has been accidentally viewed in unencrypted form.
 ---
 
 # tswap - AI Agent Secret Management Instructions


### PR DESCRIPTION
## Summary

Documents `~/.agents/skills/` as the recommended global install location for the tswap SKILL.md, replacing the vague note that "install paths vary by agent."

## Changes

- Show `~/.agents/skills/tswap/` as the canonical global location (read natively by GitHub Copilot and OpenAI Codex CLI)
- Show `~/.claude/skills/tswap` as a symlink to the shared location for Claude Code
- Add a compatibility table so it's clear which tool reads from where
- Document `.agents/skills/` as the per-project fallback (Codex CLI walks up from `$CWD`)
- Clarify that `tswap prompt-hash` should be checked to know when to re-run the install

## Motivation

Both GitHub Copilot and OpenAI Codex CLI support `~/.agents/skills/` as a user-level global skill directory. With a symlink, a single `SKILL.md` file serves all three tools without duplication.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)