### PR TITLE
Refactor phase 0: SDK pin, editorconfig, CI, fast test harness

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# Captures the existing code style so refactoring commits don't churn formatting.
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+[*.{json,yml,yaml,slnx,csproj,props,targets}]
+indent_style = space
+indent_size = 2
+
+[*.sh]
+end_of_line = lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  # Deterministic key for the TSWAP_TEST_KEY bypass (Debug builds only).
+  # Not a secret: it stubs YubiKey hardware calls in tests and has no meaning
+  # outside a throwaway test vault.
+  TSWAP_TEST_KEY: "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+
+jobs:
+  build-test-publish:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Build
+        run: dotnet build TokenSwap.slnx
+
+      - name: Unit tests
+        run: dotnet test TswapTests/TswapTests.csproj --no-build --filter "FullyQualifiedName!~ProgramTests"
+
+      # ProgramTests spawn a `dotnet run` subprocess per test (~11 min sequentially).
+      # Verified on Linux; extending to macOS/Windows runners is a follow-up once
+      # their runtime behaviour (paths, process spawning) is confirmed.
+      - name: Integration tests (ProgramTests)
+        if: matrix.os == 'ubuntu-latest'
+        timeout-minutes: 30
+        run: dotnet test TswapTests/TswapTests.csproj --no-build --filter "FullyQualifiedName~ProgramTests"
+
+      # NativeAOT publish is the tripwire for AOT-incompatible changes
+      # (reflection, unsupported patterns) that a plain build won't catch.
+      - name: AOT publish
+        run: dotnet publish tswap.csproj -c Release
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: tswap-${{ matrix.os }}
+          path: bin/Release/net10.0/*/publish/tswap*
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,12 @@ jobs:
       - name: Unit tests
         run: dotnet test TswapTests/TswapTests.csproj --no-build --filter "FullyQualifiedName!~ProgramTests"
 
-      # ProgramTests spawn a `dotnet run` subprocess per test (~11 min sequentially).
-      # Verified on Linux; extending to macOS/Windows runners is a follow-up once
-      # their runtime behaviour (paths, process spawning) is confirmed.
+      # ProgramTests builds tswap once (TswapBinaryFixture), then spawns the built
+      # binary per test (~30 s sequentially). Verified on Linux; extending to
+      # macOS/Windows runners is a follow-up once their runtime behaviour is confirmed.
       - name: Integration tests (ProgramTests)
         if: matrix.os == 'ubuntu-latest'
-        timeout-minutes: 30
+        timeout-minutes: 10
         run: dotnet test TswapTests/TswapTests.csproj --no-build --filter "FullyQualifiedName~ProgramTests"
 
       # NativeAOT publish is the tripwire for AOT-incompatible changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ tswap <command>
 ```
 
 Tests live in `TswapTests/TswapTests.csproj`. On Linux/macOS use `./runtests.sh`
-(`--unit` for the fast suite, ~1 s; `--integration` for `ProgramTests`, which spawns a
-`dotnet run` subprocess per test and takes ~11 min; no flag runs both). Or run directly:
+(`--unit` for the fast suite, ~1 s; `--integration` for `ProgramTests`, which builds
+tswap once then spawns the binary per test, ~30 s; no flag runs both). Or run directly:
 ```shell
 # Linux/macOS:
 TSWAP_TEST_KEY=$(openssl rand -hex 32) dotnet test ./TswapTests/TswapTests.csproj

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,9 @@ tswap installscript > installTswap.sh && bash installTswap.sh
 tswap <command>
 ```
 
-Tests live in `TswapTests/TswapTests.csproj`. Run with:
+Tests live in `TswapTests/TswapTests.csproj`. On Linux/macOS use `./runtests.sh`
+(`--unit` for the fast suite, ~1 s; `--integration` for `ProgramTests`, which spawns a
+`dotnet run` subprocess per test and takes ~11 min; no flag runs both). Or run directly:
 ```shell
 # Linux/macOS:
 TSWAP_TEST_KEY=$(openssl rand -hex 32) dotnet test ./TswapTests/TswapTests.csproj

--- a/TswapTests/ProgramTests.cs
+++ b/TswapTests/ProgramTests.cs
@@ -11,21 +11,23 @@ namespace TswapTests;
 /// <summary>
 /// Integration tests for Program.cs using TSWAP_TEST_KEY to bypass YubiKey.
 /// Each test gets an isolated temp config directory and a deterministic test key.
+/// The tswap binary is built once per run by <see cref="TswapBinaryFixture"/> and
+/// invoked directly (not via `dotnet run`, which re-evaluates MSBuild per call).
 /// </summary>
-public class ProgramTests : IDisposable
+public class ProgramTests : IClassFixture<TswapBinaryFixture>, IDisposable
 {
     private readonly string _tempDir;
     private readonly string _testKeyHex;
-    private readonly string _projectDir;
+    private readonly string _binaryPath;
 
-    public ProgramTests()
+    public ProgramTests(TswapBinaryFixture binary)
     {
         _tempDir = Path.Combine(Path.GetTempPath(), "tswap-prog-test-" + Guid.NewGuid().ToString("N")[..8]);
         Directory.CreateDirectory(_tempDir);
 
         // Deterministic 32-byte test key
         _testKeyHex = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
-        _projectDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        _binaryPath = binary.BinaryPath;
     }
 
     public void Dispose()
@@ -38,7 +40,7 @@ public class ProgramTests : IDisposable
     {
         var psi = new ProcessStartInfo
         {
-            FileName = "dotnet",
+            FileName = _binaryPath,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             RedirectStandardInput = redirectStdin,
@@ -51,10 +53,6 @@ public class ProgramTests : IDisposable
         // fork() from a JIT-mode .NET process crashes when W^X protection is active.
         // The deployed AOT binary has no JIT so this is not needed in production.
         psi.Environment["DOTNET_EnableWriteXorExecute"] = "0";
-        psi.ArgumentList.Add("run");
-        psi.ArgumentList.Add("--project");
-        psi.ArgumentList.Add($"{_projectDir}/tswap.csproj");
-        psi.ArgumentList.Add("--");
         return psi;
     }
 
@@ -449,8 +447,8 @@ public class ProgramTests : IDisposable
     // --- InstallScript ---
 
     /// <summary>
-    /// Under 'dotnet run', Environment.ProcessPath is the compiled binary (not the dotnet
-    /// host), so installscript succeeds and embeds the actual binary path.
+    /// Tests invoke the compiled apphost binary directly, so Environment.ProcessPath is
+    /// the binary itself and installscript succeeds and embeds the actual binary path.
     /// </summary>
     [Fact]
     public void InstallScript_OutputsScript()
@@ -692,17 +690,17 @@ public class ProgramTests : IDisposable
 
         // Write a small bash script. The two `exec` lines:
         //   1. Replace bash's own fds 0/1/2 with the slave PTY (making tswap see a real TTY).
-        //   2. Replace bash with dotnet so dotnet inherits those slave fds.
+        //   2. Replace bash with the tswap binary so it inherits those slave fds.
         //
         // The compound command is passed as a plain double-quoted string in the bash script.
-        // Bash passes it as a single argv element to dotnet, and tswap exec's sh directly
+        // Bash passes it as a single argv element to tswap, and tswap exec's sh directly
         // with that element as the -c argument — no intermediate shell re-parsing.
         var scriptPath = Path.Combine(_tempDir, "pty_test.sh");
         File.WriteAllText(scriptPath,
             $"#!/bin/bash\n" +
             $"exec <\"{slavePath}\" >\"{slavePath}\" 2>\"{slavePath}\"\n" +
-            $"exec dotnet run --project \"{_projectDir}/tswap.csproj\"" +
-            $" -- run sh -c \"echo before; echo {{{{my-secret}}}}; echo after\"\n");
+            $"exec \"{_binaryPath}\"" +
+            $" run sh -c \"echo before; echo {{{{my-secret}}}}; echo after\"\n");
 
         var psi = new ProcessStartInfo { FileName = "bash", UseShellExecute = false, CreateNoWindow = true };
         psi.ArgumentList.Add(scriptPath);
@@ -795,13 +793,13 @@ public class ProgramTests : IDisposable
     {
         var psi = new ProcessStartInfo
         {
-            FileName = "dotnet",
-            Arguments = $"run --project \"{_projectDir}/tswap.csproj\" -- init",
+            FileName = _binaryPath,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true
         };
+        psi.ArgumentList.Add("init");
         psi.Environment["TSWAP_TEST_KEY"] = "AABB"; // Only 2 bytes, not 32
         psi.Environment["TSWAP_CONFIG_DIR"] = _tempDir;
 
@@ -1364,7 +1362,7 @@ password2: """"  # tswap: missing-mixed-secret");
         File.WriteAllText(scriptPath,
             $"#!/bin/bash\n" +
             $"exec <\"{slavePath}\" >\"{slavePath}\" 2>\"{slavePath}\"\n" +
-            $"exec dotnet run --project \"{_projectDir}/tswap.csproj\" -- {quotedArgs}\n");
+            $"exec \"{_binaryPath}\" {quotedArgs}\n");
 
         var psi = new ProcessStartInfo { FileName = "bash", UseShellExecute = false, CreateNoWindow = true };
         psi.ArgumentList.Add(scriptPath);

--- a/TswapTests/TswapBinaryFixture.cs
+++ b/TswapTests/TswapBinaryFixture.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Builds tswap.csproj once (Debug) for the whole ProgramTests run and exposes the
+/// path to the built apphost binary. Tests invoke the binary directly instead of
+/// `dotnet run --project`, which pays an MSBuild project evaluation per invocation
+/// (~7.5 s per test, ~11 min across the suite when it was run that way).
+///
+/// The apphost (not `dotnet tswap.dll`) is required: Program.cs derives its usage
+/// prefix from Environment.ProcessPath, and tests assert on "tswap" in output.
+/// </summary>
+public sealed class TswapBinaryFixture
+{
+    public string BinaryPath { get; }
+
+    public TswapBinaryFixture()
+    {
+        var projectDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = projectDir,
+        };
+        psi.ArgumentList.Add("build");
+        psi.ArgumentList.Add(Path.Combine(projectDir, "tswap.csproj"));
+        // -getProperty suppresses normal build logging on stdout and prints only the
+        // property value after the build completes.
+        psi.ArgumentList.Add("-getProperty:TargetPath");
+
+        using var process = Process.Start(psi)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+            throw new Exception($"Building tswap.csproj failed (exit {process.ExitCode}):\n{stdout}\n{stderr}");
+
+        var targetPath = stdout.Trim(); // .../tswap.dll
+        var binaryPath = OperatingSystem.IsWindows()
+            ? Path.ChangeExtension(targetPath, ".exe")
+            : targetPath[..^".dll".Length];
+        if (!File.Exists(binaryPath))
+            throw new Exception($"Built tswap binary not found at: {binaryPath} (TargetPath was '{targetPath}')");
+
+        BinaryPath = binaryPath;
+    }
+}

--- a/TswapTests/TswapTests.csproj
+++ b/TswapTests/TswapTests.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="..\TswapCore\TswapCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/TswapTests/xunit.runner.json
+++ b/TswapTests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.302",
+    "rollForward": "latestFeature"
+  }
+}

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # Run the tswap test suite.
 #
-#   ./runtests.sh                 all tests (unit + integration; ~11 min)
+#   ./runtests.sh                 all tests (unit + integration; ~40 s)
 #   ./runtests.sh --unit          unit tests only (~1 s)
-#   ./runtests.sh --integration   ProgramTests only (spawns `dotnet run` per test)
+#   ./runtests.sh --integration   ProgramTests only (builds tswap once, then
+#                                 spawns the built binary per test)
 #
 # Tests run sequentially (TswapTests/xunit.runner.json): ProgramTests spawns a
-# `dotnet run` subprocess per test, and concurrent test hosts each doing that
-# can exhaust memory on constrained machines.
+# tswap subprocess per test, and concurrent test hosts each doing that can
+# exhaust memory on constrained machines.
 set -eo pipefail
 
 FILTER=""

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,1 +1,22 @@
-TSWAP_TEST_KEY=$(openssl rand -hex 32) dotnet test ./TswapTests/TswapTests.csproj
+#!/usr/bin/env bash
+# Run the tswap test suite.
+#
+#   ./runtests.sh                 all tests (unit + integration; ~11 min)
+#   ./runtests.sh --unit          unit tests only (~1 s)
+#   ./runtests.sh --integration   ProgramTests only (spawns `dotnet run` per test)
+#
+# Tests run sequentially (TswapTests/xunit.runner.json): ProgramTests spawns a
+# `dotnet run` subprocess per test, and concurrent test hosts each doing that
+# can exhaust memory on constrained machines.
+set -eo pipefail
+
+FILTER=""
+case "${1:-}" in
+  --unit)        FILTER="--filter FullyQualifiedName!~ProgramTests" ;;
+  --integration) FILTER="--filter FullyQualifiedName~ProgramTests" ;;
+  "")            ;;
+  *) echo "Usage: $0 [--unit|--integration]" >&2; exit 64 ;;
+esac
+
+TSWAP_TEST_KEY="${TSWAP_TEST_KEY:-$(openssl rand -hex 32)}" \
+  dotnet test ./TswapTests/TswapTests.csproj $FILTER


### PR DESCRIPTION
Phase 0 of the refactoring plan (#94): tooling and safety net, plus the test-speed fix that makes every later phase cheap to verify.

**Stack:** this is PR 1/5 — merge first, then #96 → #97 → #98 → #99 in order (each is based on the previous branch).

## Changes

- **`global.json`** pins SDK 10.0.3xx (`rollForward: latestFeature`) so contributors and CI share a toolchain
- **`.editorconfig`** captures the existing style so refactoring commits don't churn formatting
- **GitHub Actions CI**: build + tests + NativeAOT publish on Linux/macOS/Windows, with per-OS binary artifacts. The AOT publish step is the tripwire for AOT-incompatible changes that a plain build won't catch
- **`TswapTests/xunit.runner.json`** disables collection parallelism — concurrent test hosts spawning subprocess builds were exhausting memory on constrained machines
- **`TswapBinaryFixture`** builds tswap once per test run and invokes the built apphost per test, replacing `dotnet run --project` per test (which paid an MSBuild evaluation + JIT startup each time). **Full suite: 10 m 43 s → ~31 s.** Invoking the apphost (not `dotnet tswap.dll`) preserves `Environment.ProcessPath`-derived usage prefixes that tests assert on
- **`runtests.sh`** gains `--unit` / `--integration` variants, documented in `AGENTS.md`

## Verification

289/289 tests passing; NativeAOT publish produces a working binary. Note: the macOS/Windows CI legs are written but first exercised by this PR's workflow run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RdUvBznkJvWa6co8nn31N

---
_Generated by [Claude Code](https://claude.ai/code/session_012RdUvBznkJvWa6co8nn31N)_