### PR TITLE
Implement Linux TPM hardware backend, verified against swtpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet build TokenSwap.slnx
 
       - name: Unit tests (in-process)
-        run: dotnet test TokenSwap.slnx --no-build --filter "Category!=E2E&Category!=SecureEnclave"
+        run: dotnet test TokenSwap.slnx --no-build --filter "Category!=E2E&Category!=SecureEnclave&Category!=Tpm"
 
       # NativeAOT publish is the tripwire for AOT-incompatible changes
       # (reflection, unsupported patterns) that a plain build won't catch.

--- a/HARDWARE_BACKENDS.md
+++ b/HARDWARE_BACKENDS.md
@@ -32,7 +32,7 @@ This matters because the backends do **not** share a primitive:
 | Backend | Recovery primitive | Notes |
 |---|---|---|
 | YubiKey | HMAC-SHA1 challenge-response, then XOR-reconstruct + PBKDF2 | Two removable tokens, either unlocks |
-| TPM 2.0 | seal/unseal a machine-bound key | Windows TBS + CNG Platform Crypto Provider; Linux `tpm2`/tpm2-tss |
+| TPM 2.0 | seal/unseal a machine-bound key | Linux: `tpm2-tools` shellout (implemented, simulator-verified only). Windows TBS + CNG Platform Crypto Provider: planned, not implemented |
 | Secure Enclave | ECIES wrap/unwrap against a non-extractable P-256 key | **Cannot** do HMAC or export key bytes; presence/biometric via access control |
 
 A rename of the old `IYubiKeyService` would have kept `Challenge(serial, string)` and
@@ -181,6 +181,84 @@ Codesigning (Developer ID, notarization) still matters for eventually **distribu
 smoothly past Gatekeeper — that's a general macOS distribution concern, unrelated to whether this
 backend functions. It does not block building, testing, or using this backend locally today.
 
+## Linux TPM: implemented, verified only against a software simulator
+
+`TswapCore/Vault/LinuxTpmHardwareService.cs` implements `IHardwareKeyService`, backed by
+`TswapCore/Vault/Interop/Tpm2ToolsInterop.cs`, which shells out to the `tpm2-tools` CLI
+(`tpm2_createprimary`/`tpm2_create`/`tpm2_load`/`tpm2_unseal`) via `System.Diagnostics.Process`
+with argument arrays — the same pattern as `YkmanYubiKeyService`, not P/Invoke. `Seal` creates a
+TPM-bound primary key under the owner hierarchy and seals the vault key to it as a TPM keyed-hash
+object; `Unseal` regenerates the primary and unseals. `Config.TpmSealedKey` carries one
+self-contained base64 blob: a 4-byte length-prefixed public portion followed by the private
+(encrypted) portion — a single-slot, `k = 1` precursor to the Phase 6 multi-machine keyring, not
+the final on-disk format. Registered in `TswapCli/Program.cs` behind `OperatingSystem.IsLinux()`.
+`TswapTests/LinuxTpmHardwareServiceTests.cs` holds the trait-gated tests (`Category=Tpm`, run with
+`./runtests.sh --tpm`) — they need a reachable TPM 2.0 device or simulator.
+
+**No persisted primary key.** A TPM 2.0 primary key is deterministic — the same hierarchy plus
+the same public template always regenerates the same key, derived from that hierarchy's primary
+seed (TPM2 spec, Part 1, "Primary Seeds"). **Verified directly against swtpm for this codebase**
+(not assumed): two back-to-back `tpm2_createprimary -C o` calls on the same simulator produced a
+byte-identical RSA modulus. So `Config.TpmSealedKey` only stores the sealed object's public/private
+blobs; the primary is always regenerated fresh from the owner hierarchy, on both `Seal` and
+`Unseal`, and never written to disk. The owner hierarchy (not the null hierarchy) was chosen
+because its primary seed survives `TPM2_Startup` (a reboot) and only changes on an explicit
+`TPM2_Clear` — **also verified directly**: a blob sealed before `tpm2_startup --clear` unseals
+fine afterward, while the same blob fails to load under a primary regenerated after `tpm2_clear`
+with a TPM-reported `tpm:parameter(1):integrity check failed` error. That is exactly the
+"machine-bound, invalidated on factory reset" property this backend needs, with zero extra
+bookkeeping.
+
+### Status: PoC-grade, simulator-verified only — not yet run against real TPM hardware
+
+Functionally verified end-to-end (`tswap init --tpm` → `add`/`get`, plus the full test suite),
+**but every verification so far is against a software TPM simulator (swtpm), never a physical
+TPM.** A software simulator proves the code speaks the TPM2 protocol correctly — seal/unseal
+round-trips, error handling, wire format — it does **not** prove the real hardware root-of-trust
+property holds. Concretely still open before this should be trusted as a primary vault backend:
+
+- **No real TPM hardware has been used at any point.** All testing ran against
+  `danieltrick/swtpm-docker` (see `TPM_LINUX_PLAN.md` §4 for the exact setup) via the `swtpm`
+  TCTI. Real hardware may behave differently in ways a simulator can't surface — timing,
+  lockout/anti-hammering behavior, vendor-specific quirks, or a stricter owner-hierarchy
+  authorization policy than the simulator's default (empty) owner auth.
+- **No PCR or PIN policy support.** `MULTI_MACHINE_KEYING.md`'s per-backend table lists TPM's
+  primitive as "seal share to a machine-bound key (**optionally** PCR/PIN policy)" — this pass
+  implements only the unconditional case (no policy digest on the sealed object at all). Boot-state
+  binding (PCR policy) and a PIN/password gate are both real, useful extensions, not implemented
+  here.
+- **The sealed-key wire format is unversioned**, same caveat as `Config.SecureEnclaveWrappedKey`:
+  changing `Tpm2ToolsInterop`'s packing format is a silent breaking change for every existing TPM
+  vault, with no detection or migration path.
+- **Small transient-object budgets are a real constraint, verified, not assumed.** The swtpm
+  instance this backend was developed against exhausted its transient-object slots after two or
+  three chained `tpm2_*` invocations without an intervening `tpm2_flushcontext -t` — every
+  subsequent command then failed with "out of memory for object contexts" until flushed. Real TPMs
+  commonly have similarly small transient-object counts, so `Tpm2ToolsInterop` flushes
+  unconditionally before every `createprimary`/`load` call (verified as a safe no-op when there's
+  nothing to flush) rather than only reacting to that failure.
+- `tswap init --tpm` is explicitly a **workaround** (see its doc comment in `InitCommand.cs`) to
+  enable end-to-end testing ahead of a real enrollment flow — not the intended long-term UX. Phase
+  6 (`MULTI_MACHINE_KEYING.md`) is where a proper enrollment ceremony, multi-factor unlock, and a
+  versioned keyring format belong.
+- **TPM availability/enablement is explicitly out of scope.** No detection wizard, no "enable your
+  TPM in BIOS" guidance. A missing TPM (or, in dev/test, an unreachable simulator) fails once with
+  one clear, direct error — matching "No YubiKey detected."
+
+### Why a shellout to tpm2-tools, not P/Invoke libtss2-esys/libtss2-fapi (the path not taken)
+
+Unlike the Secure Enclave (which needed a native Swift shim because CryptoKit has no C ABI), the
+TSS2 stack does expose a C ABI (`libtss2-esys`, `libtss2-fapi`) that a direct P/Invoke binding
+could target. That path was not taken: `tpm2-tools` is well-packaged across every major Linux
+distro (`apt install tpm2-tools` on Debian/Ubuntu, `dnf install tpm2-tools` on Fedora, `apk add
+tpm2-tools` plus the separate `tpm2-tss-tcti-*` packages on Alpine — the TCTI backend libraries
+are split into their own packages there, verified while building the dev/test environment), it's
+the same shellout pattern this codebase already uses for YubiKey (`ykman` via
+`YkmanYubiKeyService`), and it avoids a large P/Invoke surface against the TSS2 APIs' many opaque
+structs and the ESAPI's own transient-object/session lifecycle (which, per the flush-before-every-call
+finding above, has sharp edges worth keeping behind a CLI's higher-level error handling rather than
+reimplementing directly).
+
 ## Adding a backend
 
 1. **Implement `IHardwareKeyService`** in `TswapCore/Vault/` (e.g. `TpmHardwareService`).
@@ -200,10 +278,11 @@ backend functions. It does not block building, testing, or using this backend lo
    it calls `ctx.YubiKeys.Challenge`/`SelectSerial` directly. A new backend needs its own
    enrollment flow (likely new `init` branches or `fleet`-style commands); that is separate
    from unlock and is where the on-disk descriptor for the backend gets written.
-6. **AOT:** implementations are native P/Invoke (TBS/CNG, tpm2-tss, Security.framework, or — as
-   the Secure Enclave backend shows — a small native shim in another language exposing a C ABI).
-   No reflection — keep it P/Invoke + spans and it stays AOT-clean. `dotnet publish -c Release`
-   (AOT) is the CI tripwire.
+6. **AOT:** implementations are native P/Invoke (TBS/CNG, Security.framework, or — as the Secure
+   Enclave backend shows — a small native shim in another language exposing a C ABI), or a plain
+   CLI shellout via `System.Diagnostics.Process` (YubiKey's `ykman`, Linux TPM's `tpm2-tools`) — no
+   reflection either way, and it stays AOT-clean. `dotnet publish -c Release` (AOT) is the CI
+   tripwire.
 
 ## Redundancy and Phase 6
 

--- a/TswapCli/Commands/InitCommand.cs
+++ b/TswapCli/Commands/InitCommand.cs
@@ -8,8 +8,8 @@ namespace TswapCli.Commands;
 public sealed class InitCommand : ICliCommand
 {
     public string Name => "init";
-    public string HelpUsage => "init [--secure-enclave]";
-    public string Description => "Initialize with 2 YubiKeys (or --secure-enclave on macOS)";
+    public string HelpUsage => "init [--secure-enclave|--tpm]";
+    public string Description => "Initialize with 2 YubiKeys (or --secure-enclave on macOS, --tpm on Linux)";
     public bool RequiresSudo => false;
 
     public int Execute(CommandContext ctx, string[] args)
@@ -25,6 +25,9 @@ public sealed class InitCommand : ICliCommand
 
         if (args.Contains("--secure-enclave"))
             return ExecuteSecureEnclave(ctx);
+
+        if (args.Contains("--tpm"))
+            return ExecuteTpm(ctx);
 
         if (ctx.TestKey != null)
         {
@@ -234,6 +237,80 @@ public sealed class InitCommand : ICliCommand
         c.Out.WriteLine("the wrapped key in config.json is meaningless without this machine's");
         c.Out.WriteLine("physical Secure Enclave. Losing this Mac means losing this vault — back");
         c.Out.WriteLine("up secrets some other way (e.g. 'tswap export') if that matters to you.");
+        return 0;
+    }
+
+    /// <summary>
+    /// Single-machine Linux TPM enrollment — a workaround to allow end-to-end testing of the
+    /// TPM backend ahead of a real enrollment flow. There is no redundancy or fleet keyring
+    /// here: one machine, one TPM, <c>k = 1</c>. Phase 6 (<c>MULTI_MACHINE_KEYING.md</c>) is
+    /// where a proper multi-factor / multi-machine enrollment ceremony belongs.
+    ///
+    /// <b>Status: only tested against a software TPM simulator (swtpm), not real TPM hardware</b>
+    /// — see <c>HARDWARE_BACKENDS.md</c>'s Linux TPM section.
+    /// </summary>
+    private static int ExecuteTpm(CommandContext ctx)
+    {
+        if (!OperatingSystem.IsLinux())
+            throw new TswapException("--tpm is only supported on Linux.");
+        return ExecuteTpmOnLinux(ctx);
+    }
+
+    [SupportedOSPlatform("linux")]
+    private static int ExecuteTpmOnLinux(CommandContext ctx)
+    {
+        var c = ctx.Console;
+
+        c.Out.WriteLine("\n╔════════════════════════════════════════╗");
+        c.Out.WriteLine("║  tswap - TPM Initialization            ║");
+        c.Out.WriteLine("╚════════════════════════════════════════╝\n");
+        c.Out.WriteLine("This vault will be protected by this machine's TPM — single machine");
+        c.Out.WriteLine("only for now (no second factor, no fleet keyring; see");
+        c.Out.WriteLine("MULTI_MACHINE_KEYING.md for the planned Phase 6 design).\n");
+
+        var tpm = new LinuxTpmHardwareService();
+        var vaultKey = RandomNumberGenerator.GetBytes(32);
+        c.Out.WriteLine("Sealing a new key to this machine's TPM...");
+        var sealedKey = tpm.Seal(vaultKey);
+
+        var config = new Config(
+            YubiKeySerials: [],
+            RedundancyXor: "",
+            Created: DateTime.UtcNow,
+            RequiresTouch: false,
+            RngMode: RngMode.System,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: Convert.ToBase64String(sealedKey));
+
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
+        if (File.Exists(ctx.Storage.ConfigFile))
+        {
+            var configBackup = ctx.Storage.ConfigFile + ".bak-" + timestamp;
+            File.Copy(ctx.Storage.ConfigFile, configBackup);
+        }
+        ctx.Storage.SaveConfig(config);
+        if (File.Exists(ctx.Storage.SecretsFile))
+        {
+            var vaultBackup = ctx.Storage.SecretsFile + ".bak-" + timestamp;
+            File.Move(ctx.Storage.SecretsFile, vaultBackup);
+            c.SetForeground(ConsoleColor.Yellow);
+            c.Out.WriteLine($"\nExisting vault moved to backup: {vaultBackup}");
+            c.Out.WriteLine("Previous config backed up alongside it. To recover old secrets:");
+            c.Out.WriteLine("  restore both .bak files under their original names.");
+            c.ResetColor();
+        }
+        ctx.Storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), vaultKey);
+
+        c.Out.WriteLine("\n╔════════════════════════════════════════╗");
+        c.Out.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");
+        c.Out.WriteLine("╚════════════════════════════════════════╝\n");
+        c.Out.WriteLine("Backend: TPM (this machine only)");
+        c.Out.WriteLine($"Config saved to: {ctx.Storage.ConfigFile}");
+        c.Out.WriteLine("\nThere is no backup share for this backend, unlike the YubiKey XOR share:");
+        c.Out.WriteLine("the sealed key in config.json is meaningless without this machine's");
+        c.Out.WriteLine("physical TPM. Losing this machine (or clearing its TPM) means losing this");
+        c.Out.WriteLine("vault — back up secrets some other way (e.g. 'tswap export') if that");
+        c.Out.WriteLine("matters to you.");
         return 0;
     }
 }

--- a/TswapCli/Program.cs
+++ b/TswapCli/Program.cs
@@ -45,7 +45,8 @@ try
     // and VaultUnlocker picks the right one from config.Backend.
     var extraBackends = new List<IHardwareKeyService>();
     if (OperatingSystem.IsMacOS()) extraBackends.Add(new SecureEnclaveHardwareService());
-    // TPM (Windows/Linux) is not implemented yet — see HARDWARE_BACKENDS.md.
+    if (OperatingSystem.IsLinux()) extraBackends.Add(new LinuxTpmHardwareService());
+    // TPM (Windows) is not implemented yet — see HARDWARE_BACKENDS.md.
     var unlocker = new VaultUnlocker(yubiKeys, overrideKey: testKey, additionalBackends: extraBackends);
 
     var ctx = new CommandContext(console, env, storage, yubiKeys, unlocker, testKey, sudoBypass);

--- a/TswapCli/SecurityWarnings.cs
+++ b/TswapCli/SecurityWarnings.cs
@@ -11,9 +11,16 @@ public static class SecurityWarnings
 {
     /// <summary>
     /// Print a warning to stderr if YubiKey slots don't require touch or status is unknown.
+    /// YubiKey-only: the wording below ("your YubiKeys", "tswap migrate") doesn't apply to
+    /// other backends, which have their own presence models and their own init-time caveats
+    /// (see SecureEnclaveHardwareService/LinuxTpmHardwareService's init flows) rather than a
+    /// shared touch-requirement warning.
     /// </summary>
     public static void WarnIfNoTouch(IConsole console, Config config)
     {
+        if (config.Backend is not (null or HardwareBackend.YubiKey))
+            return;
+
         if (config.RequiresTouch == true)
             return;
 

--- a/TswapCore/Models.cs
+++ b/TswapCore/Models.cs
@@ -61,7 +61,13 @@ public record Config(List<int> YubiKeySerials, string RedundancyXor, DateTime Cr
     // PoC status: this blob's internal byte layout (see AppleSecureEnclaveInterop.Wrap) has no
     // version tag — changing it silently breaks every existing Secure Enclave vault. See
     // HARDWARE_BACKENDS.md's "PoC-grade" section before treating this as a stable format.
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? SecureEnclaveWrappedKey = null);
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? SecureEnclaveWrappedKey = null,
+    // Linux TPM only: base64 blob of the vault master key sealed to this machine's TPM (see
+    // LinuxTpmHardwareService/Tpm2ToolsInterop). Single-slot precursor to the Phase 6
+    // multi-machine keyring — irrelevant, so omitted, for other backends. Simulator-only
+    // status: see HARDWARE_BACKENDS.md's Linux TPM section before treating this as verified
+    // against real hardware.
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? TpmSealedKey = null);
 public record Secret(string Value, DateTime Created, DateTime Modified, DateTime? BurnedAt = null, string? BurnReason = null);
 public record SecretsDb(Dictionary<string, Secret> Secrets);
 

--- a/TswapCore/Vault/IHardwareKeyService.cs
+++ b/TswapCore/Vault/IHardwareKeyService.cs
@@ -6,7 +6,8 @@ namespace TswapCore.Vault;
 /// <list type="bullet">
 /// <item><see cref="YubiKeyHardwareService"/> — HMAC challenge-response with 1-of-2 XOR
 ///   redundancy (the scheme tswap has always used).</item>
-/// <item>TPM 2.0 (Windows TBS/CNG, Linux tpm2) — seal/unseal a machine-bound key. Planned.</item>
+/// <item><see cref="LinuxTpmHardwareService"/> — seal/unseal a machine-bound key via
+///   tpm2-tools (Linux only). Windows TPM (TBS/CNG) is planned but not implemented.</item>
 /// <item><see cref="SecureEnclaveHardwareService"/> — ECIES wrap/unwrap against a
 ///   non-extractable P-256 key, via a Swift/CryptoKit shim (macOS only).</item>
 /// </list>

--- a/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
+++ b/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
@@ -21,7 +21,10 @@ namespace TswapCore.Vault.Interop;
 /// modulus. So <see cref="Seal"/> only needs to persist the sealed object's public/private blobs
 /// (<c>tpm2_create -u/-r</c> output); <see cref="Unseal"/> regenerates the same primary from
 /// scratch under the owner hierarchy (<c>-C o</c>) and loads the sealed object under it — no
-/// primary context is ever written to <see cref="Config.TpmSealedKey"/>.</para>
+/// primary context is ever written to <see cref="Config.TpmSealedKey"/>. The template is pinned
+/// explicitly (<c>-G rsa2048</c>, verified to match what this backend was developed against)
+/// rather than relying on tpm2-tools' compiled-in default, so a future tool/distro upgrade
+/// changing that default can't silently break the determinism guarantee this relies on.</para>
 ///
 /// <para>The owner hierarchy (not the null hierarchy) is used deliberately: its primary seed is
 /// preserved across <c>TPM2_Startup</c> (a reboot-equivalent) and only changes on an explicit
@@ -40,7 +43,18 @@ namespace TswapCore.Vault.Interop;
 /// with "out of memory for object contexts" — real TPMs commonly have similarly small transient
 /// slot counts, so this is cheap insurance, not simulator-only defensiveness.
 /// <c>tpm2_flushcontext -t</c> is a verified no-op (exit 0, no output) when there is nothing to
-/// flush, so it is called unconditionally before each step rather than only after a failure.</para>
+/// flush, so it is called unconditionally before each step rather than only after a failure — but
+/// its own exit code is still checked, so a genuine flush failure (e.g. TCTI misconfigured) fails
+/// fast at the real step instead of surfacing as a confusing failure later on.</para>
+///
+/// <para><b>The vault master key never touches disk as plaintext.</b> <see cref="Seal"/> pipes it
+/// to <c>tpm2_create</c> over stdin (verified directly: <c>tpm2_create -i -</c> reads the sealed
+/// payload from stdin and round-trips correctly); <see cref="Unseal"/> captures
+/// <c>tpm2_unseal</c>'s stdout as raw bytes (verified byte-for-byte, no <c>-o</c> file, no text
+/// encoding round-trip) rather than writing the recovered key to a temp file. The other temp
+/// files this class does write (<c>primary.ctx</c>, the sealed public/private blobs, the loaded
+/// object context) are TPM-protected structures, not plaintext key material, so leaving them as
+/// transient files is fine.</para>
 ///
 /// <para><b>Status: developed and tested only against a software TPM simulator (swtpm), not yet
 /// verified against real Linux TPM hardware.</b> See <c>HARDWARE_BACKENDS.md</c>'s Linux TPM
@@ -50,6 +64,11 @@ namespace TswapCore.Vault.Interop;
 [SupportedOSPlatform("linux")]
 internal static class Tpm2ToolsInterop
 {
+    // tpm2-tools' current default template already produces this (verified against swtpm), but
+    // pinning it explicitly means a future tpm2-tools/tpm2-tss default change can't silently
+    // change what "the same hierarchy + template" derives — see the class doc comment.
+    private const string PrimaryAlgorithm = "rsa2048";
+
     /// <summary>Cheap, side-effect-free presence check — reads fixed TPM properties, touches no transient objects.</summary>
     public static bool IsAvailable()
     {
@@ -68,11 +87,17 @@ internal static class Tpm2ToolsInterop
 
     private static void RequireAvailable()
     {
-        if (!IsAvailable())
+        // Deliberately not implemented as "if (!IsAvailable()) throw generic-message": that
+        // would swallow the specific, actionable "tpm2-tools isn't installed, here's how to
+        // install it" exception Run() throws on a missing binary, leaving only this method's
+        // generic message. Running the same cheap probe directly here instead lets a missing
+        // tpm2-tools install propagate its own message untouched, and folds stderr into the
+        // generic message for the "tool present, TPM unreachable" case.
+        var (exitCode, _, stderr) = Run("tpm2_getcap", "properties-fixed");
+        if (exitCode != 0)
             throw new TswapException(
                 "No usable TPM detected. This requires a TPM 2.0 device (or a reachable " +
-                "simulator in dev/test — see HARDWARE_BACKENDS.md) and the 'tpm2-tools' package " +
-                "installed. Use a different backend (YubiKey) on this machine.");
+                $"simulator in dev/test — see HARDWARE_BACKENDS.md). tpm2_getcap failed: {stderr.Trim()}");
     }
 
     /// <summary>Enrollment: seals <paramref name="plaintextKey"/> to a freshly (re)created TPM-bound primary key.</summary>
@@ -83,20 +108,22 @@ internal static class Tpm2ToolsInterop
         var tmp = Directory.CreateTempSubdirectory("tswap-tpm-");
         try
         {
-            var plaintextPath = Path.Combine(tmp.FullName, "plain.bin");
             var primaryPath = Path.Combine(tmp.FullName, "primary.ctx");
             var pubPath = Path.Combine(tmp.FullName, "seal.pub");
             var privPath = Path.Combine(tmp.FullName, "seal.priv");
 
-            File.WriteAllBytes(plaintextPath, plaintextKey);
-
             FlushTransient();
             RunOrThrow("tpm2_createprimary", "creating the TPM primary key",
-                "-C", "o", "-c", primaryPath);
+                "-C", "o", "-G", PrimaryAlgorithm, "-c", primaryPath);
 
             FlushTransient();
-            RunOrThrow("tpm2_create", "sealing the key to the TPM",
-                "-C", primaryPath, "-u", pubPath, "-r", privPath, "-i", plaintextPath);
+            // "-i -": pipe the plaintext vault key over stdin rather than writing it to a temp
+            // file first — verified directly against swtpm that tpm2_create reads and seals it
+            // correctly this way. See the class doc comment.
+            var (createExit, _, createErr) = RunWithStdin("tpm2_create", plaintextKey,
+                "-C", primaryPath, "-u", pubPath, "-r", privPath, "-i", "-");
+            if (createExit != 0)
+                throw new TswapException($"TPM operation failed while sealing the key to the TPM: {createErr.Trim()}");
 
             if (!File.Exists(pubPath) || !File.Exists(privPath))
                 throw new TpmOperationException(
@@ -117,7 +144,7 @@ internal static class Tpm2ToolsInterop
         }
         finally
         {
-            tmp.Delete(recursive: true);
+            DeleteBestEffort(tmp);
         }
     }
 
@@ -144,14 +171,13 @@ internal static class Tpm2ToolsInterop
             var pubPath = Path.Combine(tmp.FullName, "seal.pub");
             var privPath = Path.Combine(tmp.FullName, "seal.priv");
             var loadedPath = Path.Combine(tmp.FullName, "loaded.ctx");
-            var outPath = Path.Combine(tmp.FullName, "unsealed.bin");
 
             File.WriteAllBytes(pubPath, wrapped.AsSpan(4, pubLen).ToArray());
             File.WriteAllBytes(privPath, wrapped.AsSpan(4 + pubLen).ToArray());
 
             FlushTransient();
             RunOrThrow("tpm2_createprimary", "creating the TPM primary key",
-                "-C", "o", "-c", primaryPath);
+                "-C", "o", "-G", PrimaryAlgorithm, "-c", primaryPath);
 
             FlushTransient();
             var (loadExit, _, _) = Run("tpm2_load", "-C", primaryPath, "-u", pubPath, "-r", privPath, "-c", loadedPath);
@@ -159,19 +185,18 @@ internal static class Tpm2ToolsInterop
                 throw UnlockFailed();
 
             FlushTransient();
-            var (unsealExit, _, _) = Run("tpm2_unseal", "-c", loadedPath, "-o", outPath);
+            // No "-o file": capture tpm2_unseal's stdout directly as raw bytes so the recovered
+            // vault key never touches disk — verified byte-for-byte against swtpm that this
+            // matches what "-o file" would have written, with no text-encoding round-trip risk.
+            var (unsealExit, plaintext, _) = RunCapturingBinaryStdout("tpm2_unseal", "-c", loadedPath);
             if (unsealExit != 0)
                 throw UnlockFailed();
 
-            if (!File.Exists(outPath))
-                throw new TpmOperationException(
-                    "tpm2_unseal reported success but did not produce an output file — this is a tswap bug, not a config problem.");
-
-            return File.ReadAllBytes(outPath);
+            return plaintext;
         }
         finally
         {
-            tmp.Delete(recursive: true);
+            DeleteBestEffort(tmp);
         }
     }
 
@@ -183,7 +208,31 @@ internal static class Tpm2ToolsInterop
         "Could not unlock with the TPM. The sealed key may have been created on a different " +
         "machine, the TPM may have been cleared since enrollment, or config.json may be corrupted.");
 
-    private static void FlushTransient() => Run("tpm2_flushcontext", "-t");
+    private static void FlushTransient()
+    {
+        var (exitCode, _, stderr) = Run("tpm2_flushcontext", "-t");
+        // Verified as a no-op (exit 0) when there's nothing to flush, so a non-zero exit here
+        // is a genuine problem (e.g. TCTI misconfigured, TPM unreachable) — fail at this step
+        // with a clear message instead of letting a confusing failure surface later.
+        if (exitCode != 0)
+            throw new TswapException($"TPM operation failed while clearing prior TPM state: {stderr.Trim()}");
+    }
+
+    // Cleanup is best-effort: a failure here (e.g. a transient file lock) must not replace
+    // whatever exception is already propagating out of the try block above it.
+    private static void DeleteBestEffort(DirectoryInfo tmp)
+    {
+        try
+        {
+            tmp.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
 
     private static void RunOrThrow(string command, string stepDescription, params string[] args)
     {
@@ -194,9 +243,41 @@ internal static class Tpm2ToolsInterop
 
     private static (int ExitCode, string Stdout, string Stderr) Run(string command, params string[] args)
     {
+        using var process = Start(command, args, redirectStdin: false);
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, stdout, stderr);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunWithStdin(string command, byte[] stdin, params string[] args)
+    {
+        using var process = Start(command, args, redirectStdin: true);
+        process.StandardInput.BaseStream.Write(stdin);
+        process.StandardInput.BaseStream.Flush();
+        process.StandardInput.Close(); // signal EOF so the command proceeds
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, stdout, stderr);
+    }
+
+    private static (int ExitCode, byte[] Stdout, string Stderr) RunCapturingBinaryStdout(string command, params string[] args)
+    {
+        using var process = Start(command, args, redirectStdin: false);
+        var stdoutBuffer = new MemoryStream();
+        process.StandardOutput.BaseStream.CopyTo(stdoutBuffer);
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, stdoutBuffer.ToArray(), stderr);
+    }
+
+    private static Process Start(string command, string[] args, bool redirectStdin)
+    {
         var psi = new ProcessStartInfo
         {
             FileName = command,
+            RedirectStandardInput = redirectStdin,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -205,10 +286,9 @@ internal static class Tpm2ToolsInterop
         foreach (var arg in args)
             psi.ArgumentList.Add(arg);
 
-        Process process;
         try
         {
-            process = Process.Start(psi)
+            return Process.Start(psi)
                 ?? throw new TswapException($"Failed to start {command}. Is tpm2-tools installed?");
         }
         catch (Win32Exception)
@@ -217,14 +297,6 @@ internal static class Tpm2ToolsInterop
                 $"Could not run '{command}' — tpm2-tools does not appear to be installed. " +
                 "Install it via your distro's package manager (e.g. 'apt install tpm2-tools' on " +
                 "Debian/Ubuntu, 'dnf install tpm2-tools' on Fedora).");
-        }
-
-        using (process)
-        {
-            var stdout = process.StandardOutput.ReadToEnd();
-            var stderr = process.StandardError.ReadToEnd();
-            process.WaitForExit();
-            return (process.ExitCode, stdout, stderr);
         }
     }
 }

--- a/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
+++ b/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
@@ -1,0 +1,234 @@
+using System.Buffers.Binary;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+namespace TswapCore.Vault.Interop;
+
+/// <summary>
+/// Shellout bridge to the <c>tpm2-tools</c> CLI (<c>tpm2_createprimary</c>/<c>tpm2_create</c>/
+/// <c>tpm2_load</c>/<c>tpm2_unseal</c>) — matching <see cref="YkmanYubiKeyService"/>'s shellout
+/// pattern rather than P/Invoking <c>libtss2-esys</c>/<c>libtss2-fapi</c> directly. See
+/// <c>HARDWARE_BACKENDS.md</c>'s Linux TPM section for why (well-packaged CLI across distros,
+/// avoids a large P/Invoke surface against opaque TSS2 structs). Every invocation uses
+/// <see cref="ProcessStartInfo.ArgumentList"/> (an argument array), never a shell string.
+///
+/// <para><b>Primitive: seal/unseal against a primary key that is never persisted.</b> A TPM 2.0
+/// primary key is deterministic: the same hierarchy plus the same public template always yields
+/// the same key, derived from that hierarchy's primary seed (TPM2 spec, Part 1, "Primary Seeds")
+/// — <b>verified directly against swtpm for this codebase</b>, not assumed: two back-to-back
+/// <c>tpm2_createprimary -C o</c> calls on the same simulator produced a byte-identical RSA
+/// modulus. So <see cref="Seal"/> only needs to persist the sealed object's public/private blobs
+/// (<c>tpm2_create -u/-r</c> output); <see cref="Unseal"/> regenerates the same primary from
+/// scratch under the owner hierarchy (<c>-C o</c>) and loads the sealed object under it — no
+/// primary context is ever written to <see cref="Config.TpmSealedKey"/>.</para>
+///
+/// <para>The owner hierarchy (not the null hierarchy) is used deliberately: its primary seed is
+/// preserved across <c>TPM2_Startup</c> (a reboot-equivalent) and only changes on an explicit
+/// <c>TPM2_Clear</c> (<c>tpm2_clear</c> — a deliberate factory-reset-style operation, not
+/// something that happens incidentally). <b>Both verified directly against swtpm:</b> a blob
+/// sealed before a <c>tpm2_startup --clear</c> unseals fine afterward (reboot survives); the same
+/// blob fails to load under a primary regenerated after <c>tpm2_clear</c> with a TPM-reported
+/// <c>tpm:parameter(1):integrity check failed</c> error (clearing invalidates it) — exactly the
+/// "machine-bound key" property this backend needs, with no extra bookkeeping to invalidate
+/// stale blobs.</para>
+///
+/// <para><b>Verified quirk, not assumption:</b> every transient-object-producing step
+/// (<c>createprimary</c>, <c>load</c>) is preceded by <c>tpm2_flushcontext -t</c>. Without it,
+/// the swtpm instance this backend was developed against exhausts its small transient-object
+/// slot budget after only two or three chained invocations, and every subsequent command fails
+/// with "out of memory for object contexts" — real TPMs commonly have similarly small transient
+/// slot counts, so this is cheap insurance, not simulator-only defensiveness.
+/// <c>tpm2_flushcontext -t</c> is a verified no-op (exit 0, no output) when there is nothing to
+/// flush, so it is called unconditionally before each step rather than only after a failure.</para>
+///
+/// <para><b>Status: developed and tested only against a software TPM simulator (swtpm), not yet
+/// verified against real Linux TPM hardware.</b> See <c>HARDWARE_BACKENDS.md</c>'s Linux TPM
+/// section — this proves protocol-level correctness (seal/unseal round-trip, error handling,
+/// wire format) against swtpm, not that the real hardware root-of-trust property holds.</para>
+/// </summary>
+[SupportedOSPlatform("linux")]
+internal static class Tpm2ToolsInterop
+{
+    /// <summary>Cheap, side-effect-free presence check — reads fixed TPM properties, touches no transient objects.</summary>
+    public static bool IsAvailable()
+    {
+        try
+        {
+            var (exitCode, _, _) = Run("tpm2_getcap", "properties-fixed");
+            return exitCode == 0;
+        }
+        catch (TswapException)
+        {
+            // Run() throws TswapException when tpm2-tools itself isn't installed — that
+            // counts as "no usable TPM" for this check, same as an unreachable device.
+            return false;
+        }
+    }
+
+    private static void RequireAvailable()
+    {
+        if (!IsAvailable())
+            throw new TswapException(
+                "No usable TPM detected. This requires a TPM 2.0 device (or a reachable " +
+                "simulator in dev/test — see HARDWARE_BACKENDS.md) and the 'tpm2-tools' package " +
+                "installed. Use a different backend (YubiKey) on this machine.");
+    }
+
+    /// <summary>Enrollment: seals <paramref name="plaintextKey"/> to a freshly (re)created TPM-bound primary key.</summary>
+    public static byte[] Seal(byte[] plaintextKey)
+    {
+        RequireAvailable();
+
+        var tmp = Directory.CreateTempSubdirectory("tswap-tpm-");
+        try
+        {
+            var plaintextPath = Path.Combine(tmp.FullName, "plain.bin");
+            var primaryPath = Path.Combine(tmp.FullName, "primary.ctx");
+            var pubPath = Path.Combine(tmp.FullName, "seal.pub");
+            var privPath = Path.Combine(tmp.FullName, "seal.priv");
+
+            File.WriteAllBytes(plaintextPath, plaintextKey);
+
+            FlushTransient();
+            RunOrThrow("tpm2_createprimary", "creating the TPM primary key",
+                "-C", "o", "-c", primaryPath);
+
+            FlushTransient();
+            RunOrThrow("tpm2_create", "sealing the key to the TPM",
+                "-C", primaryPath, "-u", pubPath, "-r", privPath, "-i", plaintextPath);
+
+            if (!File.Exists(pubPath) || !File.Exists(privPath))
+                throw new TpmOperationException(
+                    "tpm2_create reported success but did not produce the expected sealed-object files — this is a tswap bug, not a config problem.");
+
+            var pub = File.ReadAllBytes(pubPath);
+            var priv = File.ReadAllBytes(privPath);
+
+            // One self-contained blob, mirroring AppleSecureEnclaveInterop's package layout:
+            // a 4-byte little-endian length prefix for the public portion, then the public
+            // bytes, then the private (encrypted) bytes. Bundling both means Config.TpmSealedKey
+            // stays a single field.
+            var package = new byte[4 + pub.Length + priv.Length];
+            BinaryPrimitives.WriteInt32LittleEndian(package, pub.Length);
+            Buffer.BlockCopy(pub, 0, package, 4, pub.Length);
+            Buffer.BlockCopy(priv, 0, package, 4 + pub.Length, priv.Length);
+            return package;
+        }
+        finally
+        {
+            tmp.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>Unlock: reconstitutes the TPM-bound primary and unseals a payload produced by <see cref="Seal"/>.</summary>
+    public static byte[] Unseal(byte[] wrapped)
+    {
+        RequireAvailable();
+
+        if (wrapped.Length < 4)
+            throw new TswapException("Config is corrupted: the TPM sealed key is too short to be valid.");
+
+        var pubLen = BinaryPrimitives.ReadInt32LittleEndian(wrapped);
+        // Subtraction, not "4 + pubLen > wrapped.Length": pubLen comes straight off the wire and
+        // addition can overflow for a huge value, wrapping to negative and defeating the check.
+        // wrapped.Length - 4 can't underflow (already checked wrapped.Length >= 4 above). ">="
+        // (not ">") also requires at least 1 leftover byte for the private portion.
+        if (pubLen < 0 || pubLen >= wrapped.Length - 4)
+            throw new TswapException("Config is corrupted: the TPM sealed key has an invalid length prefix.");
+
+        var tmp = Directory.CreateTempSubdirectory("tswap-tpm-");
+        try
+        {
+            var primaryPath = Path.Combine(tmp.FullName, "primary.ctx");
+            var pubPath = Path.Combine(tmp.FullName, "seal.pub");
+            var privPath = Path.Combine(tmp.FullName, "seal.priv");
+            var loadedPath = Path.Combine(tmp.FullName, "loaded.ctx");
+            var outPath = Path.Combine(tmp.FullName, "unsealed.bin");
+
+            File.WriteAllBytes(pubPath, wrapped.AsSpan(4, pubLen).ToArray());
+            File.WriteAllBytes(privPath, wrapped.AsSpan(4 + pubLen).ToArray());
+
+            FlushTransient();
+            RunOrThrow("tpm2_createprimary", "creating the TPM primary key",
+                "-C", "o", "-c", primaryPath);
+
+            FlushTransient();
+            var (loadExit, _, _) = Run("tpm2_load", "-C", primaryPath, "-u", pubPath, "-r", privPath, "-c", loadedPath);
+            if (loadExit != 0)
+                throw UnlockFailed();
+
+            FlushTransient();
+            var (unsealExit, _, _) = Run("tpm2_unseal", "-c", loadedPath, "-o", outPath);
+            if (unsealExit != 0)
+                throw UnlockFailed();
+
+            if (!File.Exists(outPath))
+                throw new TpmOperationException(
+                    "tpm2_unseal reported success but did not produce an output file — this is a tswap bug, not a config problem.");
+
+            return File.ReadAllBytes(outPath);
+        }
+        finally
+        {
+            tmp.Delete(recursive: true);
+        }
+    }
+
+    // tpm2_load/tpm2_unseal fail this way both when the blob was sealed on a different TPM
+    // (integrity check failure) and when the blob is otherwise corrupted — both are genuinely
+    // "this vault can't be unlocked here," so they collapse into one message rather than
+    // string-matching tpm2-tools' log output (which isn't a stable contract to parse).
+    private static TswapException UnlockFailed() => new(
+        "Could not unlock with the TPM. The sealed key may have been created on a different " +
+        "machine, the TPM may have been cleared since enrollment, or config.json may be corrupted.");
+
+    private static void FlushTransient() => Run("tpm2_flushcontext", "-t");
+
+    private static void RunOrThrow(string command, string stepDescription, params string[] args)
+    {
+        var (exitCode, _, stderr) = Run(command, args);
+        if (exitCode != 0)
+            throw new TswapException($"TPM operation failed while {stepDescription}: {stderr.Trim()}");
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) Run(string command, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = command,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        Process process;
+        try
+        {
+            process = Process.Start(psi)
+                ?? throw new TswapException($"Failed to start {command}. Is tpm2-tools installed?");
+        }
+        catch (Win32Exception)
+        {
+            throw new TswapException(
+                $"Could not run '{command}' — tpm2-tools does not appear to be installed. " +
+                "Install it via your distro's package manager (e.g. 'apt install tpm2-tools' on " +
+                "Debian/Ubuntu, 'dnf install tpm2-tools' on Fedora).");
+        }
+
+        using (process)
+        {
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            return (process.ExitCode, stdout, stderr);
+        }
+    }
+}
+
+/// <summary>A tpm2-tools call failed in a way that isn't a normal user-facing <see cref="TswapException"/> — an assertion that this codebase's own argument construction is wrong, not a hardware/config problem.</summary>
+[SupportedOSPlatform("linux")]
+internal sealed class TpmOperationException(string message) : Exception(message);

--- a/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
+++ b/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
@@ -180,17 +180,17 @@ internal static class Tpm2ToolsInterop
                 "-C", "o", "-G", PrimaryAlgorithm, "-c", primaryPath);
 
             FlushTransient();
-            var (loadExit, _, _) = Run("tpm2_load", "-C", primaryPath, "-u", pubPath, "-r", privPath, "-c", loadedPath);
+            var (loadExit, _, loadErr) = Run("tpm2_load", "-C", primaryPath, "-u", pubPath, "-r", privPath, "-c", loadedPath);
             if (loadExit != 0)
-                throw UnlockFailed();
+                throw UnlockFailed(loadErr);
 
             FlushTransient();
             // No "-o file": capture tpm2_unseal's stdout directly as raw bytes so the recovered
             // vault key never touches disk — verified byte-for-byte against swtpm that this
             // matches what "-o file" would have written, with no text-encoding round-trip risk.
-            var (unsealExit, plaintext, _) = RunCapturingBinaryStdout("tpm2_unseal", "-c", loadedPath);
+            var (unsealExit, plaintext, unsealErr) = RunCapturingBinaryStdout("tpm2_unseal", "-c", loadedPath);
             if (unsealExit != 0)
-                throw UnlockFailed();
+                throw UnlockFailed(unsealErr);
 
             return plaintext;
         }
@@ -202,11 +202,15 @@ internal static class Tpm2ToolsInterop
 
     // tpm2_load/tpm2_unseal fail this way both when the blob was sealed on a different TPM
     // (integrity check failure) and when the blob is otherwise corrupted — both are genuinely
-    // "this vault can't be unlocked here," so they collapse into one message rather than
-    // string-matching tpm2-tools' log output (which isn't a stable contract to parse).
-    private static TswapException UnlockFailed() => new(
+    // "this vault can't be unlocked here," so they collapse into one high-level message rather
+    // than string-matching tpm2-tools' log output to distinguish them (not a stable contract to
+    // parse). The raw stderr is still appended, though: a genuine operational failure (TCTI
+    // misconfigured, auth/policy issue) would otherwise look identical to "wrong machine," and
+    // the stderr is exactly what tells the two apart when debugging.
+    private static TswapException UnlockFailed(string stderr) => new(
         "Could not unlock with the TPM. The sealed key may have been created on a different " +
-        "machine, the TPM may have been cleared since enrollment, or config.json may be corrupted.");
+        "machine, the TPM may have been cleared since enrollment, or config.json may be " +
+        $"corrupted. tpm2-tools reported: {stderr.Trim()}");
 
     private static void FlushTransient()
     {

--- a/TswapCore/Vault/LinuxTpmHardwareService.cs
+++ b/TswapCore/Vault/LinuxTpmHardwareService.cs
@@ -46,6 +46,8 @@ public sealed class LinuxTpmHardwareService : IHardwareKeyService
     /// </summary>
     public byte[] Unlock(Config config, Func<IReadOnlyList<int>, int> chooseSerial)
     {
+        _ = chooseSerial; // intentionally unused — a TPM is a single, non-removable device
+
         if (config.TpmSealedKey is not { Length: > 0 } sealedBase64)
             throw new TswapException(
                 "Config is corrupted: vault uses the 'tpm' backend but has no sealed key. " +

--- a/TswapCore/Vault/LinuxTpmHardwareService.cs
+++ b/TswapCore/Vault/LinuxTpmHardwareService.cs
@@ -1,0 +1,87 @@
+using System.Runtime.Versioning;
+using TswapCore.Vault.Interop;
+
+namespace TswapCore.Vault;
+
+/// <summary>
+/// Linux TPM 2.0 <see cref="IHardwareKeyService"/>. Needs a TPM 2.0 device (or a reachable
+/// simulator in dev/test — see below), so it only builds/runs on Linux — see
+/// <c>HARDWARE_BACKENDS.md</c> and <c>MULTI_MACHINE_KEYING.md</c> for the design this
+/// implements.
+///
+/// <para><b>Primitive:</b> seal/unseal against a machine-bound key, via the <c>tpm2-tools</c>
+/// CLI (through <see cref="Tpm2ToolsInterop"/> — see its header comment for the shellout
+/// design, the primary-key determinism this relies on, and what's actually been verified
+/// against swtpm). No primary key material is ever persisted; unlock reconstitutes it fresh
+/// from the TPM's owner hierarchy and unseals <c>K_v</c> transiently in memory. The k≥2
+/// threshold (Shamir shares instead of the whole key) is Phase 6 — see
+/// <c>MULTI_MACHINE_KEYING.md</c>.</para>
+///
+/// <para>This is today's single-machine, <c>k = 1</c> slice (implementation-ordering step 2 in
+/// <c>MULTI_MACHINE_KEYING.md</c>): <see cref="Config.TpmSealedKey"/> carries a single
+/// self-contained blob — the sealed object's public and private portions — produced and
+/// consumed by <see cref="Tpm2ToolsInterop"/>. The general multi-machine keyring (multiple
+/// slots, signed, `epoch`-guarded) is not built yet; this field is a single-slot precursor to
+/// it, not the final on-disk format.</para>
+///
+/// <para><b>Status: developed and tested only against a software TPM simulator (swtpm), not
+/// yet verified against real Linux TPM hardware</b> — see <c>HARDWARE_BACKENDS.md</c>'s Linux
+/// TPM section before trusting this as a primary vault backend.</para>
+///
+/// <para>Registered at the composition root only on Linux — see <c>TswapCli/Program.cs</c>. On
+/// other builds <see cref="VaultUnlocker"/> returns a clear "backend not supported" error for a
+/// tpm vault.</para>
+/// </summary>
+[SupportedOSPlatform("linux")]
+public sealed class LinuxTpmHardwareService : IHardwareKeyService
+{
+    public HardwareBackend Backend => HardwareBackend.Tpm;
+
+    /// <summary>Real hardware (or a swtpm simulator pointed to by the environment), not a test double. (Tests substitute a fake at the seam.)</summary>
+    public bool IsSimulated => false;
+
+    /// <summary>
+    /// Recovers the vault master key by unsealing <see cref="Config.TpmSealedKey"/>.
+    /// <paramref name="chooseSerial"/> is unused — a TPM is a single, non-removable device.
+    /// </summary>
+    public byte[] Unlock(Config config, Func<IReadOnlyList<int>, int> chooseSerial)
+    {
+        if (config.TpmSealedKey is not { Length: > 0 } sealedBase64)
+            throw new TswapException(
+                "Config is corrupted: vault uses the 'tpm' backend but has no sealed key. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+
+        byte[] sealedBlob;
+        try
+        {
+            sealedBlob = Convert.FromBase64String(sealedBase64);
+        }
+        catch (FormatException)
+        {
+            throw new TswapException(
+                "Config is corrupted: the TPM sealed key is not valid base64. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+        }
+
+        var key = Unseal(sealedBlob);
+        // Unseal is a generic primitive (Phase 6 will use it for Shamir shares of varying
+        // size too — see MULTI_MACHINE_KEYING.md), so it doesn't itself enforce a length. This
+        // call site specifically claims "the vault master key," so it does: a corrupted or
+        // truncated sealed blob that still happens to unseal should fail here with a clear
+        // message, not surface as an opaque downstream error.
+        if (key.Length != 32)
+            throw new TswapException(
+                $"Config is corrupted: expected a 32-byte vault key from the TPM, got {key.Length}. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+        return key;
+    }
+
+    /// <summary>
+    /// Enrollment side: seals <paramref name="plaintextKey"/> (the vault key) to a fresh
+    /// TPM-bound primary key. The returned blob is useless off this machine.
+    /// </summary>
+    public byte[] Seal(byte[] plaintextKey) => Tpm2ToolsInterop.Seal(plaintextKey);
+
+    /// <summary>Unlock side: unseals a payload produced by <see cref="Seal"/> using this TPM's regenerated primary key.</summary>
+    public byte[] Unseal(byte[] wrapped) => Tpm2ToolsInterop.Unseal(wrapped);
+}

--- a/TswapTests/LinuxTpmHardwareServiceTests.cs
+++ b/TswapTests/LinuxTpmHardwareServiceTests.cs
@@ -1,0 +1,141 @@
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using TswapCore;
+using TswapCore.Vault;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Linux TPM backend tests. Trait-gated (<c>Category=Tpm</c>) and excluded from the default
+/// and <c>--unit</c> runs because they need a reachable TPM 2.0 device or simulator and the
+/// <c>tpm2-tools</c> CLI installed. Run them explicitly on Linux with both available:
+/// <code>
+///   ./runtests.sh --tpm
+///   # or: dotnet test ./TswapTests/TswapTests.csproj --filter Category=Tpm
+/// </code>
+///
+/// <b>Dev/test setup:</b> these tests were developed and are meant to run against a software
+/// TPM simulator (swtpm), not real hardware — see <c>HARDWARE_BACKENDS.md</c>'s Linux TPM
+/// section and <c>TPM_LINUX_PLAN.md</c> §4 for the container setup
+/// (<c>danieltrick/swtpm-docker</c>) and the <c>TPM2TOOLS_TCTI</c> environment variable that
+/// points <c>tpm2-tools</c> at it. On real TPM hardware no environment variable is needed —
+/// <c>tpm2-tools</c> falls back to the local device.
+/// </summary>
+[SupportedOSPlatform("linux")]
+[Trait("Category", "Tpm")]
+public class LinuxTpmHardwareServiceTests
+{
+    [Fact]
+    public void SealUnseal_RoundTripsKey()
+    {
+        // The core primitive: a key sealed to the TPM must unseal back to itself, and the
+        // sealed form must not be the plaintext.
+        var svc = new LinuxTpmHardwareService();
+        var key = RandomNumberGenerator.GetBytes(32);
+
+        var sealedKey = svc.Seal(key);
+        var recovered = svc.Unseal(sealedKey);
+
+        Assert.Equal(key, recovered);
+        Assert.NotEqual(key, sealedKey);
+    }
+
+    [Fact]
+    public void Unlock_RecoversVaultKeyFromSlot()
+    {
+        var svc = new LinuxTpmHardwareService();
+        var vaultKey = RandomNumberGenerator.GetBytes(32);
+        var sealedKey = svc.Seal(vaultKey);
+
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: Convert.ToBase64String(sealedKey));
+
+        var recovered = svc.Unlock(config, _ => throw new InvalidOperationException("chooseSerial should not be called for TPM"));
+
+        Assert.Equal(vaultKey, recovered);
+    }
+
+    [Fact]
+    public void Unlock_MissingSealedKey_ThrowsClearError()
+    {
+        var svc = new LinuxTpmHardwareService();
+        var config = new Config([], "", DateTime.UtcNow, Backend: HardwareBackend.Tpm);
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("tpm", ex.Message);
+    }
+
+    [Fact]
+    public void Unlock_InvalidBase64_ThrowsClearError()
+    {
+        var svc = new LinuxTpmHardwareService();
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: "not valid base64!!");
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("base64", ex.Message);
+    }
+
+    [Fact]
+    public void Unlock_WrongLengthKey_ThrowsClearError()
+    {
+        // Unseal is a generic primitive (round-trips whatever was sealed, per
+        // SealUnseal_RoundTripsKey), so a 16-byte payload round-trips fine at that layer.
+        // Unlock specifically promises a 32-byte vault key, so it must reject this.
+        var svc = new LinuxTpmHardwareService();
+        var sealedKey = svc.Seal(RandomNumberGenerator.GetBytes(16));
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: Convert.ToBase64String(sealedKey));
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("32-byte", ex.Message);
+    }
+
+    [Fact]
+    public void Unseal_TooShortBlob_ThrowsClearError()
+    {
+        var svc = new LinuxTpmHardwareService();
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unseal(new byte[3]));
+        Assert.Contains("too short", ex.Message);
+    }
+
+    [Fact]
+    public void Unseal_HugeLengthPrefix_ThrowsClearErrorInsteadOfOverflowing()
+    {
+        // A pubLen near int.MaxValue makes the naive "4 + pubLen > wrapped.Length" bounds
+        // check overflow (wraps to negative, so the comparison passes when it shouldn't),
+        // reaching an oversized allocation. The fix uses a subtraction-based check instead;
+        // this proves it rejects cleanly rather than attempting that allocation.
+        var svc = new LinuxTpmHardwareService();
+        var corrupted = new byte[8];
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(corrupted, int.MaxValue - 1);
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unseal(corrupted));
+        Assert.Contains("length prefix", ex.Message);
+    }
+
+    [Fact]
+    public void Unseal_SealedOnADifferentTpm_ThrowsClearError()
+    {
+        // Simulates the "wrong machine" case by corrupting the private portion of a real
+        // sealed blob so its TPM-checked integrity fails on load — the same failure mode as
+        // loading a blob sealed under a genuinely different TPM's primary key (verified
+        // manually against swtpm: both produce a "tpm:parameter(1):integrity check failed"
+        // error from tpm2_load).
+        var svc = new LinuxTpmHardwareService();
+        var sealedKey = svc.Seal(RandomNumberGenerator.GetBytes(32));
+
+        var pubLen = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(sealedKey);
+        var corrupted = (byte[])sealedKey.Clone();
+        for (var i = 4 + pubLen; i < corrupted.Length; i++)
+            corrupted[i] ^= 0xFF;
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unseal(corrupted));
+        Assert.Contains("Could not unlock", ex.Message);
+    }
+}

--- a/TswapTests/ModelsTests.cs
+++ b/TswapTests/ModelsTests.cs
@@ -97,6 +97,26 @@ public class ModelsTests
     }
 
     [Fact]
+    public void Config_NullTpmSealedKey_IsOmittedFromJson()
+    {
+        // Same backward-compat guarantee as SecureEnclaveWrappedKey: a non-TPM vault must
+        // serialize with no TpmSealedKey field at all.
+        var config = new Config([1, 2], "aabb", DateTime.UtcNow, RngMode: RngMode.System);
+        var json = JsonSerializer.Serialize(config, TswapJsonContext.Default.Config);
+        Assert.DoesNotContain("TpmSealedKey", json);
+        Assert.Null(config.TpmSealedKey);
+    }
+
+    [Fact]
+    public void Config_TpmSealedKey_RoundTrips()
+    {
+        var config = new Config([], "", DateTime.UtcNow, Backend: HardwareBackend.Tpm, TpmSealedKey: "c2VhbGVk");
+        var json = JsonSerializer.Serialize(config, TswapJsonContext.Default.Config);
+        Assert.Contains("\"TpmSealedKey\": \"c2VhbGVk\"", json);
+        Assert.Equal("c2VhbGVk", JsonSerializer.Deserialize(json, TswapJsonContext.Default.Config)!.TpmSealedKey);
+    }
+
+    [Fact]
     public void ExportFile_VersionTag_Unchanged()
     {
         Assert.Equal("tswap-export-v1", ExportFile.CurrentVersion);

--- a/TswapTests/SecurityWarningsTests.cs
+++ b/TswapTests/SecurityWarningsTests.cs
@@ -1,0 +1,33 @@
+using TswapCli;
+using TswapCore;
+using Xunit;
+
+namespace TswapTests;
+
+public class SecurityWarningsTests
+{
+    [Fact]
+    public void WarnIfNoTouch_YubiKeyWithoutTouch_Warns()
+    {
+        var console = new FakeConsole();
+        var config = new Config([1, 2], "aabb", DateTime.UtcNow, RequiresTouch: false);
+
+        SecurityWarnings.WarnIfNoTouch(console, config);
+
+        Assert.Contains("YubiKey", console.ErrorText);
+    }
+
+    [Fact]
+    public void WarnIfNoTouch_NonYubiKeyBackend_NeverWarns()
+    {
+        // TPM/Secure Enclave vaults have no YubiKeys at all; the YubiKey-specific wording
+        // ("your YubiKeys", "tswap migrate") would be actively misleading for them, and
+        // each backend already prints its own presence caveats at init time.
+        var console = new FakeConsole();
+        var tpmConfig = new Config([], "", DateTime.UtcNow, RequiresTouch: false, Backend: HardwareBackend.Tpm);
+
+        SecurityWarnings.WarnIfNoTouch(console, tpmConfig);
+
+        Assert.Equal("", console.ErrorText);
+    }
+}

--- a/runtests.sh
+++ b/runtests.sh
@@ -7,13 +7,16 @@
 #                                  set TSWAP_E2E_BINARY to test a pre-built/AOT binary)
 #   ./runtests.sh --secure-enclave Secure Enclave backend tests (macOS + real hardware only;
 #                                  prompts for biometry/presence)
+#   ./runtests.sh --tpm            Linux TPM backend tests (Linux + tpm2-tools required; needs
+#                                  a reachable TPM 2.0 device or swtpm simulator — see
+#                                  HARDWARE_BACKENDS.md's Linux TPM section)
 set -eo pipefail
 
 # Array so the xUnit '&' (AND) in a compound filter isn't treated as a shell operator.
 FILTER=()
 TARGET="./TokenSwap.slnx"
 case "${1:-}" in
-  --unit)        FILTER=(--filter 'Category!=E2E&Category!=SecureEnclave') ;;
+  --unit)        FILTER=(--filter 'Category!=E2E&Category!=SecureEnclave&Category!=Tpm') ;;
   --e2e|--integration)
                  FILTER=(--filter 'Category=E2E')
                  TARGET="./TswapTests/TswapTests.csproj" ;;
@@ -21,9 +24,12 @@ case "${1:-}" in
   --secure-enclave)
                  FILTER=(--filter 'Category=SecureEnclave')
                  TARGET="./TswapTests/TswapTests.csproj" ;;
-  # Default: everything except the hardware-gated Secure Enclave tests.
-  "")            FILTER=(--filter 'Category!=SecureEnclave') ;;
-  *) echo "Usage: $0 [--unit|--e2e|--secure-enclave]" >&2; exit 64 ;;
+  # TPM tests are Linux-only and need a reachable TPM/simulator; run them on purpose.
+  --tpm)         FILTER=(--filter 'Category=Tpm')
+                 TARGET="./TswapTests/TswapTests.csproj" ;;
+  # Default: everything except the hardware-gated Secure Enclave/TPM tests.
+  "")            FILTER=(--filter 'Category!=SecureEnclave&Category!=Tpm') ;;
+  *) echo "Usage: $0 [--unit|--e2e|--secure-enclave|--tpm]" >&2; exit 64 ;;
 esac
 
 TSWAP_TEST_KEY="${TSWAP_TEST_KEY:-$(openssl rand -hex 32)}" \


### PR DESCRIPTION
## Summary
- Adds `LinuxTpmHardwareService` + `Tpm2ToolsInterop` (a `tpm2-tools` shellout, mirroring `YkmanYubiKeyService`'s pattern rather than P/Invoking `libtss2-esys`/`libtss2-fapi`), `Config.TpmSealedKey`, and `tswap init --tpm` — following the Secure Enclave backend as the architectural template.
- Seal/unseal uses a TPM primary key regenerated fresh from the owner hierarchy on every call rather than persisted anywhere. Verified directly against a swtpm simulator (not assumed) that this is deterministic, survives a reboot-equivalent `tpm2_startup --clear`, and is invalidated by `tpm2_clear`.
- Also verified swtpm's small transient-object slot budget requires an unconditional `tpm2_flushcontext` before every `createprimary`/`load` call — without it, chained invocations fail with "out of memory for object contexts."
- `Category=Tpm` is excluded from both `runtests.sh` and `ci.yml`'s own filter — the exact gap that bit CI during the Secure Enclave work (`runtests.sh` had the exclusion but `ci.yml`'s own `dotnet test` filter didn't).
- Fixes a pre-existing bug in `SecurityWarnings.WarnIfNoTouch`: it printed YubiKey-specific wording ("your YubiKeys", "tswap migrate") for *any* backend with `RequiresTouch == false`. TPM's honest `false` value (no PIN/PCR policy in this pass) surfaced this during end-to-end testing; now gated to the YubiKey backend only.

## Status
**Simulator-only — not yet verified against real TPM hardware.** All verification (seal/unseal round-trip, `init --tpm` → `add` → `get` end-to-end, error paths) ran against `danieltrick/swtpm-docker`, not a physical TPM. See `HARDWARE_BACKENDS.md`'s new Linux TPM section for the full honesty-bar writeup.

## Test plan
- [x] `SealUnseal_RoundTripsKey` and the rest of `LinuxTpmHardwareServiceTests` (`Category=Tpm`) pass via `dotnet test` against a running swtpm container
- [x] `tswap init --tpm` → `add` → `get` → `list` verified end-to-end against the real NativeAOT-published binary
- [x] Corrupted/malformed sealed-blob and missing-TPM error paths verified to throw clear `TswapException`s, not raw crashes
- [x] `runtests.sh --unit` / default and the CI `dotnet test` filter confirmed to exclude `Category=Tpm` (and confirmed the *unfixed* filter would have let it run and fail)
- [x] `dotnet publish -c Release` (NativeAOT) verified on both Linux and macOS
- [x] Full existing test suite (`Category!=E2E&Category!=SecureEnclave`) still green: 325/325

🤖 Generated with [Claude Code](https://claude.com/claude-code)