### PR TITLE
Unify Linux + Windows TPM hardware backends into one branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet build TokenSwap.slnx
 
       - name: Unit tests (in-process)
-        run: dotnet test TokenSwap.slnx --no-build --filter "Category!=E2E&Category!=SecureEnclave"
+        run: dotnet test TokenSwap.slnx --no-build --filter "Category!=E2E&Category!=SecureEnclave&Category!=TpmWindows"
 
       # NativeAOT publish is the tripwire for AOT-incompatible changes
       # (reflection, unsupported patterns) that a plain build won't catch.
@@ -66,3 +66,4 @@ jobs:
           name: tswap-${{ matrix.os }}
           path: TswapCli/bin/Release/net10.0/*/publish/tswap*
           if-no-files-found: error
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet build TokenSwap.slnx
 
       - name: Unit tests (in-process)
-        run: dotnet test TokenSwap.slnx --no-build --filter "Category!=E2E&Category!=SecureEnclave&Category!=Tpm"
+        run: dotnet test TokenSwap.slnx --no-build --filter "Category!=E2E&Category!=SecureEnclave&Category!=Tpm&Category!=TpmWindows"
 
       # NativeAOT publish is the tripwire for AOT-incompatible changes
       # (reflection, unsupported patterns) that a plain build won't catch.
@@ -66,3 +66,4 @@ jobs:
           name: tswap-${{ matrix.os }}
           path: TswapCli/bin/Release/net10.0/*/publish/tswap*
           if-no-files-found: error
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet build TokenSwap.slnx
 
       - name: Unit tests (in-process)
-        run: dotnet test TokenSwap.slnx --no-build --filter "Category!=E2E&Category!=SecureEnclave"
+        run: dotnet test TokenSwap.slnx --no-build --filter "Category!=E2E&Category!=SecureEnclave&Category!=Tpm"
 
       # NativeAOT publish is the tripwire for AOT-incompatible changes
       # (reflection, unsupported patterns) that a plain build won't catch.

--- a/HARDWARE_BACKENDS.md
+++ b/HARDWARE_BACKENDS.md
@@ -32,7 +32,7 @@ This matters because the backends do **not** share a primitive:
 | Backend | Recovery primitive | Notes |
 |---|---|---|
 | YubiKey | HMAC-SHA1 challenge-response, then XOR-reconstruct + PBKDF2 | Two removable tokens, either unlocks |
-| TPM 2.0 | seal/unseal a machine-bound key | Windows TBS + CNG Platform Crypto Provider; Linux `tpm2`/tpm2-tss |
+| TPM 2.0 | seal/unseal (Linux) or RSA-OAEP wrap/unwrap (Windows) a machine-bound key | Windows: CNG Platform Crypto Provider, implemented, VM-verified only. Linux: `tpm2-tools`, planned, not on this branch |
 | Secure Enclave | ECIES wrap/unwrap against a non-extractable P-256 key | **Cannot** do HMAC or export key bytes; presence/biometric via access control |
 
 A rename of the old `IYubiKeyService` would have kept `Challenge(serial, string)` and
@@ -181,6 +181,77 @@ Codesigning (Developer ID, notarization) still matters for eventually **distribu
 smoothly past Gatekeeper — that's a general macOS distribution concern, unrelated to whether this
 backend functions. It does not block building, testing, or using this backend locally today.
 
+## Windows TPM: implemented, verified only against this machine's (virtual) TPM
+
+`TswapCore/Vault/WindowsTpmHardwareService.cs` implements `IHardwareKeyService`, backed by
+`TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs`, which reaches Windows' TPM-backed CNG
+"Microsoft Platform Crypto Provider" (PCP) entirely through managed
+`System.Security.Cryptography.Cng` APIs (`CngKey`/`RSACng`) — no P/Invoke or native shim needed,
+unlike the Secure Enclave (no C ABI) or Linux (a CLI shellout was chosen over a large P/Invoke
+surface). `Wrap` creates a non-exportable RSA-2048 key under a fixed, well-known persisted name
+and RSA-OAEP-SHA256-encrypts the vault key to it; `Unwrap` re-opens the same named key and
+decrypts. `Config.TpmSealedKey` — shared with the Linux backend, since a vault is inherently tied
+to one machine's OS already — carries only the RSA-OAEP ciphertext, a single-slot, `k = 1`
+precursor to the Phase 6 multi-machine keyring, not the final on-disk format. Registered in
+`TswapCli/Program.cs` behind `OperatingSystem.IsWindows()`.
+`TswapTests/WindowsTpmHardwareServiceTests.cs` holds the trait-gated tests
+(`Category=TpmWindows` — deliberately distinct from Linux's `Category=Tpm`, since both test
+classes compile on every OS regardless of `[SupportedOSPlatform]` and need to be independently
+excludable, see `runtests.sh --tpm-windows`).
+
+**Why wrap/unwrap, not TPM2 seal/unseal like Linux — a real, verified platform difference,
+not a stylistic choice.** A PCP key created with `ExportPolicy = None` (required for a
+TPM-backed, non-extractable key) **cannot be exported in any blob format** — verified directly
+against this backend's dev VM: `CngKeyBlobFormat.OpaqueTransportBlob` and every PCP-specific
+format name tried (`PCPKEY_TPM20`, `PCPKEY_TPM12`, `PCP_PLATFORM_ATTEST_KEY_BLOB`, etc.) all
+failed with "not supported" / "invalid type specified." So there is no self-contained blob to
+hand back the way `AppleSecureEnclaveInterop.Wrap` or `Tpm2ToolsInterop.Seal` do. The key instead
+lives under a fixed persisted name and is always re-opened by that name — **verified directly**
+that a key created in one process is opened and used successfully by a completely separate
+process via `CngKey.Open` alone, with no other state passed between them, and that re-running
+`init --tpm` (which recreates the key with `CngKeyCreationOptions.OverwriteExistingKey`) cleanly
+invalidates ciphertext from the previous generation (a TPM-reported `CryptographicException`,
+not a crash or silently-wrong plaintext).
+
+### Status: PoC-grade, verified only against a VM's virtual TPM — not physical TPM hardware
+
+Functionally verified end-to-end (`tswap init --tpm` → `add`/`get`/`list`, the full test suite,
+and a NativeAOT `dotnet publish -c Release`), all against a **Parallels VM running Windows 11
+ARM64 with Parallels' own virtual TPM** — not a physical TPM. Concretely still open:
+
+- **No physical TPM hardware has been used at any point.** A software/virtual TPM proves the
+  code speaks the CNG/PCP APIs correctly — key creation, wrap/unwrap round-trips, error
+  handling — it does not prove the real hardware root-of-trust property holds. Real hardware may
+  differ in lockout/anti-hammering behavior, timing, or vendor-specific PCP quirks.
+- **`Get-Tpm` (the standard PowerShell TPM-status cmdlet) fails on this VM with a TBS-level
+  HRESULT (`0x80284005`, "output buffer too small")** — a quirk specific to querying Parallels'
+  virtual TPM through that particular cmdlet's WMI provider, not a sign the TPM itself is
+  unhealthy: `tpmtool getdeviceinformation` (a different, lower-level tool) reports it present,
+  initialized, and `Ready For Storage: True` on the same machine. Worth knowing if `Get-Tpm`
+  throws during any future diagnostic work on a Parallels VM — it doesn't mean the TPM is broken.
+- **No PIN or attestation policy support** — only the unconditional wrap/unwrap case is
+  implemented, matching Linux's current scope.
+- **The sealed-key wire format is unversioned**, same caveat as the other two backends'
+  `Config` fields.
+- `tswap init --tpm` is explicitly a **workaround** (see its doc comment in `InitCommand.cs`) to
+  enable end-to-end testing ahead of a real enrollment flow, same as the other two backends.
+- **TPM availability/enablement is explicitly out of scope** — no detection wizard, no "enable
+  your TPM in BIOS" guidance. A missing TPM fails once with one clear, direct error.
+
+### Dev environment note: this VM's internet connection is a marginal cellular link
+
+Unrelated to the TPM work itself, but worth recording since it cost real time and could bite
+future work on this VM: this dev VM's internet (a Huawei WiFi router on a SIM/cellular
+connection) reliably **truncates large downloads mid-transfer** (`"unexpected EOF or 0 bytes
+from the transport stream"`) — confirmed to be genuine link marginality, not a Parallels virtual
+NIC bug, by reproducing the identical failure with a raw `Invoke-WebRequest` outside NuGet
+entirely. Small requests (KB-sized) always succeed; large ones (the 27–40MB `win-arm64` runtime
+packages this project's AOT publish needs) reliably fail on ordinary HTTP clients. The working
+fix: `curl.exe -C - --retry N --retry-delay N --retry-all-errors`, which resumes from wherever
+the connection dropped instead of restarting the whole file, then pointing NuGet at a local
+folder source (`dotnet nuget add source <folder>`) containing the resulting `.nupkg` files so
+`dotnet build`/`publish` never needs the flaky path again for those specific packages.
+
 ## Adding a backend
 
 1. **Implement `IHardwareKeyService`** in `TswapCore/Vault/` (e.g. `TpmHardwareService`).
@@ -200,9 +271,11 @@ backend functions. It does not block building, testing, or using this backend lo
    it calls `ctx.YubiKeys.Challenge`/`SelectSerial` directly. A new backend needs its own
    enrollment flow (likely new `init` branches or `fleet`-style commands); that is separate
    from unlock and is where the on-disk descriptor for the backend gets written.
-6. **AOT:** implementations are native P/Invoke (TBS/CNG, tpm2-tss, Security.framework, or — as
-   the Secure Enclave backend shows — a small native shim in another language exposing a C ABI).
-   No reflection — keep it P/Invoke + spans and it stays AOT-clean. `dotnet publish -c Release`
+6. **AOT:** implementations are native P/Invoke (Security.framework, or — as the Secure Enclave
+   backend shows — a small native shim in another language exposing a C ABI), managed-only CNG
+   APIs (Windows TPM's `System.Security.Cryptography.Cng` — no P/Invoke needed there at all), or
+   a plain CLI shellout via `System.Diagnostics.Process` (YubiKey's `ykman`, Linux TPM's planned
+   `tpm2-tools`). No reflection in any case — it stays AOT-clean. `dotnet publish -c Release`
    (AOT) is the CI tripwire.
 
 ## Redundancy and Phase 6
@@ -222,3 +295,4 @@ shares, why every alternative (escrow / XOR / Shamir / config-share) collapses i
 Secure Enclave forces wrap/unwrap, and the user-set unlock threshold (`k=1` any-device vs. `k≥2`
 two-device-required). Read it before implementing TPM/SE enrollment. See also
 `REFACTORING_PLAN.md` §Phase 6 for the mergeable on-disk format and threat model.
+

--- a/HARDWARE_BACKENDS.md
+++ b/HARDWARE_BACKENDS.md
@@ -32,7 +32,7 @@ This matters because the backends do **not** share a primitive:
 | Backend | Recovery primitive | Notes |
 |---|---|---|
 | YubiKey | HMAC-SHA1 challenge-response, then XOR-reconstruct + PBKDF2 | Two removable tokens, either unlocks |
-| TPM 2.0 | seal/unseal a machine-bound key | Windows TBS + CNG Platform Crypto Provider; Linux `tpm2`/tpm2-tss |
+| TPM 2.0 | seal/unseal a machine-bound key | Linux: `tpm2-tools` shellout (implemented, simulator-verified only). Windows TBS + CNG Platform Crypto Provider: planned, not implemented |
 | Secure Enclave | ECIES wrap/unwrap against a non-extractable P-256 key | **Cannot** do HMAC or export key bytes; presence/biometric via access control |
 
 A rename of the old `IYubiKeyService` would have kept `Challenge(serial, string)` and
@@ -181,6 +181,84 @@ Codesigning (Developer ID, notarization) still matters for eventually **distribu
 smoothly past Gatekeeper — that's a general macOS distribution concern, unrelated to whether this
 backend functions. It does not block building, testing, or using this backend locally today.
 
+## Linux TPM: implemented, verified only against a software simulator
+
+`TswapCore/Vault/LinuxTpmHardwareService.cs` implements `IHardwareKeyService`, backed by
+`TswapCore/Vault/Interop/Tpm2ToolsInterop.cs`, which shells out to the `tpm2-tools` CLI
+(`tpm2_createprimary`/`tpm2_create`/`tpm2_load`/`tpm2_unseal`) via `System.Diagnostics.Process`
+with argument arrays — the same pattern as `YkmanYubiKeyService`, not P/Invoke. `Seal` creates a
+TPM-bound primary key under the owner hierarchy and seals the vault key to it as a TPM keyed-hash
+object; `Unseal` regenerates the primary and unseals. `Config.TpmSealedKey` carries one
+self-contained base64 blob: a 4-byte length-prefixed public portion followed by the private
+(encrypted) portion — a single-slot, `k = 1` precursor to the Phase 6 multi-machine keyring, not
+the final on-disk format. Registered in `TswapCli/Program.cs` behind `OperatingSystem.IsLinux()`.
+`TswapTests/LinuxTpmHardwareServiceTests.cs` holds the trait-gated tests (`Category=Tpm`, run with
+`./runtests.sh --tpm`) — they need a reachable TPM 2.0 device or simulator.
+
+**No persisted primary key.** A TPM 2.0 primary key is deterministic — the same hierarchy plus
+the same public template always regenerates the same key, derived from that hierarchy's primary
+seed (TPM2 spec, Part 1, "Primary Seeds"). **Verified directly against swtpm for this codebase**
+(not assumed): two back-to-back `tpm2_createprimary -C o` calls on the same simulator produced a
+byte-identical RSA modulus. So `Config.TpmSealedKey` only stores the sealed object's public/private
+blobs; the primary is always regenerated fresh from the owner hierarchy, on both `Seal` and
+`Unseal`, and never written to disk. The owner hierarchy (not the null hierarchy) was chosen
+because its primary seed survives `TPM2_Startup` (a reboot) and only changes on an explicit
+`TPM2_Clear` — **also verified directly**: a blob sealed before `tpm2_startup --clear` unseals
+fine afterward, while the same blob fails to load under a primary regenerated after `tpm2_clear`
+with a TPM-reported `tpm:parameter(1):integrity check failed` error. That is exactly the
+"machine-bound, invalidated on factory reset" property this backend needs, with zero extra
+bookkeeping.
+
+### Status: PoC-grade, simulator-verified only — not yet run against real TPM hardware
+
+Functionally verified end-to-end (`tswap init --tpm` → `add`/`get`, plus the full test suite),
+**but every verification so far is against a software TPM simulator (swtpm), never a physical
+TPM.** A software simulator proves the code speaks the TPM2 protocol correctly — seal/unseal
+round-trips, error handling, wire format — it does **not** prove the real hardware root-of-trust
+property holds. Concretely still open before this should be trusted as a primary vault backend:
+
+- **No real TPM hardware has been used at any point.** All testing ran against
+  `danieltrick/swtpm-docker` (see `TPM_LINUX_PLAN.md` §4 for the exact setup) via the `swtpm`
+  TCTI. Real hardware may behave differently in ways a simulator can't surface — timing,
+  lockout/anti-hammering behavior, vendor-specific quirks, or a stricter owner-hierarchy
+  authorization policy than the simulator's default (empty) owner auth.
+- **No PCR or PIN policy support.** `MULTI_MACHINE_KEYING.md`'s per-backend table lists TPM's
+  primitive as "seal share to a machine-bound key (**optionally** PCR/PIN policy)" — this pass
+  implements only the unconditional case (no policy digest on the sealed object at all). Boot-state
+  binding (PCR policy) and a PIN/password gate are both real, useful extensions, not implemented
+  here.
+- **The sealed-key wire format is unversioned**, same caveat as `Config.SecureEnclaveWrappedKey`:
+  changing `Tpm2ToolsInterop`'s packing format is a silent breaking change for every existing TPM
+  vault, with no detection or migration path.
+- **Small transient-object budgets are a real constraint, verified, not assumed.** The swtpm
+  instance this backend was developed against exhausted its transient-object slots after two or
+  three chained `tpm2_*` invocations without an intervening `tpm2_flushcontext -t` — every
+  subsequent command then failed with "out of memory for object contexts" until flushed. Real TPMs
+  commonly have similarly small transient-object counts, so `Tpm2ToolsInterop` flushes
+  unconditionally before every `createprimary`/`load` call (verified as a safe no-op when there's
+  nothing to flush) rather than only reacting to that failure.
+- `tswap init --tpm` is explicitly a **workaround** (see its doc comment in `InitCommand.cs`) to
+  enable end-to-end testing ahead of a real enrollment flow — not the intended long-term UX. Phase
+  6 (`MULTI_MACHINE_KEYING.md`) is where a proper enrollment ceremony, multi-factor unlock, and a
+  versioned keyring format belong.
+- **TPM availability/enablement is explicitly out of scope.** No detection wizard, no "enable your
+  TPM in BIOS" guidance. A missing TPM (or, in dev/test, an unreachable simulator) fails once with
+  one clear, direct error — matching "No YubiKey detected."
+
+### Why a shellout to tpm2-tools, not P/Invoke libtss2-esys/libtss2-fapi (the path not taken)
+
+Unlike the Secure Enclave (which needed a native Swift shim because CryptoKit has no C ABI), the
+TSS2 stack does expose a C ABI (`libtss2-esys`, `libtss2-fapi`) that a direct P/Invoke binding
+could target. That path was not taken: `tpm2-tools` is well-packaged across every major Linux
+distro (`apt install tpm2-tools` on Debian/Ubuntu, `dnf install tpm2-tools` on Fedora, `apk add
+tpm2-tools` plus the separate `tpm2-tss-tcti-*` packages on Alpine — the TCTI backend libraries
+are split into their own packages there, verified while building the dev/test environment), it's
+the same shellout pattern this codebase already uses for YubiKey (`ykman` via
+`YkmanYubiKeyService`), and it avoids a large P/Invoke surface against the TSS2 APIs' many opaque
+structs and the ESAPI's own transient-object/session lifecycle (which, per the flush-before-every-call
+finding above, has sharp edges worth keeping behind a CLI's higher-level error handling rather than
+reimplementing directly).
+
 ## Adding a backend
 
 1. **Implement `IHardwareKeyService`** in `TswapCore/Vault/` (e.g. `TpmHardwareService`).
@@ -200,10 +278,11 @@ backend functions. It does not block building, testing, or using this backend lo
    it calls `ctx.YubiKeys.Challenge`/`SelectSerial` directly. A new backend needs its own
    enrollment flow (likely new `init` branches or `fleet`-style commands); that is separate
    from unlock and is where the on-disk descriptor for the backend gets written.
-6. **AOT:** implementations are native P/Invoke (TBS/CNG, tpm2-tss, Security.framework, or — as
-   the Secure Enclave backend shows — a small native shim in another language exposing a C ABI).
-   No reflection — keep it P/Invoke + spans and it stays AOT-clean. `dotnet publish -c Release`
-   (AOT) is the CI tripwire.
+6. **AOT:** implementations are native P/Invoke (TBS/CNG, Security.framework, or — as the Secure
+   Enclave backend shows — a small native shim in another language exposing a C ABI), or a plain
+   CLI shellout via `System.Diagnostics.Process` (YubiKey's `ykman`, Linux TPM's `tpm2-tools`) — no
+   reflection either way, and it stays AOT-clean. `dotnet publish -c Release` (AOT) is the CI
+   tripwire.
 
 ## Redundancy and Phase 6
 

--- a/HARDWARE_BACKENDS.md
+++ b/HARDWARE_BACKENDS.md
@@ -188,16 +188,16 @@ backend functions. It does not block building, testing, or using this backend lo
 "Microsoft Platform Crypto Provider" (PCP) entirely through managed
 `System.Security.Cryptography.Cng` APIs (`CngKey`/`RSACng`) — no P/Invoke or native shim needed,
 unlike the Secure Enclave (no C ABI) or Linux (a CLI shellout was chosen over a large P/Invoke
-surface). `Wrap` creates a non-exportable RSA-2048 key under a fixed, well-known persisted name
-and RSA-OAEP-SHA256-encrypts the vault key to it; `Unwrap` re-opens the same named key and
-decrypts. `Config.TpmSealedKey` — shared with the Linux backend, since a vault is inherently tied
-to one machine's OS already — carries only the RSA-OAEP ciphertext, a single-slot, `k = 1`
-precursor to the Phase 6 multi-machine keyring, not the final on-disk format. Registered in
-`TswapCli/Program.cs` behind `OperatingSystem.IsWindows()`.
-`TswapTests/WindowsTpmHardwareServiceTests.cs` holds the trait-gated tests
-(`Category=TpmWindows` — deliberately distinct from Linux's `Category=Tpm`, since both test
-classes compile on every OS regardless of `[SupportedOSPlatform]` and need to be independently
-excludable, see `runtests.sh --tpm-windows`).
+surface). `Wrap` creates a non-exportable RSA-2048 key under a **freshly-generated random name**
+and RSA-OAEP-SHA256-encrypts the vault key to it, bundling the key's name into the returned blob;
+`Unwrap` reads the name back out and re-opens exactly that key. `Config.TpmSealedKey` — shared
+with the Linux backend, since a vault is inherently tied to one machine's OS already — carries
+this bundled (name + ciphertext) blob, a single-slot, `k = 1` precursor to the Phase 6
+multi-machine keyring, not the final on-disk format. Registered in `TswapCli/Program.cs` behind
+`OperatingSystem.IsWindows()`. `TswapTests/WindowsTpmHardwareServiceTests.cs` holds the
+trait-gated tests (`Category=TpmWindows` — deliberately distinct from Linux's `Category=Tpm`,
+since both test classes compile on every OS regardless of `[SupportedOSPlatform]` and need to be
+independently excludable, see `runtests.sh --tpm-windows`).
 
 **Why wrap/unwrap, not TPM2 seal/unseal like Linux — a real, verified platform difference,
 not a stylistic choice.** A PCP key created with `ExportPolicy = None` (required for a
@@ -205,13 +205,22 @@ TPM-backed, non-extractable key) **cannot be exported in any blob format** — v
 against this backend's dev VM: `CngKeyBlobFormat.OpaqueTransportBlob` and every PCP-specific
 format name tried (`PCPKEY_TPM20`, `PCPKEY_TPM12`, `PCP_PLATFORM_ATTEST_KEY_BLOB`, etc.) all
 failed with "not supported" / "invalid type specified." So there is no self-contained blob to
-hand back the way `AppleSecureEnclaveInterop.Wrap` or `Tpm2ToolsInterop.Seal` do. The key instead
-lives under a fixed persisted name and is always re-opened by that name — **verified directly**
-that a key created in one process is opened and used successfully by a completely separate
-process via `CngKey.Open` alone, with no other state passed between them, and that re-running
-`init --tpm` (which recreates the key with `CngKeyCreationOptions.OverwriteExistingKey`) cleanly
-invalidates ciphertext from the previous generation (a TPM-reported `CryptographicException`,
-not a crash or silently-wrong plaintext).
+hand back the way `AppleSecureEnclaveInterop.Wrap` or `Tpm2ToolsInterop.Seal` do on their own —
+**verified directly** that a key created in one process is opened and used successfully by a
+completely separate process via `CngKey.Open` alone, with no other state passed between them, so
+bundling the name into the blob and reopening by that name at unlock time works cleanly.
+
+**The key name is random per `Wrap` call, not a single fixed name — a real bug caught in code
+review before this shipped, not a hypothetical.** An earlier version used one hard-coded
+persisted name for every vault on the machine. Because PCP key names are a single flat,
+machine-wide namespace with no per-vault scoping, a *second* `tswap init --tpm` — a different
+vault via a different `TSWAP_CONFIG_DIR`, or simply running the test suite on a machine with a
+real vault already enrolled — would silently overwrite the *first* vault's key and permanently
+break its ability to unseal. Generating a fresh random name per `Wrap` call and bundling it into
+the blob eliminates the shared-namespace problem entirely: every vault, and every test run, gets
+an isolated key with nothing to configure. The tradeoff is that re-running `init --tpm` now
+leaves the old named key orphaned in the PCP key store rather than cleanly overwriting it —
+harmless key-store clutter, not a correctness issue, given this backend is single-slot today.
 
 ### Status: PoC-grade, verified only against a VM's virtual TPM — not physical TPM hardware
 
@@ -295,4 +304,5 @@ shares, why every alternative (escrow / XOR / Shamir / config-share) collapses i
 Secure Enclave forces wrap/unwrap, and the user-set unlock threshold (`k=1` any-device vs. `k≥2`
 two-device-required). Read it before implementing TPM/SE enrollment. See also
 `REFACTORING_PLAN.md` §Phase 6 for the mergeable on-disk format and threat model.
+
 

--- a/HARDWARE_BACKENDS.md
+++ b/HARDWARE_BACKENDS.md
@@ -32,7 +32,7 @@ This matters because the backends do **not** share a primitive:
 | Backend | Recovery primitive | Notes |
 |---|---|---|
 | YubiKey | HMAC-SHA1 challenge-response, then XOR-reconstruct + PBKDF2 | Two removable tokens, either unlocks |
-| TPM 2.0 | seal/unseal a machine-bound key | Linux: `tpm2-tools` shellout (implemented, simulator-verified only). Windows TBS + CNG Platform Crypto Provider: planned, not implemented |
+| TPM 2.0 | seal/unseal (Linux) or RSA-OAEP wrap/unwrap (Windows) a machine-bound key | Linux: `tpm2-tools` shellout, simulator-verified only. Windows: CNG Platform Crypto Provider, VM-verified only |
 | Secure Enclave | ECIES wrap/unwrap against a non-extractable P-256 key | **Cannot** do HMAC or export key bytes; presence/biometric via access control |
 
 A rename of the old `IYubiKeyService` would have kept `Challenge(serial, string)` and
@@ -259,6 +259,89 @@ structs and the ESAPI's own transient-object/session lifecycle (which, per the f
 finding above, has sharp edges worth keeping behind a CLI's higher-level error handling rather than
 reimplementing directly).
 
+## Windows TPM: implemented, verified only against this machine's (virtual) TPM
+
+`TswapCore/Vault/WindowsTpmHardwareService.cs` implements `IHardwareKeyService`, backed by
+`TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs`, which reaches Windows' TPM-backed CNG
+"Microsoft Platform Crypto Provider" (PCP) entirely through managed
+`System.Security.Cryptography.Cng` APIs (`CngKey`/`RSACng`) — no P/Invoke or native shim needed,
+unlike the Secure Enclave (no C ABI) or Linux (a CLI shellout was chosen over a large P/Invoke
+surface). `Wrap` creates a non-exportable RSA-2048 key under a **freshly-generated random name**
+and RSA-OAEP-SHA256-encrypts the vault key to it, bundling the key's name into the returned blob;
+`Unwrap` reads the name back out and re-opens exactly that key. `Config.TpmSealedKey` — shared
+with the Linux backend, since a vault is inherently tied to one machine's OS already — carries
+this bundled (name + ciphertext) blob, a single-slot, `k = 1` precursor to the Phase 6
+multi-machine keyring, not the final on-disk format. Registered in `TswapCli/Program.cs` behind
+`OperatingSystem.IsWindows()`. `TswapTests/WindowsTpmHardwareServiceTests.cs` holds the
+trait-gated tests (`Category=TpmWindows` — deliberately distinct from Linux's `Category=Tpm`,
+since both test classes compile on every OS regardless of `[SupportedOSPlatform]` and need to be
+independently excludable, see `runtests.sh --tpm-windows`). The `Unlock` validation this shares
+with `LinuxTpmHardwareService` (base64 decode, 32-byte length check, identical error message
+text) lives once in `TswapCore/Vault/TpmHardwareServiceBase.cs` rather than being duplicated —
+each subclass overrides one `RecoverKey` method that calls its own `Unseal`/`Unwrap`.
+
+**Why wrap/unwrap, not TPM2 seal/unseal like Linux — a real, verified platform difference,
+not a stylistic choice.** A PCP key created with `ExportPolicy = None` (required for a
+TPM-backed, non-extractable key) **cannot be exported in any blob format** — verified directly
+against this backend's dev VM: `CngKeyBlobFormat.OpaqueTransportBlob` and every PCP-specific
+format name tried (`PCPKEY_TPM20`, `PCPKEY_TPM12`, `PCP_PLATFORM_ATTEST_KEY_BLOB`, etc.) all
+failed with "not supported" / "invalid type specified." So there is no self-contained blob to
+hand back the way `AppleSecureEnclaveInterop.Wrap` or `Tpm2ToolsInterop.Seal` do on their own —
+**verified directly** that a key created in one process is opened and used successfully by a
+completely separate process via `CngKey.Open` alone, with no other state passed between them, so
+bundling the name into the blob and reopening by that name at unlock time works cleanly.
+
+**The key name is random per `Wrap` call, not a single fixed name — a real bug caught in code
+review before this shipped, not a hypothetical.** An earlier version used one hard-coded
+persisted name for every vault on the machine. Because PCP key names are a single flat,
+machine-wide namespace with no per-vault scoping, a *second* `tswap init --tpm` — a different
+vault via a different `TSWAP_CONFIG_DIR`, or simply running the test suite on a machine with a
+real vault already enrolled — would silently overwrite the *first* vault's key and permanently
+break its ability to unseal. Generating a fresh random name per `Wrap` call and bundling it into
+the blob eliminates the shared-namespace problem entirely: every vault, and every test run, gets
+an isolated key with nothing to configure. The tradeoff is that re-running `init --tpm` now
+leaves the old named key orphaned in the PCP key store rather than cleanly overwriting it —
+harmless key-store clutter, not a correctness issue, given this backend is single-slot today.
+
+### Status: PoC-grade, verified only against a VM's virtual TPM — not physical TPM hardware
+
+Functionally verified end-to-end (`tswap init --tpm` → `add`/`get`/`list`, the full test suite,
+and a NativeAOT `dotnet publish -c Release`), all against a **Parallels VM running Windows 11
+ARM64 with Parallels' own virtual TPM** — not a physical TPM. Concretely still open:
+
+- **No physical TPM hardware has been used at any point.** A software/virtual TPM proves the
+  code speaks the CNG/PCP APIs correctly — key creation, wrap/unwrap round-trips, error
+  handling — it does not prove the real hardware root-of-trust property holds. Real hardware may
+  differ in lockout/anti-hammering behavior, timing, or vendor-specific PCP quirks.
+- **`Get-Tpm` (the standard PowerShell TPM-status cmdlet) fails on this VM with a TBS-level
+  HRESULT (`0x80284005`, "output buffer too small")** — a quirk specific to querying Parallels'
+  virtual TPM through that particular cmdlet's WMI provider, not a sign the TPM itself is
+  unhealthy: `tpmtool getdeviceinformation` (a different, lower-level tool) reports it present,
+  initialized, and `Ready For Storage: True` on the same machine. Worth knowing if `Get-Tpm`
+  throws during any future diagnostic work on a Parallels VM — it doesn't mean the TPM is broken.
+- **No PIN or attestation policy support** — only the unconditional wrap/unwrap case is
+  implemented, matching Linux's current scope.
+- **The sealed-key wire format is unversioned**, same caveat as the other two backends'
+  `Config` fields.
+- `tswap init --tpm` is explicitly a **workaround** (see its doc comment in `InitCommand.cs`) to
+  enable end-to-end testing ahead of a real enrollment flow, same as the other two backends.
+- **TPM availability/enablement is explicitly out of scope** — no detection wizard, no "enable
+  your TPM in BIOS" guidance. A missing TPM fails once with one clear, direct error.
+
+### Dev environment note: this VM's internet connection is a marginal cellular link
+
+Unrelated to the TPM work itself, but worth recording since it cost real time and could bite
+future work on this VM: this dev VM's internet (a Huawei WiFi router on a SIM/cellular
+connection) reliably **truncates large downloads mid-transfer** (`"unexpected EOF or 0 bytes
+from the transport stream"`) — confirmed to be genuine link marginality, not a Parallels virtual
+NIC bug, by reproducing the identical failure with a raw `Invoke-WebRequest` outside NuGet
+entirely. Small requests (KB-sized) always succeed; large ones (the 27–40MB `win-arm64` runtime
+packages this project's AOT publish needs) reliably fail on ordinary HTTP clients. The working
+fix: `curl.exe -C - --retry N --retry-delay N --retry-all-errors`, which resumes from wherever
+the connection dropped instead of restarting the whole file, then pointing NuGet at a local
+folder source (`dotnet nuget add source <folder>`) containing the resulting `.nupkg` files so
+`dotnet build`/`publish` never needs the flaky path again for those specific packages.
+
 ## Adding a backend
 
 1. **Implement `IHardwareKeyService`** in `TswapCore/Vault/` (e.g. `TpmHardwareService`).
@@ -278,11 +361,12 @@ reimplementing directly).
    it calls `ctx.YubiKeys.Challenge`/`SelectSerial` directly. A new backend needs its own
    enrollment flow (likely new `init` branches or `fleet`-style commands); that is separate
    from unlock and is where the on-disk descriptor for the backend gets written.
-6. **AOT:** implementations are native P/Invoke (TBS/CNG, Security.framework, or — as the Secure
-   Enclave backend shows — a small native shim in another language exposing a C ABI), or a plain
-   CLI shellout via `System.Diagnostics.Process` (YubiKey's `ykman`, Linux TPM's `tpm2-tools`) — no
-   reflection either way, and it stays AOT-clean. `dotnet publish -c Release` (AOT) is the CI
-   tripwire.
+6. **AOT:** implementations are native P/Invoke (Security.framework, or — as the Secure Enclave
+   backend shows — a small native shim in another language exposing a C ABI), managed-only CNG
+   APIs (Windows TPM's `System.Security.Cryptography.Cng` — no P/Invoke needed there at all), or
+   a plain CLI shellout via `System.Diagnostics.Process` (YubiKey's `ykman`, Linux TPM's
+   `tpm2-tools`). No reflection in any case — it stays AOT-clean. `dotnet publish -c Release`
+   (AOT) is the CI tripwire.
 
 ## Redundancy and Phase 6
 
@@ -301,3 +385,5 @@ shares, why every alternative (escrow / XOR / Shamir / config-share) collapses i
 Secure Enclave forces wrap/unwrap, and the user-set unlock threshold (`k=1` any-device vs. `k≥2`
 two-device-required). Read it before implementing TPM/SE enrollment. See also
 `REFACTORING_PLAN.md` §Phase 6 for the mergeable on-disk format and threat model.
+
+

--- a/TswapCli/Commands/InitCommand.cs
+++ b/TswapCli/Commands/InitCommand.cs
@@ -9,7 +9,7 @@ public sealed class InitCommand : ICliCommand
 {
     public string Name => "init";
     public string HelpUsage => "init [--secure-enclave|--tpm]";
-    public string Description => "Initialize with 2 YubiKeys (or --secure-enclave on macOS, --tpm on Linux)";
+    public string Description => "Initialize with 2 YubiKeys (or --secure-enclave on macOS, --tpm on Windows/Linux)";
     public bool RequiresSudo => false;
 
     public int Execute(CommandContext ctx, string[] args)
@@ -22,6 +22,9 @@ public sealed class InitCommand : ICliCommand
             if (c.ReadLine()?.ToLower() != "yes")
                 return 0;
         }
+
+        if (args.Contains("--secure-enclave") && args.Contains("--tpm"))
+            throw new UsageException($"{ctx.Prefix} init [--secure-enclave|--tpm] (mutually exclusive)");
 
         if (args.Contains("--secure-enclave"))
             return ExecuteSecureEnclave(ctx);
@@ -241,37 +244,72 @@ public sealed class InitCommand : ICliCommand
     }
 
     /// <summary>
-    /// Single-machine Linux TPM enrollment — a workaround to allow end-to-end testing of the
-    /// TPM backend ahead of a real enrollment flow. There is no redundancy or fleet keyring
-    /// here: one machine, one TPM, <c>k = 1</c>. Phase 6 (<c>MULTI_MACHINE_KEYING.md</c>) is
-    /// where a proper multi-factor / multi-machine enrollment ceremony belongs.
+    /// Single-machine TPM enrollment (Linux via <c>tpm2-tools</c>, Windows via CNG's Platform
+    /// Crypto Provider) — a workaround to allow end-to-end testing of the TPM backends ahead of
+    /// a real enrollment flow. There is no redundancy or fleet keyring here: one machine, one
+    /// TPM, <c>k = 1</c>. Phase 6 (<c>MULTI_MACHINE_KEYING.md</c>) is where a proper
+    /// multi-factor / multi-machine enrollment ceremony belongs.
     ///
-    /// <b>Status: only tested against a software TPM simulator (swtpm), not real TPM hardware</b>
-    /// — see <c>HARDWARE_BACKENDS.md</c>'s Linux TPM section.
+    /// <b>Status: only tested against a software TPM simulator (swtpm) on Linux and a virtual
+    /// TPM in a Parallels VM on Windows — neither has been verified against physical TPM
+    /// hardware</b> — see <c>HARDWARE_BACKENDS.md</c>'s Linux/Windows TPM sections.
     /// </summary>
     private static int ExecuteTpm(CommandContext ctx)
     {
-        if (!OperatingSystem.IsLinux())
-            throw new TswapException("--tpm is only supported on Linux.");
-        return ExecuteTpmOnLinux(ctx);
+        if (OperatingSystem.IsLinux())
+            return ExecuteTpmOnLinux(ctx);
+        if (OperatingSystem.IsWindows())
+            return ExecuteTpmOnWindows(ctx);
+        throw new TswapException("--tpm is only supported on Windows and Linux.");
     }
 
     [SupportedOSPlatform("linux")]
     private static int ExecuteTpmOnLinux(CommandContext ctx)
     {
         var c = ctx.Console;
+        PrintTpmInitBanner(c);
 
+        var tpm = new LinuxTpmHardwareService();
+        var vaultKey = RandomNumberGenerator.GetBytes(32);
+        c.Out.WriteLine("Sealing a new key to this machine's TPM...");
+        var sealedKey = tpm.Seal(vaultKey);
+
+        return FinishTpmInit(ctx, vaultKey, sealedKey);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static int ExecuteTpmOnWindows(CommandContext ctx)
+    {
+        var c = ctx.Console;
+        PrintTpmInitBanner(c);
+
+        var tpm = new WindowsTpmHardwareService();
+        var vaultKey = RandomNumberGenerator.GetBytes(32);
+        c.Out.WriteLine("Wrapping a new key to this machine's TPM...");
+        var wrapped = tpm.Wrap(vaultKey);
+
+        return FinishTpmInit(ctx, vaultKey, wrapped);
+    }
+
+    private static void PrintTpmInitBanner(IConsole c)
+    {
         c.Out.WriteLine("\n╔════════════════════════════════════════╗");
         c.Out.WriteLine("║  tswap - TPM Initialization            ║");
         c.Out.WriteLine("╚════════════════════════════════════════╝\n");
         c.Out.WriteLine("This vault will be protected by this machine's TPM — single machine");
         c.Out.WriteLine("only for now (no second factor, no fleet keyring; see");
         c.Out.WriteLine("MULTI_MACHINE_KEYING.md for the planned Phase 6 design).\n");
+    }
 
-        var tpm = new LinuxTpmHardwareService();
-        var vaultKey = RandomNumberGenerator.GetBytes(32);
-        c.Out.WriteLine("Sealing a new key to this machine's TPM...");
-        var sealedKey = tpm.Seal(vaultKey);
+    /// <summary>
+    /// Shared by both TPM platforms: saves the config/vault (with the same backup dance every
+    /// other init path uses) and prints the completion banner. <paramref name="sealedOrWrappedKey"/>
+    /// is Linux's TPM2-sealed blob or Windows' RSA-OAEP-wrapped blob — opaque here, since
+    /// <see cref="Config.TpmSealedKey"/> doesn't care which platform produced it.
+    /// </summary>
+    private static int FinishTpmInit(CommandContext ctx, byte[] vaultKey, byte[] sealedOrWrappedKey)
+    {
+        var c = ctx.Console;
 
         var config = new Config(
             YubiKeySerials: [],
@@ -280,7 +318,7 @@ public sealed class InitCommand : ICliCommand
             RequiresTouch: false,
             RngMode: RngMode.System,
             Backend: HardwareBackend.Tpm,
-            TpmSealedKey: Convert.ToBase64String(sealedKey));
+            TpmSealedKey: Convert.ToBase64String(sealedOrWrappedKey));
 
         var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
         if (File.Exists(ctx.Storage.ConfigFile))
@@ -314,3 +352,5 @@ public sealed class InitCommand : ICliCommand
         return 0;
     }
 }
+
+

--- a/TswapCli/Commands/InitCommand.cs
+++ b/TswapCli/Commands/InitCommand.cs
@@ -8,8 +8,8 @@ namespace TswapCli.Commands;
 public sealed class InitCommand : ICliCommand
 {
     public string Name => "init";
-    public string HelpUsage => "init [--secure-enclave]";
-    public string Description => "Initialize with 2 YubiKeys (or --secure-enclave on macOS)";
+    public string HelpUsage => "init [--secure-enclave|--tpm]";
+    public string Description => "Initialize with 2 YubiKeys (or --secure-enclave on macOS, --tpm on Linux)";
     public bool RequiresSudo => false;
 
     public int Execute(CommandContext ctx, string[] args)
@@ -25,6 +25,9 @@ public sealed class InitCommand : ICliCommand
 
         if (args.Contains("--secure-enclave"))
             return ExecuteSecureEnclave(ctx);
+
+        if (args.Contains("--tpm"))
+            return ExecuteTpm(ctx);
 
         if (ctx.TestKey != null)
         {
@@ -234,6 +237,80 @@ public sealed class InitCommand : ICliCommand
         c.Out.WriteLine("the wrapped key in config.json is meaningless without this machine's");
         c.Out.WriteLine("physical Secure Enclave. Losing this Mac means losing this vault — back");
         c.Out.WriteLine("up secrets some other way (e.g. 'tswap export') if that matters to you.");
+        return 0;
+    }
+
+    /// <summary>
+    /// Single-machine Linux TPM enrollment — a workaround to allow end-to-end testing of the
+    /// TPM backend ahead of a real enrollment flow. There is no redundancy or fleet keyring
+    /// here: one machine, one TPM, <c>k = 1</c>. Phase 6 (<c>MULTI_MACHINE_KEYING.md</c>) is
+    /// where a proper multi-factor / multi-machine enrollment ceremony belongs.
+    ///
+    /// <b>Status: only tested against a software TPM simulator (swtpm), not real TPM hardware</b>
+    /// — see <c>HARDWARE_BACKENDS.md</c>'s Linux TPM section.
+    /// </summary>
+    private static int ExecuteTpm(CommandContext ctx)
+    {
+        if (!OperatingSystem.IsLinux())
+            throw new TswapException("--tpm is only supported on Linux.");
+        return ExecuteTpmOnLinux(ctx);
+    }
+
+    [SupportedOSPlatform("linux")]
+    private static int ExecuteTpmOnLinux(CommandContext ctx)
+    {
+        var c = ctx.Console;
+
+        c.Out.WriteLine("\n╔════════════════════════════════════════╗");
+        c.Out.WriteLine("║  tswap - TPM Initialization            ║");
+        c.Out.WriteLine("╚════════════════════════════════════════╝\n");
+        c.Out.WriteLine("This vault will be protected by this machine's TPM — single machine");
+        c.Out.WriteLine("only for now (no second factor, no fleet keyring; see");
+        c.Out.WriteLine("MULTI_MACHINE_KEYING.md for the planned Phase 6 design).\n");
+
+        var tpm = new LinuxTpmHardwareService();
+        var vaultKey = RandomNumberGenerator.GetBytes(32);
+        c.Out.WriteLine("Sealing a new key to this machine's TPM...");
+        var sealedKey = tpm.Seal(vaultKey);
+
+        var config = new Config(
+            YubiKeySerials: [],
+            RedundancyXor: "",
+            Created: DateTime.UtcNow,
+            RequiresTouch: false,
+            RngMode: RngMode.System,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: Convert.ToBase64String(sealedKey));
+
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
+        if (File.Exists(ctx.Storage.ConfigFile))
+        {
+            var configBackup = ctx.Storage.ConfigFile + ".bak-" + timestamp;
+            File.Copy(ctx.Storage.ConfigFile, configBackup);
+        }
+        ctx.Storage.SaveConfig(config);
+        if (File.Exists(ctx.Storage.SecretsFile))
+        {
+            var vaultBackup = ctx.Storage.SecretsFile + ".bak-" + timestamp;
+            File.Move(ctx.Storage.SecretsFile, vaultBackup);
+            c.SetForeground(ConsoleColor.Yellow);
+            c.Out.WriteLine($"\nExisting vault moved to backup: {vaultBackup}");
+            c.Out.WriteLine("Previous config backed up alongside it. To recover old secrets:");
+            c.Out.WriteLine("  restore both .bak files under their original names.");
+            c.ResetColor();
+        }
+        ctx.Storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), vaultKey);
+
+        c.Out.WriteLine("\n╔════════════════════════════════════════╗");
+        c.Out.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");
+        c.Out.WriteLine("╚════════════════════════════════════════╝\n");
+        c.Out.WriteLine("Backend: TPM (this machine only)");
+        c.Out.WriteLine($"Config saved to: {ctx.Storage.ConfigFile}");
+        c.Out.WriteLine("\nThere is no backup share for this backend, unlike the YubiKey XOR share:");
+        c.Out.WriteLine("the sealed key in config.json is meaningless without this machine's");
+        c.Out.WriteLine("physical TPM. Losing this machine (or clearing its TPM) means losing this");
+        c.Out.WriteLine("vault — back up secrets some other way (e.g. 'tswap export') if that");
+        c.Out.WriteLine("matters to you.");
         return 0;
     }
 }

--- a/TswapCli/Commands/InitCommand.cs
+++ b/TswapCli/Commands/InitCommand.cs
@@ -8,8 +8,8 @@ namespace TswapCli.Commands;
 public sealed class InitCommand : ICliCommand
 {
     public string Name => "init";
-    public string HelpUsage => "init [--secure-enclave]";
-    public string Description => "Initialize with 2 YubiKeys (or --secure-enclave on macOS)";
+    public string HelpUsage => "init [--secure-enclave|--tpm]";
+    public string Description => "Initialize with 2 YubiKeys (or --secure-enclave on macOS, --tpm on Windows)";
     public bool RequiresSudo => false;
 
     public int Execute(CommandContext ctx, string[] args)
@@ -25,6 +25,9 @@ public sealed class InitCommand : ICliCommand
 
         if (args.Contains("--secure-enclave"))
             return ExecuteSecureEnclave(ctx);
+
+        if (args.Contains("--tpm"))
+            return ExecuteTpm(ctx);
 
         if (ctx.TestKey != null)
         {
@@ -236,4 +239,79 @@ public sealed class InitCommand : ICliCommand
         c.Out.WriteLine("up secrets some other way (e.g. 'tswap export') if that matters to you.");
         return 0;
     }
+
+    /// <summary>
+    /// Single-machine Windows TPM enrollment — a workaround to allow end-to-end testing of the
+    /// TPM backend ahead of a real enrollment flow. There is no redundancy or fleet keyring
+    /// here: one machine, one TPM, <c>k = 1</c>. Phase 6 (<c>MULTI_MACHINE_KEYING.md</c>) is
+    /// where a proper multi-factor / multi-machine enrollment ceremony belongs.
+    ///
+    /// <b>Status: only tested against this machine's (virtual) TPM in a Parallels VM, not
+    /// physical TPM hardware</b> — see <c>HARDWARE_BACKENDS.md</c>'s Windows TPM section.
+    /// </summary>
+    private static int ExecuteTpm(CommandContext ctx)
+    {
+        if (!OperatingSystem.IsWindows())
+            throw new TswapException("--tpm is only supported on Windows.");
+        return ExecuteTpmOnWindows(ctx);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static int ExecuteTpmOnWindows(CommandContext ctx)
+    {
+        var c = ctx.Console;
+
+        c.Out.WriteLine("\n╔════════════════════════════════════════╗");
+        c.Out.WriteLine("║  tswap - TPM Initialization            ║");
+        c.Out.WriteLine("╚════════════════════════════════════════╝\n");
+        c.Out.WriteLine("This vault will be protected by this machine's TPM — single machine");
+        c.Out.WriteLine("only for now (no second factor, no fleet keyring; see");
+        c.Out.WriteLine("MULTI_MACHINE_KEYING.md for the planned Phase 6 design).\n");
+
+        var tpm = new WindowsTpmHardwareService();
+        var vaultKey = RandomNumberGenerator.GetBytes(32);
+        c.Out.WriteLine("Wrapping a new key to this machine's TPM...");
+        var wrapped = tpm.Wrap(vaultKey);
+
+        var config = new Config(
+            YubiKeySerials: [],
+            RedundancyXor: "",
+            Created: DateTime.UtcNow,
+            RequiresTouch: false,
+            RngMode: RngMode.System,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: Convert.ToBase64String(wrapped));
+
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
+        if (File.Exists(ctx.Storage.ConfigFile))
+        {
+            var configBackup = ctx.Storage.ConfigFile + ".bak-" + timestamp;
+            File.Copy(ctx.Storage.ConfigFile, configBackup);
+        }
+        ctx.Storage.SaveConfig(config);
+        if (File.Exists(ctx.Storage.SecretsFile))
+        {
+            var vaultBackup = ctx.Storage.SecretsFile + ".bak-" + timestamp;
+            File.Move(ctx.Storage.SecretsFile, vaultBackup);
+            c.SetForeground(ConsoleColor.Yellow);
+            c.Out.WriteLine($"\nExisting vault moved to backup: {vaultBackup}");
+            c.Out.WriteLine("Previous config backed up alongside it. To recover old secrets:");
+            c.Out.WriteLine("  restore both .bak files under their original names.");
+            c.ResetColor();
+        }
+        ctx.Storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), vaultKey);
+
+        c.Out.WriteLine("\n╔════════════════════════════════════════╗");
+        c.Out.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");
+        c.Out.WriteLine("╚════════════════════════════════════════╝\n");
+        c.Out.WriteLine("Backend: TPM (this machine only)");
+        c.Out.WriteLine($"Config saved to: {ctx.Storage.ConfigFile}");
+        c.Out.WriteLine("\nThere is no backup share for this backend, unlike the YubiKey XOR share:");
+        c.Out.WriteLine("the sealed key in config.json is meaningless without this machine's");
+        c.Out.WriteLine("physical TPM. Losing this machine (or clearing its TPM) means losing this");
+        c.Out.WriteLine("vault — back up secrets some other way (e.g. 'tswap export') if that");
+        c.Out.WriteLine("matters to you.");
+        return 0;
+    }
 }
+

--- a/TswapCli/Commands/InitCommand.cs
+++ b/TswapCli/Commands/InitCommand.cs
@@ -23,6 +23,9 @@ public sealed class InitCommand : ICliCommand
                 return 0;
         }
 
+        if (args.Contains("--secure-enclave") && args.Contains("--tpm"))
+            throw new UsageException($"{ctx.Prefix} init [--secure-enclave|--tpm] (mutually exclusive)");
+
         if (args.Contains("--secure-enclave"))
             return ExecuteSecureEnclave(ctx);
 
@@ -314,4 +317,5 @@ public sealed class InitCommand : ICliCommand
         return 0;
     }
 }
+
 

--- a/TswapCli/Commands/MigrateCommand.cs
+++ b/TswapCli/Commands/MigrateCommand.cs
@@ -19,6 +19,18 @@ public sealed class MigrateCommand : ICliCommand
 
         var config = ctx.Storage.LoadConfig();
 
+        // This whole command is YubiKey-specific (touch-requirement slots, XOR-redundancy
+        // entropy choices) and unconditionally indexes YubiKeySerials[0]/[1] below, which a
+        // TPM/Secure Enclave vault never populates (YubiKeySerials: []) — bail out with a clear
+        // message instead of an index-out-of-range crash, same reasoning as the backend guard
+        // in SecurityWarnings.WarnIfNoTouch.
+        if (config.Backend is not (null or HardwareBackend.YubiKey))
+        {
+            c.Out.WriteLine($"'migrate' only applies to YubiKey vaults. This vault uses the " +
+                $"'{config.Backend?.DisplayName()}' backend, which has no touch/entropy settings to migrate.");
+            return 0;
+        }
+
         // Each setting is checked independently so that a partially-migrated or
         // manually-edited config still gets prompted for whichever fields are missing.
         bool needsRngPrompt          = config.RngMode == null;
@@ -121,3 +133,4 @@ public sealed class MigrateCommand : ICliCommand
         return 0;
     }
 }
+

--- a/TswapCli/Program.cs
+++ b/TswapCli/Program.cs
@@ -45,7 +45,8 @@ try
     // and VaultUnlocker picks the right one from config.Backend.
     var extraBackends = new List<IHardwareKeyService>();
     if (OperatingSystem.IsMacOS()) extraBackends.Add(new SecureEnclaveHardwareService());
-    // TPM (Windows/Linux) is not implemented yet — see HARDWARE_BACKENDS.md.
+    if (OperatingSystem.IsWindows()) extraBackends.Add(new WindowsTpmHardwareService());
+    // TPM (Linux) is not implemented on this branch yet — see HARDWARE_BACKENDS.md.
     var unlocker = new VaultUnlocker(yubiKeys, overrideKey: testKey, additionalBackends: extraBackends);
 
     var ctx = new CommandContext(console, env, storage, yubiKeys, unlocker, testKey, sudoBypass);
@@ -63,3 +64,4 @@ catch (Exception ex)
     Console.Error.WriteLine($"\n❌ Error: {ex.Message}");
     return 1;
 }
+

--- a/TswapCli/Program.cs
+++ b/TswapCli/Program.cs
@@ -45,7 +45,8 @@ try
     // and VaultUnlocker picks the right one from config.Backend.
     var extraBackends = new List<IHardwareKeyService>();
     if (OperatingSystem.IsMacOS()) extraBackends.Add(new SecureEnclaveHardwareService());
-    // TPM (Windows/Linux) is not implemented yet — see HARDWARE_BACKENDS.md.
+    if (OperatingSystem.IsLinux()) extraBackends.Add(new LinuxTpmHardwareService());
+    // TPM (Windows) is not implemented yet — see HARDWARE_BACKENDS.md.
     var unlocker = new VaultUnlocker(yubiKeys, overrideKey: testKey, additionalBackends: extraBackends);
 
     var ctx = new CommandContext(console, env, storage, yubiKeys, unlocker, testKey, sudoBypass);

--- a/TswapCli/Program.cs
+++ b/TswapCli/Program.cs
@@ -46,7 +46,7 @@ try
     var extraBackends = new List<IHardwareKeyService>();
     if (OperatingSystem.IsMacOS()) extraBackends.Add(new SecureEnclaveHardwareService());
     if (OperatingSystem.IsLinux()) extraBackends.Add(new LinuxTpmHardwareService());
-    // TPM (Windows) is not implemented yet — see HARDWARE_BACKENDS.md.
+    if (OperatingSystem.IsWindows()) extraBackends.Add(new WindowsTpmHardwareService());
     var unlocker = new VaultUnlocker(yubiKeys, overrideKey: testKey, additionalBackends: extraBackends);
 
     var ctx = new CommandContext(console, env, storage, yubiKeys, unlocker, testKey, sudoBypass);
@@ -64,3 +64,4 @@ catch (Exception ex)
     Console.Error.WriteLine($"\n❌ Error: {ex.Message}");
     return 1;
 }
+

--- a/TswapCli/SecurityWarnings.cs
+++ b/TswapCli/SecurityWarnings.cs
@@ -11,9 +11,16 @@ public static class SecurityWarnings
 {
     /// <summary>
     /// Print a warning to stderr if YubiKey slots don't require touch or status is unknown.
+    /// YubiKey-only: the wording below ("your YubiKeys", "tswap migrate") doesn't apply to
+    /// other backends, which have their own presence models and their own init-time caveats
+    /// (see SecureEnclaveHardwareService/LinuxTpmHardwareService's init flows) rather than a
+    /// shared touch-requirement warning.
     /// </summary>
     public static void WarnIfNoTouch(IConsole console, Config config)
     {
+        if (config.Backend is not (null or HardwareBackend.YubiKey))
+            return;
+
         if (config.RequiresTouch == true)
             return;
 

--- a/TswapCli/SecurityWarnings.cs
+++ b/TswapCli/SecurityWarnings.cs
@@ -11,9 +11,16 @@ public static class SecurityWarnings
 {
     /// <summary>
     /// Print a warning to stderr if YubiKey slots don't require touch or status is unknown.
+    /// YubiKey-only: the wording below ("your YubiKeys", "tswap migrate") doesn't apply to
+    /// other backends, which have their own presence models and their own init-time caveats
+    /// (see SecureEnclaveHardwareService/WindowsTpmHardwareService's init flows) rather than a
+    /// shared touch-requirement warning.
     /// </summary>
     public static void WarnIfNoTouch(IConsole console, Config config)
     {
+        if (config.Backend is not (null or HardwareBackend.YubiKey))
+            return;
+
         if (config.RequiresTouch == true)
             return;
 
@@ -46,3 +53,4 @@ public static class SecurityWarnings
         e.WriteLine();
     }
 }
+

--- a/TswapCli/SecurityWarnings.cs
+++ b/TswapCli/SecurityWarnings.cs
@@ -13,8 +13,8 @@ public static class SecurityWarnings
     /// Print a warning to stderr if YubiKey slots don't require touch or status is unknown.
     /// YubiKey-only: the wording below ("your YubiKeys", "tswap migrate") doesn't apply to
     /// other backends, which have their own presence models and their own init-time caveats
-    /// (see SecureEnclaveHardwareService/LinuxTpmHardwareService's init flows) rather than a
-    /// shared touch-requirement warning.
+    /// (see SecureEnclaveHardwareService/LinuxTpmHardwareService/WindowsTpmHardwareService's
+    /// init flows) rather than a shared touch-requirement warning.
     /// </summary>
     public static void WarnIfNoTouch(IConsole console, Config config)
     {
@@ -53,3 +53,4 @@ public static class SecurityWarnings
         e.WriteLine();
     }
 }
+

--- a/TswapCore/Models.cs
+++ b/TswapCore/Models.cs
@@ -61,7 +61,13 @@ public record Config(List<int> YubiKeySerials, string RedundancyXor, DateTime Cr
     // PoC status: this blob's internal byte layout (see AppleSecureEnclaveInterop.Wrap) has no
     // version tag — changing it silently breaks every existing Secure Enclave vault. See
     // HARDWARE_BACKENDS.md's "PoC-grade" section before treating this as a stable format.
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? SecureEnclaveWrappedKey = null);
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? SecureEnclaveWrappedKey = null,
+    // Linux TPM only: base64 blob of the vault master key sealed to this machine's TPM (see
+    // LinuxTpmHardwareService/Tpm2ToolsInterop). Single-slot precursor to the Phase 6
+    // multi-machine keyring — irrelevant, so omitted, for other backends. Simulator-only
+    // status: see HARDWARE_BACKENDS.md's Linux TPM section before treating this as verified
+    // against real hardware.
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? TpmSealedKey = null);
 public record Secret(string Value, DateTime Created, DateTime Modified, DateTime? BurnedAt = null, string? BurnReason = null);
 public record SecretsDb(Dictionary<string, Secret> Secrets);
 

--- a/TswapCore/Models.cs
+++ b/TswapCore/Models.cs
@@ -62,11 +62,12 @@ public record Config(List<int> YubiKeySerials, string RedundancyXor, DateTime Cr
     // version tag — changing it silently breaks every existing Secure Enclave vault. See
     // HARDWARE_BACKENDS.md's "PoC-grade" section before treating this as a stable format.
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? SecureEnclaveWrappedKey = null,
-    // Linux TPM only: base64 blob of the vault master key sealed to this machine's TPM (see
-    // LinuxTpmHardwareService/Tpm2ToolsInterop). Single-slot precursor to the Phase 6
-    // multi-machine keyring — irrelevant, so omitted, for other backends. Simulator-only
-    // status: see HARDWARE_BACKENDS.md's Linux TPM section before treating this as verified
-    // against real hardware.
+    // TPM only (Windows/Linux): base64 blob of the vault master key wrapped/sealed to this
+    // machine's TPM (see WindowsTpmHardwareService/PlatformCryptoProviderInterop on Windows,
+    // LinuxTpmHardwareService/Tpm2ToolsInterop on Linux). Single-slot precursor to the Phase 6
+    // multi-machine keyring — irrelevant, so omitted, for other backends. Simulator/VM-only
+    // status: see HARDWARE_BACKENDS.md's TPM sections before treating this as verified against
+    // real hardware.
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? TpmSealedKey = null);
 public record Secret(string Value, DateTime Created, DateTime Modified, DateTime? BurnedAt = null, string? BurnReason = null);
 public record SecretsDb(Dictionary<string, Secret> Secrets);
@@ -81,3 +82,4 @@ public record ExportFile(string Version, DateTime Created, string Salt, string C
 [JsonSerializable(typeof(ExportFile))]
 [JsonSourceGenerationOptions(WriteIndented = true)]
 public partial class TswapJsonContext : JsonSerializerContext { }
+

--- a/TswapCore/Models.cs
+++ b/TswapCore/Models.cs
@@ -61,7 +61,13 @@ public record Config(List<int> YubiKeySerials, string RedundancyXor, DateTime Cr
     // PoC status: this blob's internal byte layout (see AppleSecureEnclaveInterop.Wrap) has no
     // version tag — changing it silently breaks every existing Secure Enclave vault. See
     // HARDWARE_BACKENDS.md's "PoC-grade" section before treating this as a stable format.
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? SecureEnclaveWrappedKey = null);
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? SecureEnclaveWrappedKey = null,
+    // TPM only (Windows/Linux): base64 blob of the vault master key wrapped/sealed to this
+    // machine's TPM (see WindowsTpmHardwareService/PlatformCryptoProviderInterop on Windows).
+    // Single-slot precursor to the Phase 6 multi-machine keyring — irrelevant, so omitted, for
+    // other backends. Simulator/VM-only status: see HARDWARE_BACKENDS.md's TPM sections before
+    // treating this as verified against real hardware.
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? TpmSealedKey = null);
 public record Secret(string Value, DateTime Created, DateTime Modified, DateTime? BurnedAt = null, string? BurnReason = null);
 public record SecretsDb(Dictionary<string, Secret> Secrets);
 
@@ -75,3 +81,4 @@ public record ExportFile(string Version, DateTime Created, string Salt, string C
 [JsonSerializable(typeof(ExportFile))]
 [JsonSourceGenerationOptions(WriteIndented = true)]
 public partial class TswapJsonContext : JsonSerializerContext { }
+

--- a/TswapCore/Vault/IHardwareKeyService.cs
+++ b/TswapCore/Vault/IHardwareKeyService.cs
@@ -6,7 +6,8 @@ namespace TswapCore.Vault;
 /// <list type="bullet">
 /// <item><see cref="YubiKeyHardwareService"/> — HMAC challenge-response with 1-of-2 XOR
 ///   redundancy (the scheme tswap has always used).</item>
-/// <item>TPM 2.0 (Windows TBS/CNG, Linux tpm2) — seal/unseal a machine-bound key. Planned.</item>
+/// <item><see cref="LinuxTpmHardwareService"/> — seal/unseal a machine-bound key via
+///   tpm2-tools (Linux only). Windows TPM (TBS/CNG) is planned but not implemented.</item>
 /// <item><see cref="SecureEnclaveHardwareService"/> — ECIES wrap/unwrap against a
 ///   non-extractable P-256 key, via a Swift/CryptoKit shim (macOS only).</item>
 /// </list>

--- a/TswapCore/Vault/IHardwareKeyService.cs
+++ b/TswapCore/Vault/IHardwareKeyService.cs
@@ -7,7 +7,9 @@ namespace TswapCore.Vault;
 /// <item><see cref="YubiKeyHardwareService"/> — HMAC challenge-response with 1-of-2 XOR
 ///   redundancy (the scheme tswap has always used).</item>
 /// <item><see cref="LinuxTpmHardwareService"/> — seal/unseal a machine-bound key via
-///   tpm2-tools (Linux only). Windows TPM (TBS/CNG) is planned but not implemented.</item>
+///   tpm2-tools (Linux only).</item>
+/// <item><see cref="WindowsTpmHardwareService"/> — RSA-OAEP wrap/unwrap against a named,
+///   non-exportable TPM-backed key via Windows CNG's Platform Crypto Provider (Windows only).</item>
 /// <item><see cref="SecureEnclaveHardwareService"/> — ECIES wrap/unwrap against a
 ///   non-extractable P-256 key, via a Swift/CryptoKit shim (macOS only).</item>
 /// </list>
@@ -40,3 +42,4 @@ public interface IHardwareKeyService
     /// </summary>
     byte[] Unlock(Config config, Func<IReadOnlyList<int>, int> chooseSerial);
 }
+

--- a/TswapCore/Vault/IHardwareKeyService.cs
+++ b/TswapCore/Vault/IHardwareKeyService.cs
@@ -6,7 +6,9 @@ namespace TswapCore.Vault;
 /// <list type="bullet">
 /// <item><see cref="YubiKeyHardwareService"/> — HMAC challenge-response with 1-of-2 XOR
 ///   redundancy (the scheme tswap has always used).</item>
-/// <item>TPM 2.0 (Windows TBS/CNG, Linux tpm2) — seal/unseal a machine-bound key. Planned.</item>
+/// <item><see cref="WindowsTpmHardwareService"/> — RSA-OAEP wrap/unwrap against a named,
+///   non-exportable TPM-backed key via Windows CNG's Platform Crypto Provider (Windows only).
+///   Linux TPM (tpm2-tools) is planned but not implemented on this branch.</item>
 /// <item><see cref="SecureEnclaveHardwareService"/> — ECIES wrap/unwrap against a
 ///   non-extractable P-256 key, via a Swift/CryptoKit shim (macOS only).</item>
 /// </list>
@@ -39,3 +41,4 @@ public interface IHardwareKeyService
     /// </summary>
     byte[] Unlock(Config config, Func<IReadOnlyList<int>, int> chooseSerial);
 }
+

--- a/TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs
+++ b/TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs
@@ -1,5 +1,7 @@
+using System.Buffers.Binary;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
+using System.Text;
 
 namespace TswapCore.Vault.Interop;
 
@@ -18,52 +20,46 @@ namespace TswapCore.Vault.Interop;
 /// <see cref="CngExportPolicies.None"/> cannot be exported in <b>any</b> blob format —
 /// <c>CngKeyBlobFormat.OpaqueTransportBlob</c> and every PCP-specific format name tried
 /// (<c>PCPKEY_TPM20</c>, <c>PCPKEY_TPM12</c>, etc.) failed with "not supported" /
-/// "invalid type specified" when tested directly against this backend's dev VM. So there is no
-/// self-contained blob to hand back the way <c>AppleSecureEnclaveInterop.Wrap</c> or
-/// <c>Tpm2ToolsInterop.Seal</c> do. Instead the key is created once under a fixed, well-known
-/// persisted name and always re-opened by that name — <b>verified directly</b> that a key
-/// created in one process is opened and used successfully by a completely separate process via
-/// <see cref="CngKey.Open(string, CngProvider)"/> alone, no other state passed between them.
-/// <see cref="Config.TpmSealedKey"/> therefore stores only the RSA-OAEP ciphertext (not a key
-/// blob) — meaningless without the matching named key, which only exists on this machine's TPM.
-/// </para>
+/// "invalid type specified" when tested directly against this backend's dev VM.</para>
 ///
-/// <para><b>Re-init behavior, verified:</b> creating the key again with
-/// <see cref="CngKeyCreationOptions.OverwriteExistingKey"/> cleanly replaces it — the new key
-/// decrypts newly-produced ciphertext correctly and reproducibly fails (a TPM-reported
-/// <see cref="CryptographicException"/>, not a crash or silent garbage) on ciphertext produced
-/// by the key generation it replaced. That's the same "re-init invalidates the old vault key"
-/// property <c>InitCommand</c>'s other hardware-init branches rely on.</para>
+/// <para><b>The key name is random per <see cref="Wrap"/> call, not a single fixed name.</b> An
+/// earlier version used one hard-coded persisted name for every vault on the machine — that
+/// meant a second <c>tswap init --tpm</c> (a different vault via a different
+/// <c>TSWAP_CONFIG_DIR</c>, or just the test suite) would silently overwrite the *first* vault's
+/// key and permanently break its ability to unseal, since PCP key names are a single flat,
+/// machine-wide namespace with no per-vault scoping of their own. <see cref="Wrap"/> instead
+/// generates a fresh random name for every call and bundles it into the returned blob (4-byte
+/// length-prefixed name, then the RSA-OAEP ciphertext) — the same "one self-contained blob"
+/// shape <c>AppleSecureEnclaveInterop</c>/<c>Tpm2ToolsInterop</c> already use. <see cref="Unwrap"/>
+/// reads the name back out of the blob and opens exactly that key. This means every vault, and
+/// every test run, gets its own isolated TPM key with no shared state and nothing to configure —
+/// not just "test vs. prod" but any number of independent vaults on one machine.</para>
+///
+/// <para><b>Re-init leaves the old named key orphaned in the PCP key store</b> rather than
+/// reusing/overwriting it, since a fresh random name is generated every time. That's a minor key
+/// store hygiene cost (harmless: PCP keys are cheap and this Windows TPM backend is single-slot,
+/// k=1 today), not a correctness issue — the new key and its blob are fully independent of
+/// whatever the old one was.</para>
 /// </summary>
 [SupportedOSPlatform("windows")]
 internal static class PlatformCryptoProviderInterop
 {
     private const string ProviderName = "Microsoft Platform Crypto Provider";
-
-    // Fixed, well-known name: this is today's single-slot, k=1 precursor (same as
-    // Config.TpmSealedKey/SecureEnclaveWrappedKey), not the Phase 6 multi-slot keyring — see
-    // MULTI_MACHINE_KEYING.md. One tswap vault, one named key.
-    private const string KeyName = "tswap-vault-key";
-
+    private const string KeyNamePrefix = "tswap-vault-key-";
     private const int KeySizeBits = 2048;
 
     private static readonly CngProvider Provider = new(ProviderName);
 
-    /// <summary>
-    /// Cheap presence check. <b>Not independently verified against a machine with no TPM at
-    /// all</b> — this dev VM always has a (virtual) TPM, so only the "provider exists but key
-    /// doesn't" and "key exists and works" paths were tested directly. A missing-TPM machine is
-    /// expected to fail the same way <see cref="CngKey.Open"/> fails for a missing key
-    /// (<see cref="CryptographicException"/>), based on how CNG providers behave generally, but
-    /// that specific claim is not empirically confirmed here.
-    /// </summary>
+    /// <summary>Cheap, side-effect-free presence check — does not create or touch any key.</summary>
     public static bool IsAvailable()
     {
         try
         {
-            // Cheapest real probe available without creating a key: ask whether the named key
-            // exists via the provider. Throws if the KSP can't be loaded at all.
-            _ = CngKey.Exists(KeyName, Provider);
+            // Cheapest real probe available without creating a key: ask whether some
+            // definitely-nonexistent key exists via the provider. Throws if the KSP itself
+            // can't be loaded at all; returns false (not an exception) for a normal "no such
+            // key" answer either way, so this only tests provider availability.
+            _ = CngKey.Exists(KeyNamePrefix + "availability-probe", Provider);
             return true;
         }
         catch (CryptographicException)
@@ -81,70 +77,102 @@ internal static class PlatformCryptoProviderInterop
     }
 
     /// <summary>
-    /// Enrollment: (re)creates the named TPM-backed key (overwriting any prior generation —
-    /// verified this cleanly invalidates ciphertext from the previous generation) and
-    /// RSA-OAEP-SHA256-encrypts <paramref name="plaintextKey"/> to it.
+    /// Enrollment: creates a new, randomly-named, non-exportable TPM-backed key and
+    /// RSA-OAEP-SHA256-encrypts <paramref name="plaintextKey"/> to it. The returned blob bundles
+    /// the key's name with the ciphertext, so it is self-contained and useless off this machine.
     /// </summary>
     public static byte[] Wrap(byte[] plaintextKey)
     {
         RequireAvailable();
 
-        using var key = CreateKey();
+        var keyName = KeyNamePrefix + Convert.ToHexString(RandomNumberGenerator.GetBytes(16));
+        using var key = CreateKey(keyName);
         using var rsa = new RSACng(key);
+
+        byte[] ciphertext;
         try
         {
-            return rsa.Encrypt(plaintextKey, RSAEncryptionPadding.OaepSHA256);
+            ciphertext = rsa.Encrypt(plaintextKey, RSAEncryptionPadding.OaepSHA256);
         }
         catch (CryptographicException ex)
         {
             throw new TswapException($"TPM operation failed while wrapping the key: {ex.Message}");
         }
+
+        var nameBytes = Encoding.UTF8.GetBytes(keyName);
+        var package = new byte[4 + nameBytes.Length + ciphertext.Length];
+        BinaryPrimitives.WriteInt32LittleEndian(package, nameBytes.Length);
+        Buffer.BlockCopy(nameBytes, 0, package, 4, nameBytes.Length);
+        Buffer.BlockCopy(ciphertext, 0, package, 4 + nameBytes.Length, ciphertext.Length);
+        return package;
     }
 
-    /// <summary>Unlock: opens the named TPM-backed key and RSA-OAEP-SHA256-decrypts a payload produced by <see cref="Wrap"/>.</summary>
+    /// <summary>Unlock: opens the named TPM-backed key from <paramref name="wrapped"/> and RSA-OAEP-SHA256-decrypts the ciphertext bundled alongside it.</summary>
     public static byte[] Unwrap(byte[] wrapped)
     {
         RequireAvailable();
 
-        if (!CngKey.Exists(KeyName, Provider))
+        if (wrapped.Length < 4)
+            throw new TswapException("Config is corrupted: the TPM sealed key is too short to be valid.");
+
+        var nameLen = BinaryPrimitives.ReadInt32LittleEndian(wrapped);
+        // Subtraction, not "4 + nameLen > wrapped.Length": nameLen comes straight off the wire
+        // and addition can overflow for a huge value, wrapping to negative and defeating the
+        // check. wrapped.Length - 4 can't underflow (already checked wrapped.Length >= 4 above).
+        // ">=" (not ">") also requires at least 1 leftover byte for the ciphertext.
+        if (nameLen < 0 || nameLen >= wrapped.Length - 4)
+            throw new TswapException("Config is corrupted: the TPM sealed key has an invalid length prefix.");
+
+        string keyName;
+        try
+        {
+            keyName = Encoding.UTF8.GetString(wrapped.AsSpan(4, nameLen));
+        }
+        catch (DecoderFallbackException)
+        {
+            throw new TswapException("Config is corrupted: the TPM sealed key's embedded key name is not valid UTF-8.");
+        }
+
+        if (!keyName.StartsWith(KeyNamePrefix, StringComparison.Ordinal) || !CngKey.Exists(keyName, Provider))
             throw new TswapException(
                 "Config is corrupted: vault uses the 'tpm' backend but this machine has no " +
                 "matching TPM key. Restore config.json from backup or re-run 'tswap init'.");
 
-        using var key = CngKey.Open(KeyName, Provider);
+        var ciphertext = wrapped.AsSpan(4 + nameLen).ToArray();
+
+        using var key = CngKey.Open(keyName, Provider);
         using var rsa = new RSACng(key);
         try
         {
-            return rsa.Decrypt(wrapped, RSAEncryptionPadding.OaepSHA256);
+            return rsa.Decrypt(ciphertext, RSAEncryptionPadding.OaepSHA256);
         }
         catch (CryptographicException)
         {
-            // Verified: both "sealed on a different machine/generation" (stale ciphertext
-            // against a replaced key) and "malformed ciphertext" (wrong length, garbage bytes)
-            // land here as CryptographicException with different messages from the TPM/CNG
-            // stack. Collapsing to one message rather than parsing those strings, same
+            // Verified: both "sealed on a different machine/generation" (a stale blob whose
+            // named key no longer matches) and "malformed ciphertext" (wrong length, garbage
+            // bytes) land here as CryptographicException with different messages from the
+            // TPM/CNG stack. Collapsing to one message rather than parsing those strings, same
             // reasoning as Tpm2ToolsInterop.Unseal's UnlockFailed().
             throw new TswapException(
                 "Could not unlock with the TPM. The sealed key may have been created on a " +
-                "different machine or a prior 'tswap init', or config.json may be corrupted.");
+                "different machine, or config.json may be corrupted.");
         }
     }
 
-    private static CngKey CreateKey()
+    private static CngKey CreateKey(string keyName)
     {
         var creationParams = new CngKeyCreationParameters
         {
             Provider = Provider,
             ExportPolicy = CngExportPolicies.None,
             KeyUsage = CngKeyUsages.Decryption,
-            KeyCreationOptions = CngKeyCreationOptions.OverwriteExistingKey,
         };
         creationParams.Parameters.Add(new CngProperty(
             "Length", BitConverter.GetBytes(KeySizeBits), CngPropertyOptions.None));
 
         try
         {
-            return CngKey.Create(CngAlgorithm.Rsa, KeyName, creationParams);
+            return CngKey.Create(CngAlgorithm.Rsa, keyName, creationParams);
         }
         catch (CryptographicException ex)
         {

--- a/TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs
+++ b/TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs
@@ -140,10 +140,15 @@ internal static class PlatformCryptoProviderInterop
 
         var ciphertext = wrapped.AsSpan(4 + nameLen).ToArray();
 
-        using var key = CngKey.Open(keyName, Provider);
-        using var rsa = new RSACng(key);
         try
         {
+            // CngKey.Open and the RSACng construction are inside this try too, not just
+            // Decrypt: the Exists() check above and this Open() are not atomic, so the key
+            // can still legitimately vanish in between (TPM cleared, key store cleanup, a
+            // concurrent re-init) — that must surface as the same clear TswapException, not a
+            // raw CryptographicException from Open() escaping uncaught.
+            using var key = CngKey.Open(keyName, Provider);
+            using var rsa = new RSACng(key);
             return rsa.Decrypt(ciphertext, RSAEncryptionPadding.OaepSHA256);
         }
         catch (CryptographicException)
@@ -180,3 +185,4 @@ internal static class PlatformCryptoProviderInterop
         }
     }
 }
+

--- a/TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs
+++ b/TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs
@@ -1,0 +1,192 @@
+using System.Buffers.Binary;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace TswapCore.Vault.Interop;
+
+/// <summary>
+/// Bridge to Windows' CNG "Microsoft Platform Crypto Provider" (PCP) — the TPM-backed Key
+/// Storage Provider Windows itself uses for BitLocker/Windows Hello for Business keys. Reached
+/// entirely through <c>System.Security.Cryptography.Cng</c> managed APIs
+/// (<see cref="CngKey"/>/<see cref="RSACng"/>); no P/Invoke or native shim needed — unlike the
+/// Secure Enclave (no C ABI) or Linux (chose a CLI shellout over a large P/Invoke surface), the
+/// managed CNG surface already reaches PCP directly. See <c>HARDWARE_BACKENDS.md</c>'s Windows
+/// TPM section for what's actually been verified here versus assumed.
+///
+/// <para><b>Primitive: RSA-OAEP wrap/unwrap against a named, non-exportable, TPM-backed key —
+/// not TPM2 sealed-object seal/unseal like the Linux backend.</b> This is a real, verified
+/// platform difference, not a stylistic choice: a PCP key created with
+/// <see cref="CngExportPolicies.None"/> cannot be exported in <b>any</b> blob format —
+/// <c>CngKeyBlobFormat.OpaqueTransportBlob</c> and every PCP-specific format name tried
+/// (<c>PCPKEY_TPM20</c>, <c>PCPKEY_TPM12</c>, etc.) failed with "not supported" /
+/// "invalid type specified" when tested directly against this backend's dev VM.</para>
+///
+/// <para><b>The key name is random per <see cref="Wrap"/> call, not a single fixed name.</b> An
+/// earlier version used one hard-coded persisted name for every vault on the machine — that
+/// meant a second <c>tswap init --tpm</c> (a different vault via a different
+/// <c>TSWAP_CONFIG_DIR</c>, or just the test suite) would silently overwrite the *first* vault's
+/// key and permanently break its ability to unseal, since PCP key names are a single flat,
+/// machine-wide namespace with no per-vault scoping of their own. <see cref="Wrap"/> instead
+/// generates a fresh random name for every call and bundles it into the returned blob (4-byte
+/// length-prefixed name, then the RSA-OAEP ciphertext) — the same "one self-contained blob"
+/// shape <c>AppleSecureEnclaveInterop</c>/<c>Tpm2ToolsInterop</c> already use. <see cref="Unwrap"/>
+/// reads the name back out of the blob and opens exactly that key. This means every vault, and
+/// every test run, gets its own isolated TPM key with no shared state and nothing to configure —
+/// not just "test vs. prod" but any number of independent vaults on one machine.</para>
+///
+/// <para><b>Re-init leaves the old named key orphaned in the PCP key store</b> rather than
+/// reusing/overwriting it, since a fresh random name is generated every time. That's a minor key
+/// store hygiene cost (harmless: PCP keys are cheap and this Windows TPM backend is single-slot,
+/// k=1 today), not a correctness issue — the new key and its blob are fully independent of
+/// whatever the old one was.</para>
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal static class PlatformCryptoProviderInterop
+{
+    private const string ProviderName = "Microsoft Platform Crypto Provider";
+    private const string KeyNamePrefix = "tswap-vault-key-";
+    private const int KeySizeBits = 2048;
+
+    private static readonly CngProvider Provider = new(ProviderName);
+
+    /// <summary>Cheap, side-effect-free presence check — does not create or touch any key.</summary>
+    public static bool IsAvailable()
+    {
+        try
+        {
+            // Cheapest real probe available without creating a key: ask whether some
+            // definitely-nonexistent key exists via the provider. Throws if the KSP itself
+            // can't be loaded at all; returns false (not an exception) for a normal "no such
+            // key" answer either way, so this only tests provider availability.
+            _ = CngKey.Exists(KeyNamePrefix + "availability-probe", Provider);
+            return true;
+        }
+        catch (CryptographicException)
+        {
+            return false;
+        }
+    }
+
+    private static void RequireAvailable()
+    {
+        if (!IsAvailable())
+            throw new TswapException(
+                "No usable TPM detected. This requires a TPM 2.0 device exposed through Windows' " +
+                "\"Microsoft Platform Crypto Provider\". Use a different backend (YubiKey) on this machine.");
+    }
+
+    /// <summary>
+    /// Enrollment: creates a new, randomly-named, non-exportable TPM-backed key and
+    /// RSA-OAEP-SHA256-encrypts <paramref name="plaintextKey"/> to it. The returned blob bundles
+    /// the key's name with the ciphertext, so it is self-contained and useless off this machine.
+    /// </summary>
+    public static byte[] Wrap(byte[] plaintextKey)
+    {
+        RequireAvailable();
+
+        var keyName = KeyNamePrefix + Convert.ToHexString(RandomNumberGenerator.GetBytes(16));
+        using var key = CreateKey(keyName);
+        using var rsa = new RSACng(key);
+
+        byte[] ciphertext;
+        try
+        {
+            ciphertext = rsa.Encrypt(plaintextKey, RSAEncryptionPadding.OaepSHA256);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new TswapException($"TPM operation failed while wrapping the key: {ex.Message}");
+        }
+
+        var nameBytes = Encoding.UTF8.GetBytes(keyName);
+        var package = new byte[4 + nameBytes.Length + ciphertext.Length];
+        BinaryPrimitives.WriteInt32LittleEndian(package, nameBytes.Length);
+        Buffer.BlockCopy(nameBytes, 0, package, 4, nameBytes.Length);
+        Buffer.BlockCopy(ciphertext, 0, package, 4 + nameBytes.Length, ciphertext.Length);
+        return package;
+    }
+
+    /// <summary>Unlock: opens the named TPM-backed key from <paramref name="wrapped"/> and RSA-OAEP-SHA256-decrypts the ciphertext bundled alongside it.</summary>
+    public static byte[] Unwrap(byte[] wrapped)
+    {
+        RequireAvailable();
+
+        if (wrapped.Length < 4)
+            throw new TswapException("Config is corrupted: the TPM sealed key is too short to be valid.");
+
+        var nameLen = BinaryPrimitives.ReadInt32LittleEndian(wrapped);
+        // Subtraction, not "4 + nameLen > wrapped.Length": nameLen comes straight off the wire
+        // and addition can overflow for a huge value, wrapping to negative and defeating the
+        // check. wrapped.Length - 4 can't underflow (already checked wrapped.Length >= 4 above).
+        // ">=" (not ">") also requires at least 1 leftover byte for the ciphertext.
+        if (nameLen < 0 || nameLen >= wrapped.Length - 4)
+            throw new TswapException("Config is corrupted: the TPM sealed key has an invalid length prefix.");
+
+        string keyName;
+        try
+        {
+            keyName = Encoding.UTF8.GetString(wrapped.AsSpan(4, nameLen));
+        }
+        catch (DecoderFallbackException)
+        {
+            throw new TswapException("Config is corrupted: the TPM sealed key's embedded key name is not valid UTF-8.");
+        }
+
+        var ciphertext = wrapped.AsSpan(4 + nameLen).ToArray();
+
+        try
+        {
+            // CngKey.Exists, CngKey.Open, and the RSACng construction are all inside this same
+            // try as Decrypt, not just Decrypt: any of them can throw CryptographicException
+            // for a genuine provider/key-store failure (distinct from Exists() simply
+            // returning false for "no such key," which is not an exception and still throws
+            // its own clear message below via the ordinary control flow) — including the case
+            // where the key vanishes between Exists() and Open() (TPM cleared, key store
+            // cleanup, a concurrent re-init), since the two calls are not atomic. Every TPM/CNG
+            // failure from this point on should surface the same clear message.
+            if (!keyName.StartsWith(KeyNamePrefix, StringComparison.Ordinal) || !CngKey.Exists(keyName, Provider))
+                throw new TswapException(
+                    "Config is corrupted: vault uses the 'tpm' backend but this machine has no " +
+                    "matching TPM key. Restore config.json from backup or re-run 'tswap init'.");
+
+            using var key = CngKey.Open(keyName, Provider);
+            using var rsa = new RSACng(key);
+            return rsa.Decrypt(ciphertext, RSAEncryptionPadding.OaepSHA256);
+        }
+        catch (CryptographicException)
+        {
+            // Verified: both "sealed on a different machine/generation" (a stale blob whose
+            // named key no longer matches) and "malformed ciphertext" (wrong length, garbage
+            // bytes) land here as CryptographicException with different messages from the
+            // TPM/CNG stack. Collapsing to one message rather than parsing those strings, same
+            // reasoning as Tpm2ToolsInterop.Unseal's UnlockFailed().
+            throw new TswapException(
+                "Could not unlock with the TPM. The sealed key may have been created on a " +
+                "different machine, or config.json may be corrupted.");
+        }
+    }
+
+    private static CngKey CreateKey(string keyName)
+    {
+        var creationParams = new CngKeyCreationParameters
+        {
+            Provider = Provider,
+            ExportPolicy = CngExportPolicies.None,
+            KeyUsage = CngKeyUsages.Decryption,
+        };
+        creationParams.Parameters.Add(new CngProperty(
+            "Length", BitConverter.GetBytes(KeySizeBits), CngPropertyOptions.None));
+
+        try
+        {
+            return CngKey.Create(CngAlgorithm.Rsa, keyName, creationParams);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new TswapException($"TPM operation failed while creating the TPM key: {ex.Message}");
+        }
+    }
+}
+
+

--- a/TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs
+++ b/TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs
@@ -133,20 +133,23 @@ internal static class PlatformCryptoProviderInterop
             throw new TswapException("Config is corrupted: the TPM sealed key's embedded key name is not valid UTF-8.");
         }
 
-        if (!keyName.StartsWith(KeyNamePrefix, StringComparison.Ordinal) || !CngKey.Exists(keyName, Provider))
-            throw new TswapException(
-                "Config is corrupted: vault uses the 'tpm' backend but this machine has no " +
-                "matching TPM key. Restore config.json from backup or re-run 'tswap init'.");
-
         var ciphertext = wrapped.AsSpan(4 + nameLen).ToArray();
 
         try
         {
-            // CngKey.Open and the RSACng construction are inside this try too, not just
-            // Decrypt: the Exists() check above and this Open() are not atomic, so the key
-            // can still legitimately vanish in between (TPM cleared, key store cleanup, a
-            // concurrent re-init) — that must surface as the same clear TswapException, not a
-            // raw CryptographicException from Open() escaping uncaught.
+            // CngKey.Exists, CngKey.Open, and the RSACng construction are all inside this same
+            // try as Decrypt, not just Decrypt: any of them can throw CryptographicException
+            // for a genuine provider/key-store failure (distinct from Exists() simply
+            // returning false for "no such key," which is not an exception and still throws
+            // its own clear message below via the ordinary control flow) — including the case
+            // where the key vanishes between Exists() and Open() (TPM cleared, key store
+            // cleanup, a concurrent re-init), since the two calls are not atomic. Every TPM/CNG
+            // failure from this point on should surface the same clear message.
+            if (!keyName.StartsWith(KeyNamePrefix, StringComparison.Ordinal) || !CngKey.Exists(keyName, Provider))
+                throw new TswapException(
+                    "Config is corrupted: vault uses the 'tpm' backend but this machine has no " +
+                    "matching TPM key. Restore config.json from backup or re-run 'tswap init'.");
+
             using var key = CngKey.Open(keyName, Provider);
             using var rsa = new RSACng(key);
             return rsa.Decrypt(ciphertext, RSAEncryptionPadding.OaepSHA256);
@@ -185,4 +188,5 @@ internal static class PlatformCryptoProviderInterop
         }
     }
 }
+
 

--- a/TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs
+++ b/TswapCore/Vault/Interop/PlatformCryptoProviderInterop.cs
@@ -1,0 +1,154 @@
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+
+namespace TswapCore.Vault.Interop;
+
+/// <summary>
+/// Bridge to Windows' CNG "Microsoft Platform Crypto Provider" (PCP) — the TPM-backed Key
+/// Storage Provider Windows itself uses for BitLocker/Windows Hello for Business keys. Reached
+/// entirely through <c>System.Security.Cryptography.Cng</c> managed APIs
+/// (<see cref="CngKey"/>/<see cref="RSACng"/>); no P/Invoke or native shim needed — unlike the
+/// Secure Enclave (no C ABI) or Linux (chose a CLI shellout over a large P/Invoke surface), the
+/// managed CNG surface already reaches PCP directly. See <c>HARDWARE_BACKENDS.md</c>'s Windows
+/// TPM section for what's actually been verified here versus assumed.
+///
+/// <para><b>Primitive: RSA-OAEP wrap/unwrap against a named, non-exportable, TPM-backed key —
+/// not TPM2 sealed-object seal/unseal like the Linux backend.</b> This is a real, verified
+/// platform difference, not a stylistic choice: a PCP key created with
+/// <see cref="CngExportPolicies.None"/> cannot be exported in <b>any</b> blob format —
+/// <c>CngKeyBlobFormat.OpaqueTransportBlob</c> and every PCP-specific format name tried
+/// (<c>PCPKEY_TPM20</c>, <c>PCPKEY_TPM12</c>, etc.) failed with "not supported" /
+/// "invalid type specified" when tested directly against this backend's dev VM. So there is no
+/// self-contained blob to hand back the way <c>AppleSecureEnclaveInterop.Wrap</c> or
+/// <c>Tpm2ToolsInterop.Seal</c> do. Instead the key is created once under a fixed, well-known
+/// persisted name and always re-opened by that name — <b>verified directly</b> that a key
+/// created in one process is opened and used successfully by a completely separate process via
+/// <see cref="CngKey.Open(string, CngProvider)"/> alone, no other state passed between them.
+/// <see cref="Config.TpmSealedKey"/> therefore stores only the RSA-OAEP ciphertext (not a key
+/// blob) — meaningless without the matching named key, which only exists on this machine's TPM.
+/// </para>
+///
+/// <para><b>Re-init behavior, verified:</b> creating the key again with
+/// <see cref="CngKeyCreationOptions.OverwriteExistingKey"/> cleanly replaces it — the new key
+/// decrypts newly-produced ciphertext correctly and reproducibly fails (a TPM-reported
+/// <see cref="CryptographicException"/>, not a crash or silent garbage) on ciphertext produced
+/// by the key generation it replaced. That's the same "re-init invalidates the old vault key"
+/// property <c>InitCommand</c>'s other hardware-init branches rely on.</para>
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal static class PlatformCryptoProviderInterop
+{
+    private const string ProviderName = "Microsoft Platform Crypto Provider";
+
+    // Fixed, well-known name: this is today's single-slot, k=1 precursor (same as
+    // Config.TpmSealedKey/SecureEnclaveWrappedKey), not the Phase 6 multi-slot keyring — see
+    // MULTI_MACHINE_KEYING.md. One tswap vault, one named key.
+    private const string KeyName = "tswap-vault-key";
+
+    private const int KeySizeBits = 2048;
+
+    private static readonly CngProvider Provider = new(ProviderName);
+
+    /// <summary>
+    /// Cheap presence check. <b>Not independently verified against a machine with no TPM at
+    /// all</b> — this dev VM always has a (virtual) TPM, so only the "provider exists but key
+    /// doesn't" and "key exists and works" paths were tested directly. A missing-TPM machine is
+    /// expected to fail the same way <see cref="CngKey.Open"/> fails for a missing key
+    /// (<see cref="CryptographicException"/>), based on how CNG providers behave generally, but
+    /// that specific claim is not empirically confirmed here.
+    /// </summary>
+    public static bool IsAvailable()
+    {
+        try
+        {
+            // Cheapest real probe available without creating a key: ask whether the named key
+            // exists via the provider. Throws if the KSP can't be loaded at all.
+            _ = CngKey.Exists(KeyName, Provider);
+            return true;
+        }
+        catch (CryptographicException)
+        {
+            return false;
+        }
+    }
+
+    private static void RequireAvailable()
+    {
+        if (!IsAvailable())
+            throw new TswapException(
+                "No usable TPM detected. This requires a TPM 2.0 device exposed through Windows' " +
+                "\"Microsoft Platform Crypto Provider\". Use a different backend (YubiKey) on this machine.");
+    }
+
+    /// <summary>
+    /// Enrollment: (re)creates the named TPM-backed key (overwriting any prior generation —
+    /// verified this cleanly invalidates ciphertext from the previous generation) and
+    /// RSA-OAEP-SHA256-encrypts <paramref name="plaintextKey"/> to it.
+    /// </summary>
+    public static byte[] Wrap(byte[] plaintextKey)
+    {
+        RequireAvailable();
+
+        using var key = CreateKey();
+        using var rsa = new RSACng(key);
+        try
+        {
+            return rsa.Encrypt(plaintextKey, RSAEncryptionPadding.OaepSHA256);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new TswapException($"TPM operation failed while wrapping the key: {ex.Message}");
+        }
+    }
+
+    /// <summary>Unlock: opens the named TPM-backed key and RSA-OAEP-SHA256-decrypts a payload produced by <see cref="Wrap"/>.</summary>
+    public static byte[] Unwrap(byte[] wrapped)
+    {
+        RequireAvailable();
+
+        if (!CngKey.Exists(KeyName, Provider))
+            throw new TswapException(
+                "Config is corrupted: vault uses the 'tpm' backend but this machine has no " +
+                "matching TPM key. Restore config.json from backup or re-run 'tswap init'.");
+
+        using var key = CngKey.Open(KeyName, Provider);
+        using var rsa = new RSACng(key);
+        try
+        {
+            return rsa.Decrypt(wrapped, RSAEncryptionPadding.OaepSHA256);
+        }
+        catch (CryptographicException)
+        {
+            // Verified: both "sealed on a different machine/generation" (stale ciphertext
+            // against a replaced key) and "malformed ciphertext" (wrong length, garbage bytes)
+            // land here as CryptographicException with different messages from the TPM/CNG
+            // stack. Collapsing to one message rather than parsing those strings, same
+            // reasoning as Tpm2ToolsInterop.Unseal's UnlockFailed().
+            throw new TswapException(
+                "Could not unlock with the TPM. The sealed key may have been created on a " +
+                "different machine or a prior 'tswap init', or config.json may be corrupted.");
+        }
+    }
+
+    private static CngKey CreateKey()
+    {
+        var creationParams = new CngKeyCreationParameters
+        {
+            Provider = Provider,
+            ExportPolicy = CngExportPolicies.None,
+            KeyUsage = CngKeyUsages.Decryption,
+            KeyCreationOptions = CngKeyCreationOptions.OverwriteExistingKey,
+        };
+        creationParams.Parameters.Add(new CngProperty(
+            "Length", BitConverter.GetBytes(KeySizeBits), CngPropertyOptions.None));
+
+        try
+        {
+            return CngKey.Create(CngAlgorithm.Rsa, KeyName, creationParams);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new TswapException($"TPM operation failed while creating the TPM key: {ex.Message}");
+        }
+    }
+}

--- a/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
+++ b/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
@@ -21,7 +21,10 @@ namespace TswapCore.Vault.Interop;
 /// modulus. So <see cref="Seal"/> only needs to persist the sealed object's public/private blobs
 /// (<c>tpm2_create -u/-r</c> output); <see cref="Unseal"/> regenerates the same primary from
 /// scratch under the owner hierarchy (<c>-C o</c>) and loads the sealed object under it — no
-/// primary context is ever written to <see cref="Config.TpmSealedKey"/>.</para>
+/// primary context is ever written to <see cref="Config.TpmSealedKey"/>. The template is pinned
+/// explicitly (<c>-G rsa2048</c>, verified to match what this backend was developed against)
+/// rather than relying on tpm2-tools' compiled-in default, so a future tool/distro upgrade
+/// changing that default can't silently break the determinism guarantee this relies on.</para>
 ///
 /// <para>The owner hierarchy (not the null hierarchy) is used deliberately: its primary seed is
 /// preserved across <c>TPM2_Startup</c> (a reboot-equivalent) and only changes on an explicit
@@ -40,7 +43,18 @@ namespace TswapCore.Vault.Interop;
 /// with "out of memory for object contexts" — real TPMs commonly have similarly small transient
 /// slot counts, so this is cheap insurance, not simulator-only defensiveness.
 /// <c>tpm2_flushcontext -t</c> is a verified no-op (exit 0, no output) when there is nothing to
-/// flush, so it is called unconditionally before each step rather than only after a failure.</para>
+/// flush, so it is called unconditionally before each step rather than only after a failure — but
+/// its own exit code is still checked, so a genuine flush failure (e.g. TCTI misconfigured) fails
+/// fast at the real step instead of surfacing as a confusing failure later on.</para>
+///
+/// <para><b>The vault master key never touches disk as plaintext.</b> <see cref="Seal"/> pipes it
+/// to <c>tpm2_create</c> over stdin (verified directly: <c>tpm2_create -i -</c> reads the sealed
+/// payload from stdin and round-trips correctly); <see cref="Unseal"/> captures
+/// <c>tpm2_unseal</c>'s stdout as raw bytes (verified byte-for-byte, no <c>-o</c> file, no text
+/// encoding round-trip) rather than writing the recovered key to a temp file. The other temp
+/// files this class does write (<c>primary.ctx</c>, the sealed public/private blobs, the loaded
+/// object context) are TPM-protected structures, not plaintext key material, so leaving them as
+/// transient files is fine.</para>
 ///
 /// <para><b>Status: developed and tested only against a software TPM simulator (swtpm), not yet
 /// verified against real Linux TPM hardware.</b> See <c>HARDWARE_BACKENDS.md</c>'s Linux TPM
@@ -50,6 +64,11 @@ namespace TswapCore.Vault.Interop;
 [SupportedOSPlatform("linux")]
 internal static class Tpm2ToolsInterop
 {
+    // tpm2-tools' current default template already produces this (verified against swtpm), but
+    // pinning it explicitly means a future tpm2-tools/tpm2-tss default change can't silently
+    // change what "the same hierarchy + template" derives — see the class doc comment.
+    private const string PrimaryAlgorithm = "rsa2048";
+
     /// <summary>Cheap, side-effect-free presence check — reads fixed TPM properties, touches no transient objects.</summary>
     public static bool IsAvailable()
     {
@@ -68,11 +87,17 @@ internal static class Tpm2ToolsInterop
 
     private static void RequireAvailable()
     {
-        if (!IsAvailable())
+        // Deliberately not implemented as "if (!IsAvailable()) throw generic-message": that
+        // would swallow the specific, actionable "tpm2-tools isn't installed, here's how to
+        // install it" exception Run() throws on a missing binary, leaving only this method's
+        // generic message. Running the same cheap probe directly here instead lets a missing
+        // tpm2-tools install propagate its own message untouched, and folds stderr into the
+        // generic message for the "tool present, TPM unreachable" case.
+        var (exitCode, _, stderr) = Run("tpm2_getcap", "properties-fixed");
+        if (exitCode != 0)
             throw new TswapException(
                 "No usable TPM detected. This requires a TPM 2.0 device (or a reachable " +
-                "simulator in dev/test — see HARDWARE_BACKENDS.md) and the 'tpm2-tools' package " +
-                "installed. Use a different backend (YubiKey) on this machine.");
+                $"simulator in dev/test — see HARDWARE_BACKENDS.md). tpm2_getcap failed: {stderr.Trim()}");
     }
 
     /// <summary>Enrollment: seals <paramref name="plaintextKey"/> to a freshly (re)created TPM-bound primary key.</summary>
@@ -83,20 +108,22 @@ internal static class Tpm2ToolsInterop
         var tmp = Directory.CreateTempSubdirectory("tswap-tpm-");
         try
         {
-            var plaintextPath = Path.Combine(tmp.FullName, "plain.bin");
             var primaryPath = Path.Combine(tmp.FullName, "primary.ctx");
             var pubPath = Path.Combine(tmp.FullName, "seal.pub");
             var privPath = Path.Combine(tmp.FullName, "seal.priv");
 
-            File.WriteAllBytes(plaintextPath, plaintextKey);
-
             FlushTransient();
             RunOrThrow("tpm2_createprimary", "creating the TPM primary key",
-                "-C", "o", "-c", primaryPath);
+                "-C", "o", "-G", PrimaryAlgorithm, "-c", primaryPath);
 
             FlushTransient();
-            RunOrThrow("tpm2_create", "sealing the key to the TPM",
-                "-C", primaryPath, "-u", pubPath, "-r", privPath, "-i", plaintextPath);
+            // "-i -": pipe the plaintext vault key over stdin rather than writing it to a temp
+            // file first — verified directly against swtpm that tpm2_create reads and seals it
+            // correctly this way. See the class doc comment.
+            var (createExit, _, createErr) = RunWithStdin("tpm2_create", plaintextKey,
+                "-C", primaryPath, "-u", pubPath, "-r", privPath, "-i", "-");
+            if (createExit != 0)
+                throw new TswapException($"TPM operation failed while sealing the key to the TPM: {createErr.Trim()}");
 
             if (!File.Exists(pubPath) || !File.Exists(privPath))
                 throw new TpmOperationException(
@@ -117,7 +144,7 @@ internal static class Tpm2ToolsInterop
         }
         finally
         {
-            tmp.Delete(recursive: true);
+            DeleteBestEffort(tmp);
         }
     }
 
@@ -144,14 +171,13 @@ internal static class Tpm2ToolsInterop
             var pubPath = Path.Combine(tmp.FullName, "seal.pub");
             var privPath = Path.Combine(tmp.FullName, "seal.priv");
             var loadedPath = Path.Combine(tmp.FullName, "loaded.ctx");
-            var outPath = Path.Combine(tmp.FullName, "unsealed.bin");
 
             File.WriteAllBytes(pubPath, wrapped.AsSpan(4, pubLen).ToArray());
             File.WriteAllBytes(privPath, wrapped.AsSpan(4 + pubLen).ToArray());
 
             FlushTransient();
             RunOrThrow("tpm2_createprimary", "creating the TPM primary key",
-                "-C", "o", "-c", primaryPath);
+                "-C", "o", "-G", PrimaryAlgorithm, "-c", primaryPath);
 
             FlushTransient();
             var (loadExit, _, _) = Run("tpm2_load", "-C", primaryPath, "-u", pubPath, "-r", privPath, "-c", loadedPath);
@@ -159,19 +185,18 @@ internal static class Tpm2ToolsInterop
                 throw UnlockFailed();
 
             FlushTransient();
-            var (unsealExit, _, _) = Run("tpm2_unseal", "-c", loadedPath, "-o", outPath);
+            // No "-o file": capture tpm2_unseal's stdout directly as raw bytes so the recovered
+            // vault key never touches disk — verified byte-for-byte against swtpm that this
+            // matches what "-o file" would have written, with no text-encoding round-trip risk.
+            var (unsealExit, plaintext, _) = RunCapturingBinaryStdout("tpm2_unseal", "-c", loadedPath);
             if (unsealExit != 0)
                 throw UnlockFailed();
 
-            if (!File.Exists(outPath))
-                throw new TpmOperationException(
-                    "tpm2_unseal reported success but did not produce an output file — this is a tswap bug, not a config problem.");
-
-            return File.ReadAllBytes(outPath);
+            return plaintext;
         }
         finally
         {
-            tmp.Delete(recursive: true);
+            DeleteBestEffort(tmp);
         }
     }
 
@@ -183,7 +208,31 @@ internal static class Tpm2ToolsInterop
         "Could not unlock with the TPM. The sealed key may have been created on a different " +
         "machine, the TPM may have been cleared since enrollment, or config.json may be corrupted.");
 
-    private static void FlushTransient() => Run("tpm2_flushcontext", "-t");
+    private static void FlushTransient()
+    {
+        var (exitCode, _, stderr) = Run("tpm2_flushcontext", "-t");
+        // Verified as a no-op (exit 0) when there's nothing to flush, so a non-zero exit here
+        // is a genuine problem (e.g. TCTI misconfigured, TPM unreachable) — fail at this step
+        // with a clear message instead of letting a confusing failure surface later.
+        if (exitCode != 0)
+            throw new TswapException($"TPM operation failed while clearing prior TPM state: {stderr.Trim()}");
+    }
+
+    // Cleanup is best-effort: a failure here (e.g. a transient file lock) must not replace
+    // whatever exception is already propagating out of the try block above it.
+    private static void DeleteBestEffort(DirectoryInfo tmp)
+    {
+        try
+        {
+            tmp.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
 
     private static void RunOrThrow(string command, string stepDescription, params string[] args)
     {
@@ -194,9 +243,41 @@ internal static class Tpm2ToolsInterop
 
     private static (int ExitCode, string Stdout, string Stderr) Run(string command, params string[] args)
     {
+        using var process = Start(command, args, redirectStdin: false);
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, stdout, stderr);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunWithStdin(string command, byte[] stdin, params string[] args)
+    {
+        using var process = Start(command, args, redirectStdin: true);
+        process.StandardInput.BaseStream.Write(stdin);
+        process.StandardInput.BaseStream.Flush();
+        process.StandardInput.Close(); // signal EOF so the command proceeds
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, stdout, stderr);
+    }
+
+    private static (int ExitCode, byte[] Stdout, string Stderr) RunCapturingBinaryStdout(string command, params string[] args)
+    {
+        using var process = Start(command, args, redirectStdin: false);
+        var stdoutBuffer = new MemoryStream();
+        process.StandardOutput.BaseStream.CopyTo(stdoutBuffer);
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, stdoutBuffer.ToArray(), stderr);
+    }
+
+    private static Process Start(string command, string[] args, bool redirectStdin)
+    {
         var psi = new ProcessStartInfo
         {
             FileName = command,
+            RedirectStandardInput = redirectStdin,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -205,10 +286,9 @@ internal static class Tpm2ToolsInterop
         foreach (var arg in args)
             psi.ArgumentList.Add(arg);
 
-        Process process;
         try
         {
-            process = Process.Start(psi)
+            return Process.Start(psi)
                 ?? throw new TswapException($"Failed to start {command}. Is tpm2-tools installed?");
         }
         catch (Win32Exception)
@@ -217,14 +297,6 @@ internal static class Tpm2ToolsInterop
                 $"Could not run '{command}' — tpm2-tools does not appear to be installed. " +
                 "Install it via your distro's package manager (e.g. 'apt install tpm2-tools' on " +
                 "Debian/Ubuntu, 'dnf install tpm2-tools' on Fedora).");
-        }
-
-        using (process)
-        {
-            var stdout = process.StandardOutput.ReadToEnd();
-            var stderr = process.StandardError.ReadToEnd();
-            process.WaitForExit();
-            return (process.ExitCode, stdout, stderr);
         }
     }
 }

--- a/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
+++ b/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
@@ -1,0 +1,234 @@
+using System.Buffers.Binary;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+namespace TswapCore.Vault.Interop;
+
+/// <summary>
+/// Shellout bridge to the <c>tpm2-tools</c> CLI (<c>tpm2_createprimary</c>/<c>tpm2_create</c>/
+/// <c>tpm2_load</c>/<c>tpm2_unseal</c>) — matching <see cref="YkmanYubiKeyService"/>'s shellout
+/// pattern rather than P/Invoking <c>libtss2-esys</c>/<c>libtss2-fapi</c> directly. See
+/// <c>HARDWARE_BACKENDS.md</c>'s Linux TPM section for why (well-packaged CLI across distros,
+/// avoids a large P/Invoke surface against opaque TSS2 structs). Every invocation uses
+/// <see cref="ProcessStartInfo.ArgumentList"/> (an argument array), never a shell string.
+///
+/// <para><b>Primitive: seal/unseal against a primary key that is never persisted.</b> A TPM 2.0
+/// primary key is deterministic: the same hierarchy plus the same public template always yields
+/// the same key, derived from that hierarchy's primary seed (TPM2 spec, Part 1, "Primary Seeds")
+/// — <b>verified directly against swtpm for this codebase</b>, not assumed: two back-to-back
+/// <c>tpm2_createprimary -C o</c> calls on the same simulator produced a byte-identical RSA
+/// modulus. So <see cref="Seal"/> only needs to persist the sealed object's public/private blobs
+/// (<c>tpm2_create -u/-r</c> output); <see cref="Unseal"/> regenerates the same primary from
+/// scratch under the owner hierarchy (<c>-C o</c>) and loads the sealed object under it — no
+/// primary context is ever written to <see cref="Config.TpmSealedKey"/>.</para>
+///
+/// <para>The owner hierarchy (not the null hierarchy) is used deliberately: its primary seed is
+/// preserved across <c>TPM2_Startup</c> (a reboot-equivalent) and only changes on an explicit
+/// <c>TPM2_Clear</c> (<c>tpm2_clear</c> — a deliberate factory-reset-style operation, not
+/// something that happens incidentally). <b>Both verified directly against swtpm:</b> a blob
+/// sealed before a <c>tpm2_startup --clear</c> unseals fine afterward (reboot survives); the same
+/// blob fails to load under a primary regenerated after <c>tpm2_clear</c> with a TPM-reported
+/// <c>tpm:parameter(1):integrity check failed</c> error (clearing invalidates it) — exactly the
+/// "machine-bound key" property this backend needs, with no extra bookkeeping to invalidate
+/// stale blobs.</para>
+///
+/// <para><b>Verified quirk, not assumption:</b> every transient-object-producing step
+/// (<c>createprimary</c>, <c>load</c>) is preceded by <c>tpm2_flushcontext -t</c>. Without it,
+/// the swtpm instance this backend was developed against exhausts its small transient-object
+/// slot budget after only two or three chained invocations, and every subsequent command fails
+/// with "out of memory for object contexts" — real TPMs commonly have similarly small transient
+/// slot counts, so this is cheap insurance, not simulator-only defensiveness.
+/// <c>tpm2_flushcontext -t</c> is a verified no-op (exit 0, no output) when there is nothing to
+/// flush, so it is called unconditionally before each step rather than only after a failure.</para>
+///
+/// <para><b>Status: developed and tested only against a software TPM simulator (swtpm), not yet
+/// verified against real Linux TPM hardware.</b> See <c>HARDWARE_BACKENDS.md</c>'s Linux TPM
+/// section — this proves protocol-level correctness (seal/unseal round-trip, error handling,
+/// wire format) against swtpm, not that the real hardware root-of-trust property holds.</para>
+/// </summary>
+[SupportedOSPlatform("linux")]
+internal static class Tpm2ToolsInterop
+{
+    /// <summary>Cheap, side-effect-free presence check — reads fixed TPM properties, touches no transient objects.</summary>
+    public static bool IsAvailable()
+    {
+        try
+        {
+            var (exitCode, _, _) = Run("tpm2_getcap", "properties-fixed");
+            return exitCode == 0;
+        }
+        catch (TswapException)
+        {
+            // Run() throws TswapException when tpm2-tools itself isn't installed — that
+            // counts as "no usable TPM" for this check, same as an unreachable device.
+            return false;
+        }
+    }
+
+    private static void RequireAvailable()
+    {
+        if (!IsAvailable())
+            throw new TswapException(
+                "No usable TPM detected. This requires a TPM 2.0 device (or a reachable " +
+                "simulator in dev/test — see HARDWARE_BACKENDS.md) and the 'tpm2-tools' package " +
+                "installed. Use a different backend (YubiKey) on this machine.");
+    }
+
+    /// <summary>Enrollment: seals <paramref name="plaintextKey"/> to a freshly (re)created TPM-bound primary key.</summary>
+    public static byte[] Seal(byte[] plaintextKey)
+    {
+        RequireAvailable();
+
+        var tmp = Directory.CreateTempSubdirectory("tswap-tpm-");
+        try
+        {
+            var plaintextPath = Path.Combine(tmp.FullName, "plain.bin");
+            var primaryPath = Path.Combine(tmp.FullName, "primary.ctx");
+            var pubPath = Path.Combine(tmp.FullName, "seal.pub");
+            var privPath = Path.Combine(tmp.FullName, "seal.priv");
+
+            File.WriteAllBytes(plaintextPath, plaintextKey);
+
+            FlushTransient();
+            RunOrThrow("tpm2_createprimary", "creating the TPM primary key",
+                "-C", "o", "-c", primaryPath);
+
+            FlushTransient();
+            RunOrThrow("tpm2_create", "sealing the key to the TPM",
+                "-C", primaryPath, "-u", pubPath, "-r", privPath, "-i", plaintextPath);
+
+            if (!File.Exists(pubPath) || !File.Exists(privPath))
+                throw new TpmOperationException(
+                    "tpm2_create reported success but did not produce the expected sealed-object files — this is a tswap bug, not a config problem.");
+
+            var pub = File.ReadAllBytes(pubPath);
+            var priv = File.ReadAllBytes(privPath);
+
+            // One self-contained blob, mirroring AppleSecureEnclaveInterop's package layout:
+            // a 4-byte little-endian length prefix for the public portion, then the public
+            // bytes, then the private (encrypted) bytes. Bundling both means Config.TpmSealedKey
+            // stays a single field.
+            var package = new byte[4 + pub.Length + priv.Length];
+            BinaryPrimitives.WriteInt32LittleEndian(package, pub.Length);
+            Buffer.BlockCopy(pub, 0, package, 4, pub.Length);
+            Buffer.BlockCopy(priv, 0, package, 4 + pub.Length, priv.Length);
+            return package;
+        }
+        finally
+        {
+            tmp.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>Unlock: reconstitutes the TPM-bound primary and unseals a payload produced by <see cref="Seal"/>.</summary>
+    public static byte[] Unseal(byte[] wrapped)
+    {
+        RequireAvailable();
+
+        if (wrapped.Length < 4)
+            throw new TswapException("Config is corrupted: the TPM sealed key is too short to be valid.");
+
+        var pubLen = BinaryPrimitives.ReadInt32LittleEndian(wrapped);
+        // Subtraction, not "4 + pubLen > wrapped.Length": pubLen comes straight off the wire and
+        // addition can overflow for a huge value, wrapping to negative and defeating the check.
+        // wrapped.Length - 4 can't underflow (already checked wrapped.Length >= 4 above). ">="
+        // (not ">") also requires at least 1 leftover byte for the private portion.
+        if (pubLen < 0 || pubLen >= wrapped.Length - 4)
+            throw new TswapException("Config is corrupted: the TPM sealed key has an invalid length prefix.");
+
+        var tmp = Directory.CreateTempSubdirectory("tswap-tpm-");
+        try
+        {
+            var primaryPath = Path.Combine(tmp.FullName, "primary.ctx");
+            var pubPath = Path.Combine(tmp.FullName, "seal.pub");
+            var privPath = Path.Combine(tmp.FullName, "seal.priv");
+            var loadedPath = Path.Combine(tmp.FullName, "loaded.ctx");
+            var outPath = Path.Combine(tmp.FullName, "unsealed.bin");
+
+            File.WriteAllBytes(pubPath, wrapped.AsSpan(4, pubLen).ToArray());
+            File.WriteAllBytes(privPath, wrapped.AsSpan(4 + pubLen).ToArray());
+
+            FlushTransient();
+            RunOrThrow("tpm2_createprimary", "creating the TPM primary key",
+                "-C", "o", "-c", primaryPath);
+
+            FlushTransient();
+            var (loadExit, _, _) = Run("tpm2_load", "-C", primaryPath, "-u", pubPath, "-r", privPath, "-c", loadedPath);
+            if (loadExit != 0)
+                throw UnlockFailed();
+
+            FlushTransient();
+            var (unsealExit, _, _) = Run("tpm2_unseal", "-c", loadedPath, "-o", outPath);
+            if (unsealExit != 0)
+                throw UnlockFailed();
+
+            if (!File.Exists(outPath))
+                throw new TpmOperationException(
+                    "tpm2_unseal reported success but did not produce an output file — this is a tswap bug, not a config problem.");
+
+            return File.ReadAllBytes(outPath);
+        }
+        finally
+        {
+            tmp.Delete(recursive: true);
+        }
+    }
+
+    // tpm2_load/tpm2_unseal fail this way both when the blob was sealed on a different TPM
+    // (integrity check failure) and when the blob is otherwise corrupted — both are genuinely
+    // "this vault can't be unlocked here," so they collapse into one message rather than
+    // string-matching tpm2-tools' log output (which isn't a stable contract to parse).
+    private static TswapException UnlockFailed() => new(
+        "Could not unlock with the TPM. The sealed key may have been created on a different " +
+        "machine, the TPM may have been cleared since enrollment, or config.json may be corrupted.");
+
+    private static void FlushTransient() => Run("tpm2_flushcontext", "-t");
+
+    private static void RunOrThrow(string command, string stepDescription, params string[] args)
+    {
+        var (exitCode, _, stderr) = Run(command, args);
+        if (exitCode != 0)
+            throw new TswapException($"TPM operation failed while {stepDescription}: {stderr.Trim()}");
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) Run(string command, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = command,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        Process process;
+        try
+        {
+            process = Process.Start(psi)
+                ?? throw new TswapException($"Failed to start {command}. Is tpm2-tools installed?");
+        }
+        catch (Win32Exception)
+        {
+            throw new TswapException(
+                $"Could not run '{command}' — tpm2-tools does not appear to be installed. " +
+                "Install it via your distro's package manager (e.g. 'apt install tpm2-tools' on " +
+                "Debian/Ubuntu, 'dnf install tpm2-tools' on Fedora).");
+        }
+
+        using (process)
+        {
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            return (process.ExitCode, stdout, stderr);
+        }
+    }
+}
+
+/// <summary>A tpm2-tools call failed in a way that isn't a normal user-facing <see cref="TswapException"/> — an assertion that this codebase's own argument construction is wrong, not a hardware/config problem.</summary>
+[SupportedOSPlatform("linux")]
+internal sealed class TpmOperationException(string message) : Exception(message);

--- a/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
+++ b/TswapCore/Vault/Interop/Tpm2ToolsInterop.cs
@@ -180,17 +180,17 @@ internal static class Tpm2ToolsInterop
                 "-C", "o", "-G", PrimaryAlgorithm, "-c", primaryPath);
 
             FlushTransient();
-            var (loadExit, _, _) = Run("tpm2_load", "-C", primaryPath, "-u", pubPath, "-r", privPath, "-c", loadedPath);
+            var (loadExit, _, loadErr) = Run("tpm2_load", "-C", primaryPath, "-u", pubPath, "-r", privPath, "-c", loadedPath);
             if (loadExit != 0)
-                throw UnlockFailed();
+                throw UnlockFailed(loadErr);
 
             FlushTransient();
             // No "-o file": capture tpm2_unseal's stdout directly as raw bytes so the recovered
             // vault key never touches disk — verified byte-for-byte against swtpm that this
             // matches what "-o file" would have written, with no text-encoding round-trip risk.
-            var (unsealExit, plaintext, _) = RunCapturingBinaryStdout("tpm2_unseal", "-c", loadedPath);
+            var (unsealExit, plaintext, unsealErr) = RunCapturingBinaryStdout("tpm2_unseal", "-c", loadedPath);
             if (unsealExit != 0)
-                throw UnlockFailed();
+                throw UnlockFailed(unsealErr);
 
             return plaintext;
         }
@@ -202,11 +202,15 @@ internal static class Tpm2ToolsInterop
 
     // tpm2_load/tpm2_unseal fail this way both when the blob was sealed on a different TPM
     // (integrity check failure) and when the blob is otherwise corrupted — both are genuinely
-    // "this vault can't be unlocked here," so they collapse into one message rather than
-    // string-matching tpm2-tools' log output (which isn't a stable contract to parse).
-    private static TswapException UnlockFailed() => new(
+    // "this vault can't be unlocked here," so they collapse into one high-level message rather
+    // than string-matching tpm2-tools' log output to distinguish them (not a stable contract to
+    // parse). The raw stderr is still appended, though: a genuine operational failure (TCTI
+    // misconfigured, auth/policy issue) would otherwise look identical to "wrong machine," and
+    // the stderr is exactly what tells the two apart when debugging.
+    private static TswapException UnlockFailed(string stderr) => new(
         "Could not unlock with the TPM. The sealed key may have been created on a different " +
-        "machine, the TPM may have been cleared since enrollment, or config.json may be corrupted.");
+        "machine, the TPM may have been cleared since enrollment, or config.json may be " +
+        $"corrupted. tpm2-tools reported: {stderr.Trim()}");
 
     private static void FlushTransient()
     {

--- a/TswapCore/Vault/LinuxTpmHardwareService.cs
+++ b/TswapCore/Vault/LinuxTpmHardwareService.cs
@@ -7,7 +7,8 @@ namespace TswapCore.Vault;
 /// Linux TPM 2.0 <see cref="IHardwareKeyService"/>. Needs a TPM 2.0 device (or a reachable
 /// simulator in dev/test — see below), so it only builds/runs on Linux — see
 /// <c>HARDWARE_BACKENDS.md</c> and <c>MULTI_MACHINE_KEYING.md</c> for the design this
-/// implements.
+/// implements. The <see cref="Unlock"/> validation logic (base64 decode, 32-byte length check)
+/// lives in <see cref="TpmHardwareServiceBase"/>, shared with <see cref="WindowsTpmHardwareService"/>.
 ///
 /// <para><b>Primitive:</b> seal/unseal against a machine-bound key, via the <c>tpm2-tools</c>
 /// CLI (through <see cref="Tpm2ToolsInterop"/> — see its header comment for the shellout
@@ -33,51 +34,8 @@ namespace TswapCore.Vault;
 /// tpm vault.</para>
 /// </summary>
 [SupportedOSPlatform("linux")]
-public sealed class LinuxTpmHardwareService : IHardwareKeyService
+public sealed class LinuxTpmHardwareService : TpmHardwareServiceBase
 {
-    public HardwareBackend Backend => HardwareBackend.Tpm;
-
-    /// <summary>Real hardware (or a swtpm simulator pointed to by the environment), not a test double. (Tests substitute a fake at the seam.)</summary>
-    public bool IsSimulated => false;
-
-    /// <summary>
-    /// Recovers the vault master key by unsealing <see cref="Config.TpmSealedKey"/>.
-    /// <paramref name="chooseSerial"/> is unused — a TPM is a single, non-removable device.
-    /// </summary>
-    public byte[] Unlock(Config config, Func<IReadOnlyList<int>, int> chooseSerial)
-    {
-        _ = chooseSerial; // intentionally unused — a TPM is a single, non-removable device
-
-        if (config.TpmSealedKey is not { Length: > 0 } sealedBase64)
-            throw new TswapException(
-                "Config is corrupted: vault uses the 'tpm' backend but has no sealed key. " +
-                "Restore config.json from backup or re-run 'tswap init'.");
-
-        byte[] sealedBlob;
-        try
-        {
-            sealedBlob = Convert.FromBase64String(sealedBase64);
-        }
-        catch (FormatException)
-        {
-            throw new TswapException(
-                "Config is corrupted: the TPM sealed key is not valid base64. " +
-                "Restore config.json from backup or re-run 'tswap init'.");
-        }
-
-        var key = Unseal(sealedBlob);
-        // Unseal is a generic primitive (Phase 6 will use it for Shamir shares of varying
-        // size too — see MULTI_MACHINE_KEYING.md), so it doesn't itself enforce a length. This
-        // call site specifically claims "the vault master key," so it does: a corrupted or
-        // truncated sealed blob that still happens to unseal should fail here with a clear
-        // message, not surface as an opaque downstream error.
-        if (key.Length != 32)
-            throw new TswapException(
-                $"Config is corrupted: expected a 32-byte vault key from the TPM, got {key.Length}. " +
-                "Restore config.json from backup or re-run 'tswap init'.");
-        return key;
-    }
-
     /// <summary>
     /// Enrollment side: seals <paramref name="plaintextKey"/> (the vault key) to a fresh
     /// TPM-bound primary key. The returned blob is useless off this machine.
@@ -86,4 +44,6 @@ public sealed class LinuxTpmHardwareService : IHardwareKeyService
 
     /// <summary>Unlock side: unseals a payload produced by <see cref="Seal"/> using this TPM's regenerated primary key.</summary>
     public byte[] Unseal(byte[] wrapped) => Tpm2ToolsInterop.Unseal(wrapped);
+
+    protected override byte[] RecoverKey(byte[] wrapped) => Unseal(wrapped);
 }

--- a/TswapCore/Vault/LinuxTpmHardwareService.cs
+++ b/TswapCore/Vault/LinuxTpmHardwareService.cs
@@ -46,6 +46,8 @@ public sealed class LinuxTpmHardwareService : IHardwareKeyService
     /// </summary>
     public byte[] Unlock(Config config, Func<IReadOnlyList<int>, int> chooseSerial)
     {
+        _ = chooseSerial; // intentionally unused — a TPM is a single, non-removable device
+
         if (config.TpmSealedKey is not { Length: > 0 } sealedBase64)
             throw new TswapException(
                 "Config is corrupted: vault uses the 'tpm' backend but has no sealed key. " +

--- a/TswapCore/Vault/LinuxTpmHardwareService.cs
+++ b/TswapCore/Vault/LinuxTpmHardwareService.cs
@@ -1,0 +1,87 @@
+using System.Runtime.Versioning;
+using TswapCore.Vault.Interop;
+
+namespace TswapCore.Vault;
+
+/// <summary>
+/// Linux TPM 2.0 <see cref="IHardwareKeyService"/>. Needs a TPM 2.0 device (or a reachable
+/// simulator in dev/test — see below), so it only builds/runs on Linux — see
+/// <c>HARDWARE_BACKENDS.md</c> and <c>MULTI_MACHINE_KEYING.md</c> for the design this
+/// implements.
+///
+/// <para><b>Primitive:</b> seal/unseal against a machine-bound key, via the <c>tpm2-tools</c>
+/// CLI (through <see cref="Tpm2ToolsInterop"/> — see its header comment for the shellout
+/// design, the primary-key determinism this relies on, and what's actually been verified
+/// against swtpm). No primary key material is ever persisted; unlock reconstitutes it fresh
+/// from the TPM's owner hierarchy and unseals <c>K_v</c> transiently in memory. The k≥2
+/// threshold (Shamir shares instead of the whole key) is Phase 6 — see
+/// <c>MULTI_MACHINE_KEYING.md</c>.</para>
+///
+/// <para>This is today's single-machine, <c>k = 1</c> slice (implementation-ordering step 2 in
+/// <c>MULTI_MACHINE_KEYING.md</c>): <see cref="Config.TpmSealedKey"/> carries a single
+/// self-contained blob — the sealed object's public and private portions — produced and
+/// consumed by <see cref="Tpm2ToolsInterop"/>. The general multi-machine keyring (multiple
+/// slots, signed, `epoch`-guarded) is not built yet; this field is a single-slot precursor to
+/// it, not the final on-disk format.</para>
+///
+/// <para><b>Status: developed and tested only against a software TPM simulator (swtpm), not
+/// yet verified against real Linux TPM hardware</b> — see <c>HARDWARE_BACKENDS.md</c>'s Linux
+/// TPM section before trusting this as a primary vault backend.</para>
+///
+/// <para>Registered at the composition root only on Linux — see <c>TswapCli/Program.cs</c>. On
+/// other builds <see cref="VaultUnlocker"/> returns a clear "backend not supported" error for a
+/// tpm vault.</para>
+/// </summary>
+[SupportedOSPlatform("linux")]
+public sealed class LinuxTpmHardwareService : IHardwareKeyService
+{
+    public HardwareBackend Backend => HardwareBackend.Tpm;
+
+    /// <summary>Real hardware (or a swtpm simulator pointed to by the environment), not a test double. (Tests substitute a fake at the seam.)</summary>
+    public bool IsSimulated => false;
+
+    /// <summary>
+    /// Recovers the vault master key by unsealing <see cref="Config.TpmSealedKey"/>.
+    /// <paramref name="chooseSerial"/> is unused — a TPM is a single, non-removable device.
+    /// </summary>
+    public byte[] Unlock(Config config, Func<IReadOnlyList<int>, int> chooseSerial)
+    {
+        if (config.TpmSealedKey is not { Length: > 0 } sealedBase64)
+            throw new TswapException(
+                "Config is corrupted: vault uses the 'tpm' backend but has no sealed key. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+
+        byte[] sealedBlob;
+        try
+        {
+            sealedBlob = Convert.FromBase64String(sealedBase64);
+        }
+        catch (FormatException)
+        {
+            throw new TswapException(
+                "Config is corrupted: the TPM sealed key is not valid base64. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+        }
+
+        var key = Unseal(sealedBlob);
+        // Unseal is a generic primitive (Phase 6 will use it for Shamir shares of varying
+        // size too — see MULTI_MACHINE_KEYING.md), so it doesn't itself enforce a length. This
+        // call site specifically claims "the vault master key," so it does: a corrupted or
+        // truncated sealed blob that still happens to unseal should fail here with a clear
+        // message, not surface as an opaque downstream error.
+        if (key.Length != 32)
+            throw new TswapException(
+                $"Config is corrupted: expected a 32-byte vault key from the TPM, got {key.Length}. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+        return key;
+    }
+
+    /// <summary>
+    /// Enrollment side: seals <paramref name="plaintextKey"/> (the vault key) to a fresh
+    /// TPM-bound primary key. The returned blob is useless off this machine.
+    /// </summary>
+    public byte[] Seal(byte[] plaintextKey) => Tpm2ToolsInterop.Seal(plaintextKey);
+
+    /// <summary>Unlock side: unseals a payload produced by <see cref="Seal"/> using this TPM's regenerated primary key.</summary>
+    public byte[] Unseal(byte[] wrapped) => Tpm2ToolsInterop.Unseal(wrapped);
+}

--- a/TswapCore/Vault/TpmHardwareServiceBase.cs
+++ b/TswapCore/Vault/TpmHardwareServiceBase.cs
@@ -1,0 +1,70 @@
+namespace TswapCore.Vault;
+
+/// <summary>
+/// Shared <see cref="IHardwareKeyService.Unlock"/> plumbing for <see cref="LinuxTpmHardwareService"/>
+/// and <see cref="WindowsTpmHardwareService"/>: both platforms store an opaque, platform-specific
+/// blob in the same <see cref="Config.TpmSealedKey"/> field (see either subclass's header comment
+/// for what that blob actually contains), and both need identical base64-decode and 32-byte
+/// length validation around whatever platform-specific "recover the key" primitive their own
+/// interop class implements (<c>Tpm2ToolsInterop</c> on Linux, <c>PlatformCryptoProviderInterop</c>
+/// on Windows). Only that primitive differs — hence <see cref="RecoverKey"/> — which is why this
+/// exists as a shared base rather than duplicating this validation (and its exact error message
+/// text) in both subclasses.
+///
+/// Deliberately public (not internal): <see cref="LinuxTpmHardwareService"/>/
+/// <see cref="WindowsTpmHardwareService"/> are themselves public, and a base class can't be less
+/// accessible than its derived class.
+/// </summary>
+public abstract class TpmHardwareServiceBase : IHardwareKeyService
+{
+    public HardwareBackend Backend => HardwareBackend.Tpm;
+
+    /// <summary>Real hardware (or a simulator/virtual TPM pointed to by the environment), not a test double. (Tests substitute a fake at the seam.)</summary>
+    public bool IsSimulated => false;
+
+    /// <summary>
+    /// Recovers the vault master key by unsealing/unwrapping <see cref="Config.TpmSealedKey"/>.
+    /// <paramref name="chooseSerial"/> is unused — a TPM is a single, non-removable device.
+    /// </summary>
+    public byte[] Unlock(Config config, Func<IReadOnlyList<int>, int> chooseSerial)
+    {
+        _ = chooseSerial; // intentionally unused — a TPM is a single, non-removable device
+
+        if (config.TpmSealedKey is not { Length: > 0 } sealedBase64)
+            throw new TswapException(
+                "Config is corrupted: vault uses the 'tpm' backend but has no sealed key. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+
+        byte[] sealedBlob;
+        try
+        {
+            sealedBlob = Convert.FromBase64String(sealedBase64);
+        }
+        catch (FormatException)
+        {
+            throw new TswapException(
+                "Config is corrupted: the TPM sealed key is not valid base64. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+        }
+
+        var key = RecoverKey(sealedBlob);
+        // RecoverKey is a generic primitive (Phase 6 will use it for Shamir shares of varying
+        // size too — see MULTI_MACHINE_KEYING.md), so it doesn't itself enforce a length. This
+        // call site specifically claims "the vault master key," so it does: a corrupted or
+        // truncated sealed blob that still happens to unseal/decrypt should fail here with a
+        // clear message, not surface as an opaque downstream error.
+        if (key.Length != 32)
+            throw new TswapException(
+                $"Config is corrupted: expected a 32-byte vault key from the TPM, got {key.Length}. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+        return key;
+    }
+
+    /// <summary>
+    /// The platform-specific unseal (Linux)/unwrap (Windows) primitive — the same operation as
+    /// this backend's own public <c>Unseal</c>/<c>Unwrap</c> method, just named neutrally here
+    /// since the two platforms don't share a verb for it (see each subclass's header comment for
+    /// why: TPM2 sealed-object seal/unseal on Linux vs. RSA-OAEP wrap/unwrap on Windows).
+    /// </summary>
+    protected abstract byte[] RecoverKey(byte[] wrapped);
+}

--- a/TswapCore/Vault/WindowsTpmHardwareService.cs
+++ b/TswapCore/Vault/WindowsTpmHardwareService.cs
@@ -1,0 +1,52 @@
+using System.Runtime.Versioning;
+using TswapCore.Vault.Interop;
+
+namespace TswapCore.Vault;
+
+/// <summary>
+/// Windows TPM 2.0 <see cref="IHardwareKeyService"/>. Needs a TPM 2.0 device exposed through
+/// Windows' CNG "Microsoft Platform Crypto Provider", so it only builds/runs on Windows — see
+/// <c>HARDWARE_BACKENDS.md</c> and <c>MULTI_MACHINE_KEYING.md</c> for the design this
+/// implements. The <see cref="Unlock"/> validation logic (base64 decode, 32-byte length check)
+/// lives in <see cref="TpmHardwareServiceBase"/>, shared with <see cref="LinuxTpmHardwareService"/>.
+///
+/// <para><b>Primitive:</b> RSA-OAEP wrap/unwrap against a named, non-exportable, TPM-backed
+/// key, via <see cref="PlatformCryptoProviderInterop"/> — see its header comment for why this is
+/// wrap/unwrap rather than the TPM2 sealed-object seal/unseal the Linux backend uses (a real,
+/// verified platform difference: PCP keys cannot be exported in any blob format, so there is no
+/// self-contained key blob to hand back on its own — instead a fresh, randomly-named key is
+/// created on every <see cref="Wrap"/> call and its name bundled into the returned blob, so the
+/// blob as a whole is still self-contained and every vault gets its own isolated TPM key).</para>
+///
+/// <para>This is today's single-machine, <c>k = 1</c> slice (implementation-ordering step 2 in
+/// <c>MULTI_MACHINE_KEYING.md</c>), sharing <see cref="Config.TpmSealedKey"/> with the Linux
+/// backend: both write only an opaque, platform-specific blob there (RSA-OAEP ciphertext here,
+/// a TPM2 sealed public/private pair on Linux) under the same <see cref="HardwareBackend.Tpm"/>
+/// tag — a vault is inherently tied to one machine's OS already, so there's no need for a
+/// separate config field per platform. The general multi-machine keyring (multiple slots,
+/// signed, `epoch`-guarded) is not built yet; this field is a single-slot precursor to it, not
+/// the final on-disk format.</para>
+///
+/// <para><b>Status: developed and tested only against this machine's (virtual) TPM in a
+/// Parallels VM, not yet verified against physical TPM hardware</b> — see
+/// <c>HARDWARE_BACKENDS.md</c>'s Windows TPM section before trusting this as a primary vault
+/// backend.</para>
+///
+/// <para>Registered at the composition root only on Windows — see <c>TswapCli/Program.cs</c>. On
+/// other builds <see cref="VaultUnlocker"/> returns a clear "backend not supported" error for a
+/// tpm vault.</para>
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class WindowsTpmHardwareService : TpmHardwareServiceBase
+{
+    /// <summary>
+    /// Enrollment side: wraps <paramref name="plaintextKey"/> (the vault key) to a fresh
+    /// TPM-backed key. The returned blob is useless off this machine.
+    /// </summary>
+    public byte[] Wrap(byte[] plaintextKey) => PlatformCryptoProviderInterop.Wrap(plaintextKey);
+
+    /// <summary>Unlock side: unwraps a payload produced by <see cref="Wrap"/> using this machine's named TPM-backed key.</summary>
+    public byte[] Unwrap(byte[] wrapped) => PlatformCryptoProviderInterop.Unwrap(wrapped);
+
+    protected override byte[] RecoverKey(byte[] wrapped) => Unwrap(wrapped);
+}

--- a/TswapCore/Vault/WindowsTpmHardwareService.cs
+++ b/TswapCore/Vault/WindowsTpmHardwareService.cs
@@ -1,0 +1,88 @@
+using System.Runtime.Versioning;
+using TswapCore.Vault.Interop;
+
+namespace TswapCore.Vault;
+
+/// <summary>
+/// Windows TPM 2.0 <see cref="IHardwareKeyService"/>. Needs a TPM 2.0 device exposed through
+/// Windows' CNG "Microsoft Platform Crypto Provider", so it only builds/runs on Windows — see
+/// <c>HARDWARE_BACKENDS.md</c> and <c>MULTI_MACHINE_KEYING.md</c> for the design this
+/// implements.
+///
+/// <para><b>Primitive:</b> RSA-OAEP wrap/unwrap against a named, non-exportable, TPM-backed
+/// key, via <see cref="PlatformCryptoProviderInterop"/> — see its header comment for why this is
+/// wrap/unwrap rather than the TPM2 sealed-object seal/unseal the Linux backend uses (a real,
+/// verified platform difference: PCP keys cannot be exported in any blob format, so there is no
+/// self-contained key blob to hand back — the key lives under a fixed persisted name instead,
+/// re-opened by name at unlock time rather than reconstructed from <see cref="Config"/>).</para>
+///
+/// <para>This is today's single-machine, <c>k = 1</c> slice (implementation-ordering step 2 in
+/// <c>MULTI_MACHINE_KEYING.md</c>), sharing <see cref="Config.TpmSealedKey"/> with the Linux
+/// backend: both write only an opaque, platform-specific blob there (RSA-OAEP ciphertext here,
+/// a TPM2 sealed public/private pair on Linux) under the same <see cref="HardwareBackend.Tpm"/>
+/// tag — a vault is inherently tied to one machine's OS already, so there's no need for a
+/// separate config field per platform. The general multi-machine keyring (multiple slots,
+/// signed, `epoch`-guarded) is not built yet; this field is a single-slot precursor to it, not
+/// the final on-disk format.</para>
+///
+/// <para><b>Status: developed and tested only against this machine's (virtual) TPM in a
+/// Parallels VM, not yet verified against physical TPM hardware</b> — see
+/// <c>HARDWARE_BACKENDS.md</c>'s Windows TPM section before trusting this as a primary vault
+/// backend.</para>
+///
+/// <para>Registered at the composition root only on Windows — see <c>TswapCli/Program.cs</c>. On
+/// other builds <see cref="VaultUnlocker"/> returns a clear "backend not supported" error for a
+/// tpm vault.</para>
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class WindowsTpmHardwareService : IHardwareKeyService
+{
+    public HardwareBackend Backend => HardwareBackend.Tpm;
+
+    /// <summary>Real hardware (or this VM's virtual TPM), not a test double. (Tests substitute a fake at the seam.)</summary>
+    public bool IsSimulated => false;
+
+    /// <summary>
+    /// Recovers the vault master key by unwrapping <see cref="Config.TpmSealedKey"/>.
+    /// <paramref name="chooseSerial"/> is unused — a TPM is a single, non-removable device.
+    /// </summary>
+    public byte[] Unlock(Config config, Func<IReadOnlyList<int>, int> chooseSerial)
+    {
+        if (config.TpmSealedKey is not { Length: > 0 } sealedBase64)
+            throw new TswapException(
+                "Config is corrupted: vault uses the 'tpm' backend but has no sealed key. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+
+        byte[] wrapped;
+        try
+        {
+            wrapped = Convert.FromBase64String(sealedBase64);
+        }
+        catch (FormatException)
+        {
+            throw new TswapException(
+                "Config is corrupted: the TPM sealed key is not valid base64. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+        }
+
+        var key = Unwrap(wrapped);
+        // Unwrap is a generic primitive, so it doesn't itself enforce a length. This call site
+        // specifically claims "the vault master key," so it does: a corrupted or truncated
+        // sealed blob that still happens to decrypt should fail here with a clear message, not
+        // surface as an opaque downstream error.
+        if (key.Length != 32)
+            throw new TswapException(
+                $"Config is corrupted: expected a 32-byte vault key from the TPM, got {key.Length}. " +
+                "Restore config.json from backup or re-run 'tswap init'.");
+        return key;
+    }
+
+    /// <summary>
+    /// Enrollment side: wraps <paramref name="plaintextKey"/> (the vault key) to a fresh
+    /// TPM-backed key. The returned blob is useless off this machine.
+    /// </summary>
+    public byte[] Wrap(byte[] plaintextKey) => PlatformCryptoProviderInterop.Wrap(plaintextKey);
+
+    /// <summary>Unlock side: unwraps a payload produced by <see cref="Wrap"/> using this machine's named TPM-backed key.</summary>
+    public byte[] Unwrap(byte[] wrapped) => PlatformCryptoProviderInterop.Unwrap(wrapped);
+}

--- a/TswapCore/Vault/WindowsTpmHardwareService.cs
+++ b/TswapCore/Vault/WindowsTpmHardwareService.cs
@@ -13,8 +13,9 @@ namespace TswapCore.Vault;
 /// key, via <see cref="PlatformCryptoProviderInterop"/> — see its header comment for why this is
 /// wrap/unwrap rather than the TPM2 sealed-object seal/unseal the Linux backend uses (a real,
 /// verified platform difference: PCP keys cannot be exported in any blob format, so there is no
-/// self-contained key blob to hand back — the key lives under a fixed persisted name instead,
-/// re-opened by name at unlock time rather than reconstructed from <see cref="Config"/>).</para>
+/// self-contained key blob to hand back on its own — instead a fresh, randomly-named key is
+/// created on every <see cref="Wrap"/> call and its name bundled into the returned blob, so the
+/// blob as a whole is still self-contained and every vault gets its own isolated TPM key).</para>
 ///
 /// <para>This is today's single-machine, <c>k = 1</c> slice (implementation-ordering step 2 in
 /// <c>MULTI_MACHINE_KEYING.md</c>), sharing <see cref="Config.TpmSealedKey"/> with the Linux
@@ -86,3 +87,4 @@ public sealed class WindowsTpmHardwareService : IHardwareKeyService
     /// <summary>Unlock side: unwraps a payload produced by <see cref="Wrap"/> using this machine's named TPM-backed key.</summary>
     public byte[] Unwrap(byte[] wrapped) => PlatformCryptoProviderInterop.Unwrap(wrapped);
 }
+

--- a/TswapTests/CommandTests.cs
+++ b/TswapTests/CommandTests.cs
@@ -81,6 +81,17 @@ public class CommandTests : IDisposable
         Assert.Equal(new List<int> { 99999999, 99999998 }, config.YubiKeySerials);
     }
 
+    [Fact]
+    public void Init_SecureEnclaveAndTpmBothPassed_RejectsAsUsageError()
+    {
+        // Regression test: the checks used to be sequential (--secure-enclave always won,
+        // --tpm silently ignored) since neither branch checked for the other flag.
+        var (exit, _, stderr) = RunTswap("init", "--secure-enclave", "--tpm");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Usage:", stderr);
+    }
+
     // --- Create ---
 
     [Fact]
@@ -1007,6 +1018,22 @@ password2: """"  # tswap: missing-mixed-secret");
     }
 
     [Fact]
+    public void Migrate_TpmBackend_DoesNotCrashOnEmptyYubiKeySerials()
+    {
+        // TPM/Secure Enclave vaults have YubiKeySerials: [] — migrate must not blindly index
+        // [0]/[1] into that (regression test for the Copilot-flagged crash).
+        RunTswap("init");
+        var configPath = Path.Combine(_tempDir, "config.json");
+        var tpmConfig = new Config([], "", DateTime.UtcNow, Backend: HardwareBackend.Tpm, TpmSealedKey: "irrelevant");
+        File.WriteAllText(configPath, JsonSerializer.Serialize(tpmConfig, TswapJsonContext.Default.Config));
+
+        var (exit, stdout, _) = RunTswap("migrate");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("only applies to YubiKey vaults", stdout);
+    }
+
+    [Fact]
     public void Migrate_ModernConfig_ReportsUpToDate()
     {
         RunTswap("init");
@@ -1326,3 +1353,5 @@ password2: """"  # tswap: missing-mixed-secret");
         Assert.Contains("Usage", stderr);
     }
 }
+
+

--- a/TswapTests/CommandTests.cs
+++ b/TswapTests/CommandTests.cs
@@ -1007,6 +1007,22 @@ password2: """"  # tswap: missing-mixed-secret");
     }
 
     [Fact]
+    public void Migrate_TpmBackend_DoesNotCrashOnEmptyYubiKeySerials()
+    {
+        // TPM/Secure Enclave vaults have YubiKeySerials: [] — migrate must not blindly index
+        // [0]/[1] into that (regression test for the Copilot-flagged crash).
+        RunTswap("init");
+        var configPath = Path.Combine(_tempDir, "config.json");
+        var tpmConfig = new Config([], "", DateTime.UtcNow, Backend: HardwareBackend.Tpm, TpmSealedKey: "irrelevant");
+        File.WriteAllText(configPath, JsonSerializer.Serialize(tpmConfig, TswapJsonContext.Default.Config));
+
+        var (exit, stdout, _) = RunTswap("migrate");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("only applies to YubiKey vaults", stdout);
+    }
+
+    [Fact]
     public void Migrate_ModernConfig_ReportsUpToDate()
     {
         RunTswap("init");
@@ -1326,3 +1342,4 @@ password2: """"  # tswap: missing-mixed-secret");
         Assert.Contains("Usage", stderr);
     }
 }
+

--- a/TswapTests/CommandTests.cs
+++ b/TswapTests/CommandTests.cs
@@ -81,6 +81,17 @@ public class CommandTests : IDisposable
         Assert.Equal(new List<int> { 99999999, 99999998 }, config.YubiKeySerials);
     }
 
+    [Fact]
+    public void Init_SecureEnclaveAndTpmBothPassed_RejectsAsUsageError()
+    {
+        // Regression test: the checks used to be sequential (--secure-enclave always won,
+        // --tpm silently ignored) since neither branch checked for the other flag.
+        var (exit, _, stderr) = RunTswap("init", "--secure-enclave", "--tpm");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Usage:", stderr);
+    }
+
     // --- Create ---
 
     [Fact]
@@ -1342,4 +1353,5 @@ password2: """"  # tswap: missing-mixed-secret");
         Assert.Contains("Usage", stderr);
     }
 }
+
 

--- a/TswapTests/LinuxTpmHardwareServiceTests.cs
+++ b/TswapTests/LinuxTpmHardwareServiceTests.cs
@@ -1,0 +1,141 @@
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using TswapCore;
+using TswapCore.Vault;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Linux TPM backend tests. Trait-gated (<c>Category=Tpm</c>) and excluded from the default
+/// and <c>--unit</c> runs because they need a reachable TPM 2.0 device or simulator and the
+/// <c>tpm2-tools</c> CLI installed. Run them explicitly on Linux with both available:
+/// <code>
+///   ./runtests.sh --tpm
+///   # or: dotnet test ./TswapTests/TswapTests.csproj --filter Category=Tpm
+/// </code>
+///
+/// <b>Dev/test setup:</b> these tests were developed and are meant to run against a software
+/// TPM simulator (swtpm), not real hardware — see <c>HARDWARE_BACKENDS.md</c>'s Linux TPM
+/// section and <c>TPM_LINUX_PLAN.md</c> §4 for the container setup
+/// (<c>danieltrick/swtpm-docker</c>) and the <c>TPM2TOOLS_TCTI</c> environment variable that
+/// points <c>tpm2-tools</c> at it. On real TPM hardware no environment variable is needed —
+/// <c>tpm2-tools</c> falls back to the local device.
+/// </summary>
+[SupportedOSPlatform("linux")]
+[Trait("Category", "Tpm")]
+public class LinuxTpmHardwareServiceTests
+{
+    [Fact]
+    public void SealUnseal_RoundTripsKey()
+    {
+        // The core primitive: a key sealed to the TPM must unseal back to itself, and the
+        // sealed form must not be the plaintext.
+        var svc = new LinuxTpmHardwareService();
+        var key = RandomNumberGenerator.GetBytes(32);
+
+        var sealedKey = svc.Seal(key);
+        var recovered = svc.Unseal(sealedKey);
+
+        Assert.Equal(key, recovered);
+        Assert.NotEqual(key, sealedKey);
+    }
+
+    [Fact]
+    public void Unlock_RecoversVaultKeyFromSlot()
+    {
+        var svc = new LinuxTpmHardwareService();
+        var vaultKey = RandomNumberGenerator.GetBytes(32);
+        var sealedKey = svc.Seal(vaultKey);
+
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: Convert.ToBase64String(sealedKey));
+
+        var recovered = svc.Unlock(config, _ => throw new InvalidOperationException("chooseSerial should not be called for TPM"));
+
+        Assert.Equal(vaultKey, recovered);
+    }
+
+    [Fact]
+    public void Unlock_MissingSealedKey_ThrowsClearError()
+    {
+        var svc = new LinuxTpmHardwareService();
+        var config = new Config([], "", DateTime.UtcNow, Backend: HardwareBackend.Tpm);
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("tpm", ex.Message);
+    }
+
+    [Fact]
+    public void Unlock_InvalidBase64_ThrowsClearError()
+    {
+        var svc = new LinuxTpmHardwareService();
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: "not valid base64!!");
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("base64", ex.Message);
+    }
+
+    [Fact]
+    public void Unlock_WrongLengthKey_ThrowsClearError()
+    {
+        // Unseal is a generic primitive (round-trips whatever was sealed, per
+        // SealUnseal_RoundTripsKey), so a 16-byte payload round-trips fine at that layer.
+        // Unlock specifically promises a 32-byte vault key, so it must reject this.
+        var svc = new LinuxTpmHardwareService();
+        var sealedKey = svc.Seal(RandomNumberGenerator.GetBytes(16));
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: Convert.ToBase64String(sealedKey));
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("32-byte", ex.Message);
+    }
+
+    [Fact]
+    public void Unseal_TooShortBlob_ThrowsClearError()
+    {
+        var svc = new LinuxTpmHardwareService();
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unseal(new byte[3]));
+        Assert.Contains("too short", ex.Message);
+    }
+
+    [Fact]
+    public void Unseal_HugeLengthPrefix_ThrowsClearErrorInsteadOfOverflowing()
+    {
+        // A pubLen near int.MaxValue makes the naive "4 + pubLen > wrapped.Length" bounds
+        // check overflow (wraps to negative, so the comparison passes when it shouldn't),
+        // reaching an oversized allocation. The fix uses a subtraction-based check instead;
+        // this proves it rejects cleanly rather than attempting that allocation.
+        var svc = new LinuxTpmHardwareService();
+        var corrupted = new byte[8];
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(corrupted, int.MaxValue - 1);
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unseal(corrupted));
+        Assert.Contains("length prefix", ex.Message);
+    }
+
+    [Fact]
+    public void Unseal_SealedOnADifferentTpm_ThrowsClearError()
+    {
+        // Simulates the "wrong machine" case by corrupting the private portion of a real
+        // sealed blob so its TPM-checked integrity fails on load — the same failure mode as
+        // loading a blob sealed under a genuinely different TPM's primary key (verified
+        // manually against swtpm: both produce a "tpm:parameter(1):integrity check failed"
+        // error from tpm2_load).
+        var svc = new LinuxTpmHardwareService();
+        var sealedKey = svc.Seal(RandomNumberGenerator.GetBytes(32));
+
+        var pubLen = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(sealedKey);
+        var corrupted = (byte[])sealedKey.Clone();
+        for (var i = 4 + pubLen; i < corrupted.Length; i++)
+            corrupted[i] ^= 0xFF;
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unseal(corrupted));
+        Assert.Contains("Could not unlock", ex.Message);
+    }
+}

--- a/TswapTests/ModelsTests.cs
+++ b/TswapTests/ModelsTests.cs
@@ -125,3 +125,4 @@ public class ModelsTests
         Assert.Contains("\"Version\": \"tswap-export-v1\"", json);
     }
 }
+

--- a/TswapTests/ModelsTests.cs
+++ b/TswapTests/ModelsTests.cs
@@ -97,6 +97,26 @@ public class ModelsTests
     }
 
     [Fact]
+    public void Config_NullTpmSealedKey_IsOmittedFromJson()
+    {
+        // Same backward-compat guarantee as SecureEnclaveWrappedKey: a non-TPM vault must
+        // serialize with no TpmSealedKey field at all.
+        var config = new Config([1, 2], "aabb", DateTime.UtcNow, RngMode: RngMode.System);
+        var json = JsonSerializer.Serialize(config, TswapJsonContext.Default.Config);
+        Assert.DoesNotContain("TpmSealedKey", json);
+        Assert.Null(config.TpmSealedKey);
+    }
+
+    [Fact]
+    public void Config_TpmSealedKey_RoundTrips()
+    {
+        var config = new Config([], "", DateTime.UtcNow, Backend: HardwareBackend.Tpm, TpmSealedKey: "c2VhbGVk");
+        var json = JsonSerializer.Serialize(config, TswapJsonContext.Default.Config);
+        Assert.Contains("\"TpmSealedKey\": \"c2VhbGVk\"", json);
+        Assert.Equal("c2VhbGVk", JsonSerializer.Deserialize(json, TswapJsonContext.Default.Config)!.TpmSealedKey);
+    }
+
+    [Fact]
     public void ExportFile_VersionTag_Unchanged()
     {
         Assert.Equal("tswap-export-v1", ExportFile.CurrentVersion);

--- a/TswapTests/ModelsTests.cs
+++ b/TswapTests/ModelsTests.cs
@@ -97,6 +97,26 @@ public class ModelsTests
     }
 
     [Fact]
+    public void Config_NullTpmSealedKey_IsOmittedFromJson()
+    {
+        // Same backward-compat guarantee as SecureEnclaveWrappedKey: a non-TPM vault must
+        // serialize with no TpmSealedKey field at all.
+        var config = new Config([1, 2], "aabb", DateTime.UtcNow, RngMode: RngMode.System);
+        var json = JsonSerializer.Serialize(config, TswapJsonContext.Default.Config);
+        Assert.DoesNotContain("TpmSealedKey", json);
+        Assert.Null(config.TpmSealedKey);
+    }
+
+    [Fact]
+    public void Config_TpmSealedKey_RoundTrips()
+    {
+        var config = new Config([], "", DateTime.UtcNow, Backend: HardwareBackend.Tpm, TpmSealedKey: "c2VhbGVk");
+        var json = JsonSerializer.Serialize(config, TswapJsonContext.Default.Config);
+        Assert.Contains("\"TpmSealedKey\": \"c2VhbGVk\"", json);
+        Assert.Equal("c2VhbGVk", JsonSerializer.Deserialize(json, TswapJsonContext.Default.Config)!.TpmSealedKey);
+    }
+
+    [Fact]
     public void ExportFile_VersionTag_Unchanged()
     {
         Assert.Equal("tswap-export-v1", ExportFile.CurrentVersion);
@@ -105,3 +125,4 @@ public class ModelsTests
         Assert.Contains("\"Version\": \"tswap-export-v1\"", json);
     }
 }
+

--- a/TswapTests/SecurityWarningsTests.cs
+++ b/TswapTests/SecurityWarningsTests.cs
@@ -1,0 +1,33 @@
+using TswapCli;
+using TswapCore;
+using Xunit;
+
+namespace TswapTests;
+
+public class SecurityWarningsTests
+{
+    [Fact]
+    public void WarnIfNoTouch_YubiKeyWithoutTouch_Warns()
+    {
+        var console = new FakeConsole();
+        var config = new Config([1, 2], "aabb", DateTime.UtcNow, RequiresTouch: false);
+
+        SecurityWarnings.WarnIfNoTouch(console, config);
+
+        Assert.Contains("YubiKey", console.ErrorText);
+    }
+
+    [Fact]
+    public void WarnIfNoTouch_NonYubiKeyBackend_NeverWarns()
+    {
+        // TPM/Secure Enclave vaults have no YubiKeys at all; the YubiKey-specific wording
+        // ("your YubiKeys", "tswap migrate") would be actively misleading for them, and
+        // each backend already prints its own presence caveats at init time.
+        var console = new FakeConsole();
+        var tpmConfig = new Config([], "", DateTime.UtcNow, RequiresTouch: false, Backend: HardwareBackend.Tpm);
+
+        SecurityWarnings.WarnIfNoTouch(console, tpmConfig);
+
+        Assert.Equal("", console.ErrorText);
+    }
+}

--- a/TswapTests/WindowsTpmHardwareServiceTests.cs
+++ b/TswapTests/WindowsTpmHardwareServiceTests.cs
@@ -1,5 +1,7 @@
+using System.Buffers.Binary;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
+using System.Text;
 using TswapCore;
 using TswapCore.Vault;
 using Xunit;
@@ -18,10 +20,13 @@ namespace TswapTests;
 ///   # or: dotnet test ./TswapTests/TswapTests.csproj --filter Category=TpmWindows
 /// </code>
 ///
+/// Every <see cref="WindowsTpmHardwareService.Wrap"/> call creates a fresh, randomly-named TPM
+/// key (see <c>PlatformCryptoProviderInterop</c>'s header comment), so these tests never touch
+/// or overwrite a real vault's TPM key — no isolation setup/teardown needed.
+///
 /// <b>Dev/test setup:</b> developed and verified against a Parallels VM's virtual TPM (Windows
 /// 11, ARM64) — see <c>HARDWARE_BACKENDS.md</c>'s Windows TPM section for exactly what was and
-/// wasn't verified. No extra tooling/container needed, unlike Linux's swtpm setup — Windows'
-/// "Microsoft Platform Crypto Provider" is built in and reached entirely via managed CNG APIs.
+/// wasn't verified.
 /// </summary>
 [SupportedOSPlatform("windows")]
 [Trait("Category", "TpmWindows")]
@@ -40,6 +45,23 @@ public class WindowsTpmHardwareServiceTests
 
         Assert.Equal(key, recovered);
         Assert.NotEqual(key, wrapped);
+    }
+
+    [Fact]
+    public void Wrap_TwoCallsUseIndependentKeys()
+    {
+        // The fix for the real bug Copilot flagged: a fixed key name meant a second Wrap()
+        // (e.g. a second vault, or just the test suite) would silently invalidate the first.
+        // Each call must get its own isolated, independently-unwrappable key.
+        var svc = new WindowsTpmHardwareService();
+        var key1 = RandomNumberGenerator.GetBytes(32);
+        var key2 = RandomNumberGenerator.GetBytes(32);
+
+        var wrapped1 = svc.Wrap(key1);
+        var wrapped2 = svc.Wrap(key2);
+
+        Assert.Equal(key1, svc.Unwrap(wrapped1));
+        Assert.Equal(key2, svc.Unwrap(wrapped2));
     }
 
     [Fact]
@@ -97,16 +119,61 @@ public class WindowsTpmHardwareServiceTests
     }
 
     [Fact]
+    public void Unwrap_TooShortBlob_ThrowsClearError()
+    {
+        var svc = new WindowsTpmHardwareService();
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(new byte[3]));
+        Assert.Contains("too short", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_HugeLengthPrefix_ThrowsClearErrorInsteadOfOverflowing()
+    {
+        // A nameLen near int.MaxValue makes the naive "4 + nameLen > wrapped.Length" bounds
+        // check overflow (wraps to negative, so the comparison passes when it shouldn't),
+        // reaching an oversized allocation/read. The fix uses a subtraction-based check
+        // instead; this proves it rejects cleanly rather than attempting that read.
+        var svc = new WindowsTpmHardwareService();
+        var corrupted = new byte[8];
+        BinaryPrimitives.WriteInt32LittleEndian(corrupted, int.MaxValue - 1);
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(corrupted));
+        Assert.Contains("length prefix", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_KeyDoesNotExist_ThrowsClearError()
+    {
+        // A blob whose embedded key name was never created by Wrap() — simulates either a
+        // corrupted blob or a genuinely different machine, since real TPM key names never
+        // collide across machines/processes (random per Wrap() call).
+        var svc = new WindowsTpmHardwareService();
+        var fakeName = Encoding.UTF8.GetBytes("tswap-vault-key-does-not-exist-" + Guid.NewGuid().ToString("N"));
+        var fakeCiphertext = new byte[256];
+        var blob = new byte[4 + fakeName.Length + fakeCiphertext.Length];
+        BinaryPrimitives.WriteInt32LittleEndian(blob, fakeName.Length);
+        fakeName.CopyTo(blob, 4);
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(blob));
+        Assert.Contains("no matching TPM key", ex.Message);
+    }
+
+    [Fact]
     public void Unwrap_MalformedCiphertext_ThrowsClearError()
     {
-        // Right-length-for-RSA-2048 (256 bytes) but garbage content — verified manually against
-        // this backend's TPM that this fails as a TPM-reported CryptographicException, not a
-        // crash or silently-wrong plaintext.
+        // A blob with a real, existing key name (so it passes the "does the key exist" check)
+        // but corrupted ciphertext content — verified manually against this backend's TPM that
+        // this fails as a TPM-reported CryptographicException, not a crash or silently-wrong
+        // plaintext.
         var svc = new WindowsTpmHardwareService();
-        // Ensure a key exists so this exercises "malformed ciphertext" rather than "no key yet".
-        svc.Wrap(RandomNumberGenerator.GetBytes(32));
+        var wrapped = svc.Wrap(RandomNumberGenerator.GetBytes(32));
+        var nameLen = BinaryPrimitives.ReadInt32LittleEndian(wrapped);
 
-        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(new byte[256]));
+        var corrupted = (byte[])wrapped.Clone();
+        Array.Clear(corrupted, 4 + nameLen, corrupted.Length - (4 + nameLen));
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(corrupted));
         Assert.Contains("Could not unlock", ex.Message);
     }
 
@@ -114,23 +181,13 @@ public class WindowsTpmHardwareServiceTests
     public void Unwrap_WrongLengthCiphertext_ThrowsClearError()
     {
         var svc = new WindowsTpmHardwareService();
-        svc.Wrap(RandomNumberGenerator.GetBytes(32));
+        var wrapped = svc.Wrap(RandomNumberGenerator.GetBytes(32));
+        var nameLen = BinaryPrimitives.ReadInt32LittleEndian(wrapped);
 
-        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(new byte[8]));
-        Assert.Contains("Could not unlock", ex.Message);
-    }
+        // Keep the real (existing) key name, but truncate the ciphertext portion.
+        var truncated = wrapped.AsSpan(0, 4 + nameLen + 8).ToArray();
 
-    [Fact]
-    public void Unwrap_SealedByAPriorGeneration_ThrowsClearError()
-    {
-        // Verified manually: re-wrapping (which overwrites the named TPM key, exactly what
-        // 're-run tswap init --tpm' does) cleanly invalidates ciphertext produced under the
-        // previous generation of the key, rather than silently decrypting to garbage.
-        var svc = new WindowsTpmHardwareService();
-        var staleWrapped = svc.Wrap(RandomNumberGenerator.GetBytes(32));
-        svc.Wrap(RandomNumberGenerator.GetBytes(32)); // overwrites the named key
-
-        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(staleWrapped));
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(truncated));
         Assert.Contains("Could not unlock", ex.Message);
     }
 }

--- a/TswapTests/WindowsTpmHardwareServiceTests.cs
+++ b/TswapTests/WindowsTpmHardwareServiceTests.cs
@@ -1,0 +1,193 @@
+using System.Buffers.Binary;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Text;
+using TswapCore;
+using TswapCore.Vault;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Windows TPM backend tests. Trait-gated (<c>Category=TpmWindows</c> — deliberately distinct
+/// from the Linux backend's <c>Category=Tpm</c>, since both test classes compile on every OS
+/// regardless of <c>[SupportedOSPlatform]</c> and must be independently excludable/runnable)
+/// and excluded from the default and <c>--unit</c> runs because they need a real or virtual TPM
+/// exposed through Windows' "Microsoft Platform Crypto Provider". Run them explicitly on
+/// Windows:
+/// <code>
+///   ./runtests.sh --tpm-windows
+///   # or: dotnet test ./TswapTests/TswapTests.csproj --filter Category=TpmWindows
+/// </code>
+///
+/// Every <see cref="WindowsTpmHardwareService.Wrap"/> call creates a fresh, randomly-named TPM
+/// key (see <c>PlatformCryptoProviderInterop</c>'s header comment), so these tests never touch
+/// or overwrite a real vault's TPM key — no isolation setup/teardown needed.
+///
+/// <b>Dev/test setup:</b> developed and verified against a Parallels VM's virtual TPM (Windows
+/// 11, ARM64) — see <c>HARDWARE_BACKENDS.md</c>'s Windows TPM section for exactly what was and
+/// wasn't verified.
+/// </summary>
+[SupportedOSPlatform("windows")]
+[Trait("Category", "TpmWindows")]
+public class WindowsTpmHardwareServiceTests
+{
+    [Fact]
+    public void WrapUnwrap_RoundTripsKey()
+    {
+        // The core primitive: a key wrapped to the TPM must unwrap back to itself, and the
+        // wrapped form must not be the plaintext.
+        var svc = new WindowsTpmHardwareService();
+        var key = RandomNumberGenerator.GetBytes(32);
+
+        var wrapped = svc.Wrap(key);
+        var recovered = svc.Unwrap(wrapped);
+
+        Assert.Equal(key, recovered);
+        Assert.NotEqual(key, wrapped);
+    }
+
+    [Fact]
+    public void Wrap_TwoCallsUseIndependentKeys()
+    {
+        // The fix for the real bug Copilot flagged: a fixed key name meant a second Wrap()
+        // (e.g. a second vault, or just the test suite) would silently invalidate the first.
+        // Each call must get its own isolated, independently-unwrappable key.
+        var svc = new WindowsTpmHardwareService();
+        var key1 = RandomNumberGenerator.GetBytes(32);
+        var key2 = RandomNumberGenerator.GetBytes(32);
+
+        var wrapped1 = svc.Wrap(key1);
+        var wrapped2 = svc.Wrap(key2);
+
+        Assert.Equal(key1, svc.Unwrap(wrapped1));
+        Assert.Equal(key2, svc.Unwrap(wrapped2));
+    }
+
+    [Fact]
+    public void Unlock_RecoversVaultKeyFromSlot()
+    {
+        var svc = new WindowsTpmHardwareService();
+        var vaultKey = RandomNumberGenerator.GetBytes(32);
+        var wrapped = svc.Wrap(vaultKey);
+
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: Convert.ToBase64String(wrapped));
+
+        var recovered = svc.Unlock(config, _ => throw new InvalidOperationException("chooseSerial should not be called for TPM"));
+
+        Assert.Equal(vaultKey, recovered);
+    }
+
+    [Fact]
+    public void Unlock_MissingSealedKey_ThrowsClearError()
+    {
+        var svc = new WindowsTpmHardwareService();
+        var config = new Config([], "", DateTime.UtcNow, Backend: HardwareBackend.Tpm);
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("tpm", ex.Message);
+    }
+
+    [Fact]
+    public void Unlock_InvalidBase64_ThrowsClearError()
+    {
+        var svc = new WindowsTpmHardwareService();
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: "not valid base64!!");
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("base64", ex.Message);
+    }
+
+    [Fact]
+    public void Unlock_WrongLengthKey_ThrowsClearError()
+    {
+        // Unwrap is a generic primitive (round-trips whatever was wrapped, per
+        // WrapUnwrap_RoundTripsKey), so a 16-byte payload round-trips fine at that layer.
+        // Unlock specifically promises a 32-byte vault key, so it must reject this.
+        var svc = new WindowsTpmHardwareService();
+        var wrapped = svc.Wrap(RandomNumberGenerator.GetBytes(16));
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: Convert.ToBase64String(wrapped));
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("32-byte", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_TooShortBlob_ThrowsClearError()
+    {
+        var svc = new WindowsTpmHardwareService();
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(new byte[3]));
+        Assert.Contains("too short", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_HugeLengthPrefix_ThrowsClearErrorInsteadOfOverflowing()
+    {
+        // A nameLen near int.MaxValue makes the naive "4 + nameLen > wrapped.Length" bounds
+        // check overflow (wraps to negative, so the comparison passes when it shouldn't),
+        // reaching an oversized allocation/read. The fix uses a subtraction-based check
+        // instead; this proves it rejects cleanly rather than attempting that read.
+        var svc = new WindowsTpmHardwareService();
+        var corrupted = new byte[8];
+        BinaryPrimitives.WriteInt32LittleEndian(corrupted, int.MaxValue - 1);
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(corrupted));
+        Assert.Contains("length prefix", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_KeyDoesNotExist_ThrowsClearError()
+    {
+        // A blob whose embedded key name was never created by Wrap() — simulates either a
+        // corrupted blob or a genuinely different machine, since real TPM key names never
+        // collide across machines/processes (random per Wrap() call).
+        var svc = new WindowsTpmHardwareService();
+        var fakeName = Encoding.UTF8.GetBytes("tswap-vault-key-does-not-exist-" + Guid.NewGuid().ToString("N"));
+        var fakeCiphertext = new byte[256];
+        var blob = new byte[4 + fakeName.Length + fakeCiphertext.Length];
+        BinaryPrimitives.WriteInt32LittleEndian(blob, fakeName.Length);
+        fakeName.CopyTo(blob, 4);
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(blob));
+        Assert.Contains("no matching TPM key", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_MalformedCiphertext_ThrowsClearError()
+    {
+        // A blob with a real, existing key name (so it passes the "does the key exist" check)
+        // but corrupted ciphertext content — verified manually against this backend's TPM that
+        // this fails as a TPM-reported CryptographicException, not a crash or silently-wrong
+        // plaintext.
+        var svc = new WindowsTpmHardwareService();
+        var wrapped = svc.Wrap(RandomNumberGenerator.GetBytes(32));
+        var nameLen = BinaryPrimitives.ReadInt32LittleEndian(wrapped);
+
+        var corrupted = (byte[])wrapped.Clone();
+        Array.Clear(corrupted, 4 + nameLen, corrupted.Length - (4 + nameLen));
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(corrupted));
+        Assert.Contains("Could not unlock", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_WrongLengthCiphertext_ThrowsClearError()
+    {
+        var svc = new WindowsTpmHardwareService();
+        var wrapped = svc.Wrap(RandomNumberGenerator.GetBytes(32));
+        var nameLen = BinaryPrimitives.ReadInt32LittleEndian(wrapped);
+
+        // Keep the real (existing) key name, but truncate the ciphertext portion.
+        var truncated = wrapped.AsSpan(0, 4 + nameLen + 8).ToArray();
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(truncated));
+        Assert.Contains("Could not unlock", ex.Message);
+    }
+}

--- a/TswapTests/WindowsTpmHardwareServiceTests.cs
+++ b/TswapTests/WindowsTpmHardwareServiceTests.cs
@@ -1,0 +1,136 @@
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using TswapCore;
+using TswapCore.Vault;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Windows TPM backend tests. Trait-gated (<c>Category=TpmWindows</c> — deliberately distinct
+/// from the Linux backend's <c>Category=Tpm</c>, since both test classes compile on every OS
+/// regardless of <c>[SupportedOSPlatform]</c> and must be independently excludable/runnable)
+/// and excluded from the default and <c>--unit</c> runs because they need a real or virtual TPM
+/// exposed through Windows' "Microsoft Platform Crypto Provider". Run them explicitly on
+/// Windows:
+/// <code>
+///   ./runtests.sh --tpm-windows
+///   # or: dotnet test ./TswapTests/TswapTests.csproj --filter Category=TpmWindows
+/// </code>
+///
+/// <b>Dev/test setup:</b> developed and verified against a Parallels VM's virtual TPM (Windows
+/// 11, ARM64) — see <c>HARDWARE_BACKENDS.md</c>'s Windows TPM section for exactly what was and
+/// wasn't verified. No extra tooling/container needed, unlike Linux's swtpm setup — Windows'
+/// "Microsoft Platform Crypto Provider" is built in and reached entirely via managed CNG APIs.
+/// </summary>
+[SupportedOSPlatform("windows")]
+[Trait("Category", "TpmWindows")]
+public class WindowsTpmHardwareServiceTests
+{
+    [Fact]
+    public void WrapUnwrap_RoundTripsKey()
+    {
+        // The core primitive: a key wrapped to the TPM must unwrap back to itself, and the
+        // wrapped form must not be the plaintext.
+        var svc = new WindowsTpmHardwareService();
+        var key = RandomNumberGenerator.GetBytes(32);
+
+        var wrapped = svc.Wrap(key);
+        var recovered = svc.Unwrap(wrapped);
+
+        Assert.Equal(key, recovered);
+        Assert.NotEqual(key, wrapped);
+    }
+
+    [Fact]
+    public void Unlock_RecoversVaultKeyFromSlot()
+    {
+        var svc = new WindowsTpmHardwareService();
+        var vaultKey = RandomNumberGenerator.GetBytes(32);
+        var wrapped = svc.Wrap(vaultKey);
+
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: Convert.ToBase64String(wrapped));
+
+        var recovered = svc.Unlock(config, _ => throw new InvalidOperationException("chooseSerial should not be called for TPM"));
+
+        Assert.Equal(vaultKey, recovered);
+    }
+
+    [Fact]
+    public void Unlock_MissingSealedKey_ThrowsClearError()
+    {
+        var svc = new WindowsTpmHardwareService();
+        var config = new Config([], "", DateTime.UtcNow, Backend: HardwareBackend.Tpm);
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("tpm", ex.Message);
+    }
+
+    [Fact]
+    public void Unlock_InvalidBase64_ThrowsClearError()
+    {
+        var svc = new WindowsTpmHardwareService();
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: "not valid base64!!");
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("base64", ex.Message);
+    }
+
+    [Fact]
+    public void Unlock_WrongLengthKey_ThrowsClearError()
+    {
+        // Unwrap is a generic primitive (round-trips whatever was wrapped, per
+        // WrapUnwrap_RoundTripsKey), so a 16-byte payload round-trips fine at that layer.
+        // Unlock specifically promises a 32-byte vault key, so it must reject this.
+        var svc = new WindowsTpmHardwareService();
+        var wrapped = svc.Wrap(RandomNumberGenerator.GetBytes(16));
+        var config = new Config([], "", DateTime.UtcNow,
+            Backend: HardwareBackend.Tpm,
+            TpmSealedKey: Convert.ToBase64String(wrapped));
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unlock(config, _ => 0));
+        Assert.Contains("32-byte", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_MalformedCiphertext_ThrowsClearError()
+    {
+        // Right-length-for-RSA-2048 (256 bytes) but garbage content — verified manually against
+        // this backend's TPM that this fails as a TPM-reported CryptographicException, not a
+        // crash or silently-wrong plaintext.
+        var svc = new WindowsTpmHardwareService();
+        // Ensure a key exists so this exercises "malformed ciphertext" rather than "no key yet".
+        svc.Wrap(RandomNumberGenerator.GetBytes(32));
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(new byte[256]));
+        Assert.Contains("Could not unlock", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_WrongLengthCiphertext_ThrowsClearError()
+    {
+        var svc = new WindowsTpmHardwareService();
+        svc.Wrap(RandomNumberGenerator.GetBytes(32));
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(new byte[8]));
+        Assert.Contains("Could not unlock", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_SealedByAPriorGeneration_ThrowsClearError()
+    {
+        // Verified manually: re-wrapping (which overwrites the named TPM key, exactly what
+        // 're-run tswap init --tpm' does) cleanly invalidates ciphertext produced under the
+        // previous generation of the key, rather than silently decrypting to garbage.
+        var svc = new WindowsTpmHardwareService();
+        var staleWrapped = svc.Wrap(RandomNumberGenerator.GetBytes(32));
+        svc.Wrap(RandomNumberGenerator.GetBytes(32)); // overwrites the named key
+
+        var ex = Assert.Throws<TswapException>(() => svc.Unwrap(staleWrapped));
+        Assert.Contains("Could not unlock", ex.Message);
+    }
+}

--- a/runtests.sh
+++ b/runtests.sh
@@ -7,13 +7,16 @@
 #                                  set TSWAP_E2E_BINARY to test a pre-built/AOT binary)
 #   ./runtests.sh --secure-enclave Secure Enclave backend tests (macOS + real hardware only;
 #                                  prompts for biometry/presence)
+#   ./runtests.sh --tpm            Linux TPM backend tests (Linux + tpm2-tools required; needs
+#                                  a reachable TPM 2.0 device or swtpm simulator — see
+#                                  HARDWARE_BACKENDS.md's Linux TPM section)
 set -eo pipefail
 
 # Array so the xUnit '&' (AND) in a compound filter isn't treated as a shell operator.
 FILTER=()
 TARGET="./TokenSwap.slnx"
 case "${1:-}" in
-  --unit)        FILTER=(--filter 'Category!=E2E&Category!=SecureEnclave') ;;
+  --unit)        FILTER=(--filter 'Category!=E2E&Category!=SecureEnclave&Category!=Tpm') ;;
   --e2e|--integration)
                  FILTER=(--filter 'Category=E2E')
                  TARGET="./TswapTests/TswapTests.csproj" ;;
@@ -21,9 +24,12 @@ case "${1:-}" in
   --secure-enclave)
                  FILTER=(--filter 'Category=SecureEnclave')
                  TARGET="./TswapTests/TswapTests.csproj" ;;
-  # Default: everything except the hardware-gated Secure Enclave tests.
-  "")            FILTER=(--filter 'Category!=SecureEnclave') ;;
-  *) echo "Usage: $0 [--unit|--e2e|--secure-enclave]" >&2; exit 64 ;;
+  # TPM tests are Linux-only and need a reachable TPM/simulator; run them on purpose.
+  --tpm)         FILTER=(--filter 'Category=Tpm')
+                 TARGET="./TswapTests/TswapTests.csproj" ;;
+  # Default: everything except the hardware-gated Secure Enclave/TPM tests.
+  "")            FILTER=(--filter 'Category!=SecureEnclave&Category!=Tpm') ;;
+  *) echo "Usage: $0 [--unit|--e2e|--secure-enclave|--tpm]" >&2; exit 64 ;;
 esac
 
 TSWAP_TEST_KEY="${TSWAP_TEST_KEY:-$(openssl rand -hex 32)}" \

--- a/runtests.sh
+++ b/runtests.sh
@@ -7,13 +7,16 @@
 #                                  set TSWAP_E2E_BINARY to test a pre-built/AOT binary)
 #   ./runtests.sh --secure-enclave Secure Enclave backend tests (macOS + real hardware only;
 #                                  prompts for biometry/presence)
+#   ./runtests.sh --tpm-windows    Windows TPM backend tests (Windows + a TPM 2.0 device or
+#                                  virtual TPM required — see HARDWARE_BACKENDS.md's Windows
+#                                  TPM section)
 set -eo pipefail
 
 # Array so the xUnit '&' (AND) in a compound filter isn't treated as a shell operator.
 FILTER=()
 TARGET="./TokenSwap.slnx"
 case "${1:-}" in
-  --unit)        FILTER=(--filter 'Category!=E2E&Category!=SecureEnclave') ;;
+  --unit)        FILTER=(--filter 'Category!=E2E&Category!=SecureEnclave&Category!=TpmWindows') ;;
   --e2e|--integration)
                  FILTER=(--filter 'Category=E2E')
                  TARGET="./TswapTests/TswapTests.csproj" ;;
@@ -21,10 +24,14 @@ case "${1:-}" in
   --secure-enclave)
                  FILTER=(--filter 'Category=SecureEnclave')
                  TARGET="./TswapTests/TswapTests.csproj" ;;
-  # Default: everything except the hardware-gated Secure Enclave tests.
-  "")            FILTER=(--filter 'Category!=SecureEnclave') ;;
-  *) echo "Usage: $0 [--unit|--e2e|--secure-enclave]" >&2; exit 64 ;;
+  # TPM tests are Windows-only and need a reachable TPM/virtual TPM; run them on purpose.
+  --tpm-windows) FILTER=(--filter 'Category=TpmWindows')
+                 TARGET="./TswapTests/TswapTests.csproj" ;;
+  # Default: everything except the hardware-gated Secure Enclave/TPM tests.
+  "")            FILTER=(--filter 'Category!=SecureEnclave&Category!=TpmWindows') ;;
+  *) echo "Usage: $0 [--unit|--e2e|--secure-enclave|--tpm-windows]" >&2; exit 64 ;;
 esac
 
 TSWAP_TEST_KEY="${TSWAP_TEST_KEY:-$(openssl rand -hex 32)}" \
   dotnet test "$TARGET" "${FILTER[@]}"
+

--- a/runtests.sh
+++ b/runtests.sh
@@ -10,13 +10,16 @@
 #   ./runtests.sh --tpm            Linux TPM backend tests (Linux + tpm2-tools required; needs
 #                                  a reachable TPM 2.0 device or swtpm simulator — see
 #                                  HARDWARE_BACKENDS.md's Linux TPM section)
+#   ./runtests.sh --tpm-windows    Windows TPM backend tests (Windows + a TPM 2.0 device or
+#                                  virtual TPM required — see HARDWARE_BACKENDS.md's Windows
+#                                  TPM section)
 set -eo pipefail
 
 # Array so the xUnit '&' (AND) in a compound filter isn't treated as a shell operator.
 FILTER=()
 TARGET="./TokenSwap.slnx"
 case "${1:-}" in
-  --unit)        FILTER=(--filter 'Category!=E2E&Category!=SecureEnclave&Category!=Tpm') ;;
+  --unit)        FILTER=(--filter 'Category!=E2E&Category!=SecureEnclave&Category!=Tpm&Category!=TpmWindows') ;;
   --e2e|--integration)
                  FILTER=(--filter 'Category=E2E')
                  TARGET="./TswapTests/TswapTests.csproj" ;;
@@ -27,9 +30,12 @@ case "${1:-}" in
   # TPM tests are Linux-only and need a reachable TPM/simulator; run them on purpose.
   --tpm)         FILTER=(--filter 'Category=Tpm')
                  TARGET="./TswapTests/TswapTests.csproj" ;;
+  # TPM tests are Windows-only and need a reachable TPM/virtual TPM; run them on purpose.
+  --tpm-windows) FILTER=(--filter 'Category=TpmWindows')
+                 TARGET="./TswapTests/TswapTests.csproj" ;;
   # Default: everything except the hardware-gated Secure Enclave/TPM tests.
-  "")            FILTER=(--filter 'Category!=SecureEnclave&Category!=Tpm') ;;
-  *) echo "Usage: $0 [--unit|--e2e|--secure-enclave|--tpm]" >&2; exit 64 ;;
+  "")            FILTER=(--filter 'Category!=SecureEnclave&Category!=Tpm&Category!=TpmWindows') ;;
+  *) echo "Usage: $0 [--unit|--e2e|--secure-enclave|--tpm|--tpm-windows]" >&2; exit 64 ;;
 esac
 
 TSWAP_TEST_KEY="${TSWAP_TEST_KEY:-$(openssl rand -hex 32)}" \


### PR DESCRIPTION
## Summary

Merges #102 (Linux TPM) and #103 (Windows TPM) into one branch, since both were developed in parallel from plain `main` and independently touched the same integration points (`InitCommand.cs`, `Program.cs`, `SecurityWarnings.cs`, `Models.cs`, `IHardwareKeyService.cs`, `runtests.sh`, `ci.yml`) — exactly as flagged in both PR descriptions as an expected future conflict. This resolves that conflict directly instead of letting one PR block on the other merging first.

Beyond mechanical conflict resolution:

- **`tswap init --tpm` now actually dispatches to both platforms.** Each individual branch's `ExecuteTpm()` only knew about its own OS (`"--tpm is only supported on Linux."` / `"...on Windows."`) since neither had the other's implementation yet. Now checks both.
- **`--secure-enclave --tpm` together is rejected as a usage error** (already fixed on the Windows PR via Copilot review; carried through here).
- **Extracted the shared TPM init boilerplate.** `ExecuteTpmOnLinux`/`ExecuteTpmOnWindows` differed only in which service gets instantiated and one console message verb ("sealing" vs "wrapping") — the identical config-save/backup/completion-message logic now lives in one `FinishTpmInit` helper.
- **Extracted the shared `Unlock()` validation logic** (base64 decode, 32-byte length check, byte-for-byte identical error message text) from `LinuxTpmHardwareService`/`WindowsTpmHardwareService` into a new `TpmHardwareServiceBase`. Each backend keeps its own `Seal`/`Unseal` vs. `Wrap`/`Unwrap` vocabulary — those really are different primitives (TPM2 seal/unseal on Linux, RSA-OAEP wrap/unwrap on Windows) — only the validation plumbing above that was actually duplicated.

## Test plan

Re-verified from scratch on both platforms after the merge + refactor:
- [x] Linux: `Category=Tpm` (8/8) against a real swtpm container, full regression suite (327/327 excluding `TpmWindows`), NativeAOT publish, `init --tpm → add → get → migrate` end-to-end
- [x] Windows: `Category=TpmWindows` (11/11) against this VM's real virtual TPM, full regression suite (330/330 excluding `Tpm`), NativeAOT publish, `init --tpm → add → get → migrate` end-to-end, `--secure-enclave --tpm` conflict rejection
- [x] macOS: clean build (0 warnings), full non-hardware-gated suite (319/319), NativeAOT publish
- [x] Confirmed the *unfixed* single-exclusion filter would let Linux TPM tests run (and fail) on Windows — validates why `ci.yml`/`runtests.sh` need both `Category!=Tpm` and `Category!=TpmWindows`

## Status

Same honesty-bar caveats as both source PRs: Linux verified only against swtpm (no real hardware), Windows verified only against a Parallels virtual TPM (no real hardware) — see `HARDWARE_BACKENDS.md`'s Linux/Windows TPM sections.

Supersedes #102 and #103 — once this is reviewed, those two can be closed in favor of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)