### PR TITLE
Fold 2026-07-27 Phase 6 keyring design review into the plan docs

### DIFF
--- a/HARDWARE_BACKENDS.md
+++ b/HARDWARE_BACKENDS.md
@@ -223,10 +223,13 @@ property holds. Concretely still open before this should be trusted as a primary
   lockout/anti-hammering behavior, vendor-specific quirks, or a stricter owner-hierarchy
   authorization policy than the simulator's default (empty) owner auth.
 - **No PCR or PIN policy support.** `MULTI_MACHINE_KEYING.md`'s per-backend table lists TPM's
-  primitive as "seal share to a machine-bound key (**optionally** PCR/PIN policy)" — this pass
-  implements only the unconditional case (no policy digest on the sealed object at all). Boot-state
-  binding (PCR policy) and a PIN/password gate are both real, useful extensions, not implemented
-  here.
+  primitive as "seal `KEK_slot` to a machine-bound key (**optionally** PCR/PIN policy)" — this
+  pass implements only the unconditional case (no policy digest on the sealed object at all).
+  Boot-state binding (PCR policy) and a PIN/password gate are both real, useful **standalone**
+  hardening for this backend on its own merits — not a component of any future threshold-unlock
+  scheme. `MULTI_MACHINE_KEYING.md`'s "Why not k ≥ 2 (yet)" section is explicit that a TPM
+  PIN/PCR check doesn't compose into an independent second factor for multi-device unlock (same
+  root of trust as this slot); it's worth having for this backend regardless.
 - **The sealed-key wire format is unversioned**, same caveat as `Config.SecureEnclaveWrappedKey`:
   changing `Tpm2ToolsInterop`'s packing format is a silent breaking change for every existing TPM
   vault, with no detection or migration path.
@@ -375,15 +378,30 @@ not generalize to a TPM or Secure Enclave soldered to one machine. For those, re
 achieved at the fleet level: the Phase 6 "keyring of wrapped keys" gives each machine its own
 wrapped slot for a shared vault key.
 
-That is why `IHardwareKeyService` is the same seam Phase 6 builds on. Today `Unlock` returns
-the vault **master key** directly (single machine). Under Phase 6 the value a backend recovers
-becomes that machine's **key-encryption key (KEK)**, and a keyring layer unwraps the shared
-vault key with it — the backend contract is unchanged; only what sits above it grows.
+That is why `IHardwareKeyService` is the same seam Phase 6 builds on — and, per
+`MULTI_MACHINE_KEYING.md`'s two-layer slot wrap design, it needs **no interface change at
+all**: `Unlock` already returns exactly what that design needs — 32 bytes, in the backend's own
+idiom. Today those 32 bytes *are* the vault master key directly (single machine, `k = 1`,
+today's shipped behaviour). Under Phase 6's keyring, the same 32 bytes become that machine's
+slot key-encryption key (`KEK_slot`), and an AEAD layer above `IHardwareKeyService` — not
+inside any backend — unwraps the shared vault key with it. Every backend implementation in this
+file is already Phase-6-shaped; what's missing is the keyring layer above them, not a rewrite
+of any of them.
 
 **`MULTI_MACHINE_KEYING.md`** is the settled design for that key model: the keyring of wrapped
 shares, why every alternative (escrow / XOR / Shamir / config-share) collapses into it, why the
-Secure Enclave forces wrap/unwrap, and the user-set unlock threshold (`k=1` any-device vs. `k≥2`
-two-device-required). Read it before implementing TPM/SE enrollment. See also
-`REFACTORING_PLAN.md` §Phase 6 for the mergeable on-disk format and threat model.
+Secure Enclave forces wrap/unwrap, and why `k ≥ 2` unlock is demoted to a rationale note (no
+independent zero-friction second factor exists on any target platform today — TPM PIN/PCR
+policy stays on the backlog on its own merits as standalone hardening, not as a threshold
+ingredient). Read it before implementing further TPM/SE/YubiKey enrollment work.
+See also `REFACTORING_PLAN.md` §Phase 6 for the mergeable on-disk format and threat model.
+
+**Forward note on the "unversioned wire format" caveat** raised in each backend's status
+section below (`Config.SecureEnclaveWrappedKey`, `Config.TpmSealedKey`): Phase 6's keyring
+format resolves this by construction, not by patching the current fields. Each backend's blob
+becomes a slot's `hwBlob`, and `formatVersion` becomes part of the AEAD's associated data
+(`MULTI_MACHINE_KEYING.md` §AAD binding) rather than an afterthought — so this is a rename that
+comes with the Phase 6 migration, not a change to make to today's single-slot fields in
+isolation.
 
 

--- a/MULTI_MACHINE_KEYING.md
+++ b/MULTI_MACHINE_KEYING.md
@@ -5,6 +5,32 @@
 before implementing TPM or Secure Enclave enrollment — the byte layout it implies must be
 settled before any vault is written in the new format.
 
+A 2026-07-27 design review settled several open questions this doc previously left unresolved
+(the recovery slot, threshold unlock, and the enforcement/theatre distinction below); those
+sections now read as decided, not proposed. See §Scope for what that changed and §Deferred to
+v1 for what it explicitly pushed out.
+
+## Scope: v0 / v1 / v2
+
+This doc previously read as one large deliverable. It splits into three, and only the first is
+needed to deliver the adoption story in the section below ("a user can adopt tswap with zero
+extra hardware"):
+
+- **v0** — n slots, `k = 1` only. Backends: YubiKey, Secure Enclave, TPM, recovery keypair.
+  Hand-carried enrollment (new machine and enrolling machine exchange two files directly — scp,
+  USB, paste into a terminal — not over the sync transport). **No revocation, no `K_v` rotation,
+  no merge engine.**
+- **v1** — revocation, `K_v` rotation, and automating the enrollment exchange over the sync
+  transport (which reinstates the enrollment fingerprint as the *primary* control, not
+  defense-in-depth — see §The landmine below).
+- **v2** — threshold (`k`-of-`n`) *enrollment* governance, and the merge engine's HLC/
+  commutativity work (the latter belongs to `REFACTORING_PLAN.md` §Phase 6, not this doc).
+
+The line between v0 and v1 is **extension without revocation**. Adding a machine needs no
+rotation, no re-encryption, and none of the rotation-atomicity question — it is an append to the
+keyring. Removing one needs all of that. "To remove a machine, re-init" is an acceptable v0
+answer for a tool with no deployed fleets yet, and it is exactly where the hard work starts.
+
 ## Why: broaden hardware support to grow adoption
 
 Today tswap requires **two YubiKeys**. That is the single biggest barrier to adoption: it
@@ -65,131 +91,368 @@ scheme either excludes the SE or bolts a second mechanism (ECIES) alongside the 
 in-code seam (`IHardwareKeyService`) abstracts *"recover the key,"* not *"run a
 challenge-response."*
 
-## The model: a keyring of wrapped shares, with a user-set threshold
+## Where enforcement can and cannot live (a standing rule)
 
-One structure covers both the convenience and the defense-in-depth posture, because the
-convenience case is the degenerate `k = 1`:
+Settled 2026-07-27, and worth stating once because it governs several decisions below,
+including why the recovery slot has no PKI and why `k ≥ 2` unlock is demoted rather than
+implemented naively.
+
+Open source is not what makes a barrier weak. What matters is **who enforces it**.
+
+- **The binary in the attacker's hands — theatre.** `recoveryOnly`, `RequiresSudo`, the
+  `run`-command blocklist, expiry dates, OCSP checks the client itself performs. A closed
+  binary fails identically — the attacker controls the process, so any check the process makes
+  on itself is advisory.
+- **A different machine that does not hold the attacker's key — genuine.** `k` and
+  `formatVersion` bound into a slot's AAD (§AAD binding, below) are not policies an attacker
+  declines to honour; they are conditions on their own AEAD unwrap succeeding, enforced by math,
+  not cooperation.
+- **Evidence — real, but label it as such.** A generation counter or rotation bump lands in
+  files other copies will read. An attacker can suppress it locally, but then their copy
+  diverges and stops syncing cleanly — they cannot have both silence and continued
+  participation. That is detection, not prevention, and the two should never be conflated in
+  how a feature is described.
+
+**Rule:** if a barrier is load-bearing, bind it into the AEAD's AAD or a signature verified by
+a different device. If it is ergonomics (accident prevention, a clearer error message), keep it
+— it has real value — but document it as ergonomics. Never write a feature flag up as a
+security control.
+
+## The model: a keyring of wrapped shares (k = 1)
 
 ```
 keyring {
-  epoch:      monotonically increasing (anti-rollback)
-  threshold:  k                        # unlock requires k slots
+  formatVersion, vaultId
+  k:          1                        # see "Why not k ≥ 2" below
   slots: [
-    { deviceId, label, backend, enrolledAt, enrolledBy,
-      wrapped:  wrap(share_i, KEK_device_i) }   # AEAD/ECIES/sealed, per backend
+    { slotId, label, backend, enrolledAt,
+      hwBlob:  backendWrap(KEK_slot),                    # 32 random bytes, per backend
+      wrapped: AEAD(payload, key: KEK_slot, aad: formatVersion‖vaultId‖k‖slotId) }
     ...
   ]
-  signature:  signed by an enrolled machine    # see governance, below
 }
 ```
 
-- **`k = 1` (default — any one device unlocks).** Each slot wraps the whole `K_v`; the
-  "share" is just the key. This is today's convenience, generalized to *n* heterogeneous
-  devices. Best for adoption: one machine, one device, unlock alone.
-- **`k ≥ 2` (defense-in-depth — two devices required).** Shamir-split `K_v` into shares; each
-  slot wraps one share. Unlock = unwrap `k` shares, interpolate `K_v`. No single stolen
-  device unlocks. Costs solo-device unlock (you must have `k` devices present).
+Each slot wraps the whole `K_v` (via an intermediate `KEK_slot` — see "Two-layer slot wrap"
+below); the "share" is just the key. This is today's YubiKey-pair convenience, generalized to
+*n* heterogeneous devices: one machine, one device, unlock alone. No machine needs to be online,
+present, or aware for another to use the vault — adding a slot is an append, which is what makes
+the design work over a sync transport with zero coordination.
 
-**Making `k` a user policy is the right call** — the trade between "any one device" and "two
-devices required" is a threat-model choice, not something the design should hard-code.
+`K_v` is random with no reconstruction path, so a fixed-at-init slot set would mean no machine
+could ever be added or replaced. Extensibility is not optional, and 1-of-n is the honest
+default: any single unlockable machine can already export every secret in plaintext, so denying
+it slot-addition rights protects nothing real (see the enforcement rule above).
 
-### Why wrapping the shares is what lets the SE into a threshold
+### Extension implies decryption — an "extension-only" recovery slot isn't achievable
 
-Raw Shamir excluded the SE because shares had to be bytes on the CPU. But if each share is
-**wrapped** (ECIES to the SE), the SE decrypts *its own* share to bytes transiently, and you
-interpolate those. So a user-set threshold does **not** reintroduce the two-mechanism
-problem — it is still just wrap/unwrap, all backends uniform.
+Adding a machine requires wrapping `K_v` to the new machine's public key, which requires
+possessing `K_v`. Anything that can extend the fleet can therefore decrypt the vault — there is
+no way to grant "may enroll new machines" without also granting "may read everything."
+
+A genuine governance-only credential would need the keyring's **signing** key separated from
+`K_v`, with the credential holding only signing power. But that recovers no data, so it's
+useless for the single-machine-died scenario the recovery slot exists to solve. A signing-only
+credential is a real, different thing (see the fleet signing key in "Deferred to v1"), not a
+safer version of the recovery slot.
+
+`recoveryOnly: true` may still be carried on a slot as a label. **Document it as
+accident-prevention, not a security control** — it stops casual use of break-glass for a routine
+`get`, nothing more. Given that, exposure of the recovery slot is reduced by three things
+instead, per the enforcement rule above:
+
+1. **Custody** — the private key never lives on a running machine. This is the only genuine
+   control.
+2. **Use forces rotation** (v1) — after any recovery-slot unlock, refuse normal operation until
+   `K_v` is rotated and a fresh recovery keypair enrolled.
+3. **Evidence** (v1) — rotation and generation bumps are visible to other copies. An attacker
+   can suppress this locally but then diverges and stops syncing cleanly: they cannot have both
+   silence and continued access. Detection, not prevention.
+
+### Why not k ≥ 2 (yet)
+
+Demoted 2026-07-27 from a near-term roadmap item to a rationale note, because **no independent
+zero-friction second factor exists on any target platform today.** A user-set `k` is still the
+right idea in principle — the trade between "any one device unlocks" and "two devices required"
+is a genuine threat-model choice — but every candidate second factor we found either isn't
+actually independent, or breaks the hot-path UX (`get`, `run` must stay prompt-free/one-touch):
+
+| Candidate second factor | Verdict |
+|---|---|
+| Keypair in a filesystem file, read without prompting | Not a second factor. Same disk, same user, same compromise. Doubles loss surface for no gain. |
+| Windows LocalMachine cert store / macOS System keychain | Real ACL boundary (defeats user-level malware), but **requires elevation on every unlock** — fails on UX grounds, since this is the hot path. |
+| Same, but TPM/PCP-backed | Same root of trust as the existing TPM slot. `k=2` in name only. |
+| macOS "Always Allow" | Login-keychain ACL, not System keychain; binds to code signature, dragging back the Developer ID problem already escaped via CryptoKit (see `HARDWARE_BACKENDS.md`); `SecTrustedApplication` is deprecated. Never actually applies to the store in question. |
+| Windows equivalent of "Always Allow" | Does not exist. Granting the user's SID read access to the key container means any process running as that user can read it — independence collapses. |
+| GNOME Keyring / KWallet | Session stores, PAM-unlocked at login, reachable over D-Bus by anything in the session. Looks like a machine store, behaves like a file in `$HOME`. Also a desktop-environment dependency on headless boxes. |
+| No-touch YubiKey with check-in/check-out custody | Genuinely works, cross-platform, needs no new backend. But it buys a **temporal bound**, not access control — while inserted, anything running as the user can challenge it. Rests entirely on check-out discipline. An enterprise/government-grade control, disproportionate here. |
+
+A real second factor costs a PIN or a touch. TPM PIN and PCR policy stay on the backlog on
+their own merits (PCR costs nothing interactively — see `HARDWARE_BACKENDS.md`'s TPM sections),
+**not** as components of a threshold scheme.
+
+If `k ≥ 2` is ever revisited: wrapping (rather than raw Shamir) is still what would let the
+Secure Enclave participate in a threshold at all — each share is ECIES-wrapped, the SE decrypts
+*its own* share to bytes transiently, and those get interpolated. So a future user-set threshold
+would not reintroduce the "SE can't export key material" problem; it stays wrap/unwrap, all
+backends uniform. That reasoning doesn't change; only the priority of building it did.
+
+### Two-layer slot wrap
+
+```
+slot = {
+  slotId, label, backend, enrolledAt,
+  hwBlob:  backendWrap(KEK_slot),                    # 32 random bytes, per backend
+  wrapped: AES-256-GCM(payload, key: KEK_slot, aad: <see AAD binding, below>)
+}
+```
+
+Backends wrap 32 random bytes (`KEK_slot`) rather than `K_v` itself; a uniform AES-256-GCM layer
+above that (in plain C#, not backend-specific) wraps the actual payload. This is **less** work
+than earlier drafts of this doc implied: the backend contract collapses to "recover 32 bytes,"
+which is exactly what `IHardwareKeyService.Unlock` already returns today — no interface change
+needed. It also removes any requirement for a backend to support AAD natively, which matters
+because TPM2 sealed objects cannot carry arbitrary AAD.
+
+**Do not use XOR here.** XOR made sense only while `K_v` was *derived* from hardware (today's
+scheme). Under two-layer slots, `wrap_A(K1) + wrap_B(K2)` plus a public `K1⊕K2` share is
+isomorphic to `wrap_A(K_v) + wrap_B(K_v)` with an extra derivation step and the one-time-pad
+reuse hazard on rotation flagged in "The landmine" below — more code, not less, and a format to
+eventually migrate off.
+
+### AAD binding
+
+**Include in the AEAD's associated data:** `formatVersion`, `vaultId`, `k`, `slotId`, and (once
+v1 lands) `fleetSigPub`.
+
+**Do NOT include the generation/epoch counter.** Anything in the AAD can only change if every
+slot is re-wrapped, which needs every device physically present — the right property for `k`
+(see "The landmine", below) and completely the wrong one for a counter that bumps on every
+write.
+
+**Encoding: fixed binary, length-prefixed fields, explicit ordering — not serialized JSON.**
+`System.Text.Json` gives no byte-stability guarantee across versions or property reordering, and
+an incidental whitespace or property-order change would silently change every AAD computation
+and brick every vault on disk with no diagnosable cause. This is a format decision, not an
+implementation detail, and it belongs in the byte layout from day one.
+
+### Per-slot X25519 keypair
+
+Every slot gets an X25519 keypair: the private half wrapped by that slot's own `KEK_slot`
+(hardware-backed as above), the public half stored in the keyring in the clear.
+
+```
+unlock: hardware -> KEK_slot -> slot private key -> K_v
+```
+
+One extra step over the two-layer wrap alone. In exchange, **any holder of `K_v` can write a
+fresh slot for any enrolled device offline** — including for YubiKey slots, which otherwise have
+no public key to encrypt to (challenge-response yields a symmetric KEK only, not a keypair).
+
+This keypair is also what the hand-carried enrollment exchange (below) trades. And it is **the
+only item in the v0 format whose retrofit would require every enrolled device to be physically
+present again** — everything else in this design migrates mechanically (read with the old key,
+rewrite with the new, one pass, no ceremony). Without it, rotating `K_v` later means "plug in
+every YubiKey you ever enrolled," which for a token sitting in a drawer in another country is a
+migration step that never actually happens.
+
+## The recovery slot: a bare keypair, not a CA-issued certificate (a path not taken)
+
+An earlier draft of this doc proposed a CSR/CA-issued recovery certificate (self-hosted step-ca
+or any CA the user points tswap at), reasoning that the CA step buys revocation for a lost or
+compromised recovery credential. On review, that doesn't hold up, and the design is simpler for
+it: **the recovery slot is a bare keypair. No X.509, no CA, no CSR, no chain validation, no
+OCSP/CRL, no `notAfter`.** It needs a public key to wrap to and a private key to recover with;
+nothing else.
+
+**Why revocation cannot work here.** Revocation only does anything when the credential is
+presented to a verifier who checks it *and* who holds something the presenter needs — the TLS
+case, where the server is the gatekeeper. Recovery is offline decryption of bytes the holder
+already possesses. There is no verifier in the loop, so no revocation mechanism can function:
+not CRL, not OCSP, not stapling, not short-lived certs. This isn't an artifact of tswap being
+open source — a closed binary would fail identically, since an attacker who has the ciphertext,
+the private key, and a documented format needs nothing else the client-side code could withhold.
+
+**Why expiry is actively harmful, not just unnecessary.** A break-glass credential sits unused
+for years by design — that's the point of it. `notAfter` guarantees expiry lands exactly when
+the credential is finally needed. If a client honours it, the disaster-recovery path is bricked
+by a date field at the worst possible moment. If it doesn't honour it, the field was always
+theatre.
+
+**Why chain validation is a new single point of failure.** If validating a chain were required
+at recovery time, losing the CA in the same event that took the machine (a house fire, a
+provider outage, a bankrupt CA) converts a recoverable situation into an unrecoverable one — the
+opposite of what a disaster-recovery slot is for.
+
+The per-backend table below reflects this: the recovery slot wraps to a bare keypair's public
+key, generated however the user sees fit (this is a tool for technical users; custody is their
+call, same as the YubiKey XOR share already is today), or — better, where practical — generated
+non-extractably inside a TPM/Secure Enclave/YubiKey so a leaked public key alone grants nothing.
+**Custody is the only real control** (see "Extension implies decryption", above); the deferred
+v1 items (recovery-forces-rotation, evidence via generation bumps) are what stand in for the
+revocation this credential structurally cannot offer.
 
 ### Per-backend wrap primitive
 
 | Backend | KEK / wrap | Presence | Platform API |
 |---|---|---|---|
-| YubiKey | challenge-response → `PBKDF2` → KEK; AES-256-GCM wrap | touch | ykman / HMAC-SHA1 slot 2 |
-| TPM 2.0 | seal `share` to a machine-bound key (optionally PCR/PIN policy) | PIN / none | Windows TBS + CNG PCP; Linux tpm2-tss |
-| Secure Enclave | ECIES-encrypt `share` to a non-extractable P-256 key | biometric / user-presence | Security.framework `SecKeyCreate{Encrypted,Decrypted}Data` |
-| Recovery cert | ECIES-encrypt `share` to a CSR-issued keypair's public key | none — this is the deliberately presence-free break-glass slot | Standard X.509/PKIX (CSR, CA-signed cert, optional OCSP/CRL check) |
+| YubiKey | challenge-response → `PBKDF2` → `KEK_slot`; AES-256-GCM wrap | touch | ykman / HMAC-SHA1 slot 2 |
+| TPM 2.0 | seal `KEK_slot` to a machine-bound key (optionally PCR/PIN policy) | PIN / none | Windows TBS + CNG PCP; Linux tpm2-tss |
+| Secure Enclave | ECIES-encrypt `KEK_slot` to a non-extractable P-256 key | biometric / user-presence | Security.framework / CryptoKit |
+| Recovery keypair | Wrap `KEK_slot` to a bare X25519 (or EC) keypair's public key — no PKI, no CSR, no cert, no expiry | none — this is the deliberately presence-free, offline-capable break-glass slot | Custody of the private key is the only control (see above) |
 
-`K_v` (or a Shamir share) never leaves as plaintext except transiently in memory during
-unlock; the wrapped forms in the keyring are useless off the enrolled machine.
+`K_v` never leaves as plaintext except transiently in memory during unlock; the wrapped forms
+in the keyring are useless off the enrolled machine, and useless without that machine's private
+key even if copied.
+
+## Hand-carried enrollment (v0)
+
+The expensive part of enrollment in earlier drafts of this design was a fingerprint-comparison
+ceremony, and that cost exists **only because the request travels over the sync transport**,
+where a MITM could substitute their own public key and the approving machine would obligingly
+wrap `K_v` to it.
+
+If the user moves the two files themselves — scp, USB, paste into a terminal — the channel is as
+trusted as their own hands, and there is no MITM to defend against. Three commands, no protocol
+work, reusing the per-slot X25519 keypair above:
+
+- `slot request` on the new machine — emits its X25519 public key.
+- `slot approve` on an already-enrolled machine — unlocks, wraps `K_v`, emits the slot.
+- `slot accept` on the new machine — imports the slot, re-wraps under its own hardware `KEK_slot`.
+
+Still display a short fingerprint on both machines as cheap defense in depth (a few dozen lines
+of code), but it is no longer the load-bearing control in v0, so the usable-security question of
+whether people actually compare it isn't on the critical path yet. **v1's transport-borne
+enrollment reinstates the fingerprint as the primary control** — see "Deferred to v1".
+
+**Document plainly, once implemented: move these two files yourself; do not drop them in the
+sync folder.** Automating the exchange over the transport is v1 work, not a v0 shortcut.
+
+**Rejected alternative: sharing the recovery keypair across machines.** Copying the config
+directory plus the recovery keypair to a second machine would work and needs no new commands at
+all — but it puts the break-glass credential on every machine as a daily-use credential, which
+is precisely what "Extension implies decryption" above says not to do, and it means the recovery
+key can never be hardware-wrapped, since it would need to stay portable. Per-machine slots keep
+the recovery key in a drawer where it belongs.
 
 ## The landmine: threshold downgrade
 
-If `k` is a plaintext field, a thief with the synced files **and one enrolled device** just
-rewrites `k = 2 → k = 1` and unlocks — a silent downgrade that defeats the whole point of
-the stronger posture. Therefore:
+If `k` (or `formatVersion`) lived in a plaintext field, a thief with the synced files **and one
+enrolled device** could just rewrite `k = 2 → k = 1` and unlock — a silent downgrade that would
+defeat the whole point of a stronger posture, if one is ever configured.
 
-- `k`, the slot set, and the `epoch` must live inside the **signed keyring**; unlock verifies
-  the signature before trusting `k`.
-- An `epoch` counter (checked monotonic) prevents **rollback** to an older keyring with a
-  weaker `k` or a since-revoked slot.
+Per the enforcement rule above, the **primary** defense is that `k`, `vaultId`, and
+`formatVersion` are bound into every slot's AEAD **associated data** (see "AAD binding"): they
+are not policy an attacker declines to honour, they are inputs whose mismatch makes the AEAD
+unwrap itself fail. Downgrading `k` for one slot without re-wrapping *every* slot to match
+produces slots whose AAD is now inconsistent with the keyring header — which requires
+possessing every enrolled device, exactly the barrier that matters.
 
-This pushes the hard problem up one level to **keyring authenticity / enrollment authority**,
-which is genuinely the unsolved-in-v1 part (see Phase 6): v1 uses 1-of-n enrollment + a
-tamper-evident audit trail; v2 adds k-of-n threshold *enrollment* (distinct from the k-of-n
-*unlock* threshold here). Do not ship configurable `k` unlock while treating the keyring as
-unauthenticated plaintext — the downgrade makes the higher `k` security theatre.
+A keyring **signature** is a secondary, v1-era hardening layer once a fleet signing key exists
+(see "Deferred to v1") — useful for catching a rogue slot *addition* that AAD binding alone
+doesn't cover, but not the primary mechanism the way an earlier draft of this doc assumed.
 
 ## How this maps onto the code already in the branch
 
-The seam from the `IHardwareKeyService` reshape is the right shape for this:
+The seam from the `IHardwareKeyService` reshape is the right shape for this, and — per "Two-layer
+slot wrap" above — needs **no interface change**:
 
-- **`IHardwareKeyService.Unlock`** becomes "unwrap this backend's slot" — returns one
-  contribution (`K_v` when `k=1`, or one Shamir share when `k≥2`), in the backend's own idiom.
-- **`VaultUnlocker`** grows from "pick one backend, return its key" into "gather `k`
-  contributions and interpolate." For `k = 1` it calls exactly one backend — which is what it
-  does today, so the convenience path is unchanged.
-- **`Config.Backend`** (already added) selects *which* backend a machine uses; the keyring
-  (new, per Phase 6) enumerates *all* enrolled slots across machines.
-- **`IVaultStore`** (already added) is where the keyring + wrapped `K_v` load/save lives — a
-  new store implementation, the current single-file format staying as the default.
+- **`IHardwareKeyService.Unlock`** already returns exactly what the two-layer design needs: 32
+  bytes (`KEK_slot`), in the backend's own idiom. Under `k = 1` this is used to unwrap `K_v`
+  directly; the interface doesn't need to know that.
+- **`VaultUnlocker`** grows from "pick one backend, return its key" into "find this machine's
+  slot, unwrap `KEK_slot` via the backend, then unwrap `K_v` via the AEAD layer." For today's
+  single-backend-per-vault case this is one extra unwrap step, not a redesign.
+- **`Config.Backend`** (already added) selects *which* backend a machine uses today; the keyring
+  (new, per Phase 6) enumerates *all* enrolled slots across machines, superseding the single
+  discriminator for multi-machine vaults.
+- **`IVaultStore`** (already added) is where the keyring + wrapped `K_v` load/save lives — a new
+  store implementation, the current single-file format staying as the default for
+  single-machine vaults that never opt in.
 
-## Implementation ordering (each independently shippable)
+## Implementation ordering
 
-1. **Random `K_v` + single-slot keyring, `k = 1`, YubiKey only.** Move from "derive `K_v`"
-   to "random `K_v` wrapped by the YubiKey KEK." This is the format change; do it behind
-   `IVaultStore` with migration from the existing derived-key vaults, and golden-file tests.
-   Design the slot format to carry `k` and wrap *shares* now, even though `k=1`, so k≥2 is a
-   forward-compatible addition rather than a format break.
+**v0** (each step independently shippable, all still single-`k`):
+
+1. **Random `K_v` + single-slot keyring, `k = 1`, YubiKey only.** Move from "derive `K_v`" to
+   "random `K_v` wrapped via the two-layer scheme above." This is the format change; do it
+   behind `IVaultStore` with migration from the existing derived-key vaults, golden-file tests,
+   and the AAD/binary-encoding decisions above locked in from the start — they cannot be
+   retrofitted once vaults exist in the new format.
 2. **Second backend (TPM or Secure Enclave), still `k = 1`, single machine.** Prove the
-   wrap/unwrap seam across a second, non-YubiKey backend. Enrollment writes that backend's slot.
-3. **Multi-machine keyring, 1-of-n enrollment.** `fleet init` / `fleet enroll` /
-   `fleet machines`; offline two-file enrollment exchange (per Phase 6). Still `k = 1`.
-4. **Revocation + `K_v` rotation** (bump `epoch`, re-wrap all slots). Makes revocation real.
-5. **(v2) User-set `k ≥ 2` unlock** — the multi-device unlock ceremony (gather `k` devices,
-   coordinate touches) plus guardrails: warn when `k` exceeds enrolled devices, and nudge
-   toward a recovery slot so a user cannot Shamir themselves out of their own vault.
+   wrap/unwrap seam across a second, non-YubiKey backend — already done today at the
+   `IHardwareKeyService` level (see `HARDWARE_BACKENDS.md`); this step is about proving it
+   through the new two-layer keyring format specifically.
+3. **Multi-machine keyring via hand-carried enrollment.** `slot request` / `approve` / `accept`
+   (see above), each slot getting its own X25519 keypair. Still `k = 1`. No revocation, no
+   rotation, no merge engine — see `REFACTORING_PLAN.md` §Phase 6 for the per-secret record
+   format this pairs with.
+
+**v1:**
+
+4. **Transport-borne enrollment** — automate the hand-carried exchange over the sync folder,
+   which reinstates the enrollment fingerprint as the primary defense against a MITM substituting
+   their own key (see "Deferred to v1").
+5. **Revocation + `K_v` rotation:** slot removal, `K_v` rotation, re-encrypt all records, bump a
+   keyring generation counter so stale copies are detectably outdated. This is the step that
+   makes revocation real; do not describe step 3 as "secure sharing" without it landing.
+
+**v2:**
+
+6. **User-set `k ≥ 2` unlock** — only if a genuine independent second factor materializes on some
+   platform (see "Why not k ≥ 2 (yet)"); otherwise this stays a rationale note indefinitely.
+7. **k-of-n threshold *enrollment*** (governance over who may extend the fleet — distinct from
+   `k`-of-`n` *unlock*, demoted above). Shamir-split enrollment key; adding a machine requires k
+   approvals.
 
 ## Open questions
 
-- **Recovery slot.** With `k ≥ 2`, an escrowed recovery slot (a printed/stored wrapped share)
-  is the safety net against device loss — but re-introduces the escrow exposure. Make it an
-  explicit, opt-in slot, not a default.
+- **`K_names` provenance.** Deriving the filename-HMAC key from `K_v` means a rotation (v1)
+  renames every record; deriving it from a separate, non-rotated fleet constant avoids mass
+  renames but must never be reconstructible without fleet membership. Does not gate v0 — there's
+  no rotation yet — but should be settled before v1 implements rotation.
+- **Backends that can't do presence uniformly.** TPM PIN vs. YubiKey touch vs. SE biometric.
+  Surface each slot's presence guarantee honestly in a future `slots`/`fleet machines` listing —
+  it must not misreport a no-touch YubiKey as simply "unprotected" (see "Why not k ≥ 2" above:
+  a no-touch YubiKey with check-in/check-out custody is a real, if unusual, control).
+- **Whether `init` caps default slot count.** Enrolling two slots by default (one device +
+  recovery) with further slots behind an explicit flag keeps the honest "concurrent edits to the
+  same secret can still produce conflicted copies" story visible, without capping `n` in the
+  format itself.
 
-  **A CA-issued recovery certificate is a concrete, better-shaped answer to this than a raw
-  printed share.** The mechanism: the user generates a keypair, submits a CSR, and gets back
-  a cert signed by a CA they've configured as trusted (self-hosted — e.g. `step-ca` — or any
-  CA; tswap trusts whatever root the user points it at, no bundled default). `Wrap` targets
-  the cert's public key exactly like any other backend; the *private* key, not the cert, is
-  what recovers the share.
+Filename determinism (`HMAC(K_names, name)` vs. randomized-filename-plus-internal-id) is
+**settled, not open** — see `REFACTORING_PLAN.md` §Phase 6 for the decision and reasoning; it's
+a record-format question, not a key-model one, so it lives there.
 
-  This is deliberately the **presence-free, offline-capable** slot — the point is that it
-  works when every other factor is gone. The private key can be printed/stored however the
-  user sees fit (this is a tool for technical users; key custody is their call, same as the
-  YubiKey XOR share already is), or — better, where practical — generated non-extractably
-  inside a TPM/Secure Enclave/YubiKey and only the public key CSR'd, so a leaked cert alone
-  grants nothing.
+## Deferred to v1
 
-  What the CA step actually buys you, since the wrap/unwrap crypto itself doesn't need one:
-  **revocation.** A lost or compromised YubiKey/TPM/SE slot can only be handled by removing it
-  from the keyring and rotating `K_v` (step 4 below); a lost or compromised recovery cert can
-  be revoked at the CA (OCSP/CRL) without touching anything else, *if* unlock checks
-  revocation status for this slot. That check is a network dependency — acceptable here
-  specifically because this is the break-glass path, not everyday unlock, which stays fully
-  offline on every other backend.
-- **`K_names` provenance** and **deterministic vs. randomized record filenames** — carried
-  over from Phase 6; independent of the key model but must be settled with the same format.
-- **Keyring signing key** — per-machine Ed25519 derived alongside `KEK_device`? Decide in
-  step 3; it is the root of the downgrade/rollback protection above.
-- **Backends that can't do presence uniformly** — TPM PIN vs. YubiKey touch vs. SE biometric.
-  Surface each slot's presence guarantee in `fleet machines` so the user sees what actually
-  protects each machine.
+Recorded so the work isn't lost, and so it doesn't leak into v0 scope by accident:
+
+- **Fleet signing key `K_s`** (Ed25519), wrapped alongside `K_v` in every slot, so any machine
+  that can unlock can sign. Resolves the keyring-authenticity question above (a device learns
+  `fleetSigPub` from its enrollment response; successfully decrypting `K_v` with it authenticates
+  the response) and gives "The landmine" section a secondary defense beyond AAD binding.
+- **Rotation atomicity — the largest open design question in this entire doc.** A partially
+  rotated record directory syncing against another, not-yet-rotated copy needs a rotation
+  generation per record, a merge rule that tolerates mixed generations mid-rotation, and
+  resumability if a rotation is interrupted. Must be fully settled before v1 writes a single
+  rotated record — this is exactly the kind of byte-layout decision that cannot be retrofitted.
+- **Fingerprint confirmation becomes the primary control**, not defense-in-depth, once
+  transport-borne enrollment (v1, above) removes the manual-file-movement trust boundary. Neither
+  the Secure Enclave nor a TPM helps here — hardware attestation proves *some* device is
+  involved, not *your* device specifically. This is also a usable-security question in its own
+  right (whether users actually compare a fingerprint rather than pressing enter has a real
+  research literature) and probably wants outside input rather than being solved from first
+  principles — see the closing note in `REFACTORING_PLAN.md` §Phase 6 about external review.
+- **Recovery-slot use forces rotation.** After any recovery-slot unlock, refuse normal operation
+  until `K_v` is rotated and a fresh recovery keypair enrolled — see "Extension implies
+  decryption" above for why this substitutes for revocation on a credential that structurally
+  can't be revoked.
+- **Pinned monotonic epoch counter in local (unsynced) config**, as defense in depth alongside
+  rotation — an old keyring yields the old `K_v`, which decrypts nothing written since, so this
+  is a belt-and-suspenders check, not where the real work happens.
+- **Non-extractable enrollment-key custody per backend.** A transient software key is fine for
+  v1 — the exposure window is seconds, on the machine about to hold `K_v` anyway. Backing the
+  enrollment keypair with a non-extractable key (SE ECIES public key, Windows CNG public key) is
+  a later hardening pass; the Linux TPM path would need a TPM-resident ECC key rather than the
+  keyed-hash object `tpm2_create` produces today.

--- a/MULTI_MACHINE_KEYING.md
+++ b/MULTI_MACHINE_KEYING.md
@@ -127,7 +127,7 @@ keyring {
   slots: [
     { slotId, label, backend, enrolledAt,
       hwBlob:  backendWrap(KEK_slot),                    # 32 random bytes, per backend
-      wrapped: AEAD(payload, key: KEK_slot, aad: formatVersion‖vaultId‖k‖slotId) }
+      wrapped: AEAD(payload, key: KEK_slot, aad: formatVersion || vaultId || k || slotId) }
     ...
   ]
 }

--- a/REFACTORING_PLAN.md
+++ b/REFACTORING_PLAN.md
@@ -371,9 +371,22 @@ key-management model and a mergeable on-disk format.
 
 > **The key-management half is now worked out in `MULTI_MACHINE_KEYING.md`** — the keyring
 > of wrapped shares, the design-space rationale (why escrow / XOR / Shamir / config-share all
-> collapse into it), why the Secure Enclave forces wrap/unwrap, and the user-set unlock
-> threshold. It is also the motivation for going multi-backend at all: TPM + Secure Enclave
-> remove the two-YubiKey adoption barrier. The sections below cover the *on-disk format* half.
+> collapse into it), why the Secure Enclave forces wrap/unwrap, and why `k ≥ 2` unlock is
+> demoted to a rationale note rather than a near-term goal. It is also the motivation for going
+> multi-backend at all: TPM + Secure Enclave remove the two-YubiKey adoption barrier. The
+> sections below cover the *on-disk format* half.
+
+**A 2026-07-27 design review split this phase into v0 / v1 / v2** (full reasoning in
+`MULTI_MACHINE_KEYING.md` §Scope) — the short version, from the format side:
+
+- **v0**: per-secret records with tombstones, a keyring at `k = 1`, hand-carried enrollment.
+  No revocation, no `K_v` rotation, no merge engine.
+- **v1**: revocation, rotation, and automating the enrollment exchange over the sync transport.
+- **v2**: the merge engine (HLC, commutativity/idempotence fuzz tests) and threshold
+  enrollment governance.
+
+Everything below is written against that split; steps and open questions are labeled v0/v1/v2
+so it's clear what's gating and what can be revised later under a format-version bump.
 
 #### How today's crypto actually works (and why it points at the design)
 
@@ -447,23 +460,56 @@ secrets produce conflicting opaque blobs. Replace it with **per-secret encrypted
 records**, one file per secret:
 
 - Filename = `HMAC(K_names, secret-name)` (hex) so names never appear on disk and the
-  set of filenames does not leak the secret names to the sync transport.
-- Each record = `AEAD_encrypt(payload, key = K_v)` where the payload carries the value
-  plus **merge metadata**: a hybrid logical clock (HLC) / lamport counter, the origin
-  `machineId`, and burn/tombstone fields.
+  set of filenames does not leak the secret names to the sync transport. **This is settled,
+  not open** — see the per-file security notes below.
+- Each record = `AEAD_encrypt(payload, key = per-record key)` (see the per-file security notes
+  for why the key is per-record, not `K_v` directly) where the payload carries the value plus
+  **merge metadata**.
+
+**Record type is part of the payload, and a delete/burn is a record, not an absent file
+(v0 gate — cannot be retrofitted).** Three record types: `value`, `tombstone` (deleted),
+`burned`. The filename is unaffected by a type change — it's `HMAC(K_names, name)` and doesn't
+depend on content. Without an explicit tombstone type, machine A deletes a secret, machine B
+still has the old file, and sync silently resurrects it on the next merge — worse for `burn`
+specifically, where a resurrected secret destroys the incident record the burn exists to
+create. **Tombstones must be padded to the same size buckets as live records** (see the
+padding item below), or a tombstone is trivially distinguishable from a live secret by file
+size alone.
+
+**Ordering authority is a per-item write counter plus an id tiebreak, not a wall-clock
+timestamp (v0 gate).** UTC timestamps are unsafe as the *authority* for merge ordering across
+machines — clock skew, VMs resuming from suspend, and manual clock changes all produce wrong
+outcomes silently. Keep a timestamp in the record for display/human intuition in `names`
+output; keep the write counter + origin id for correctness. A per-item counter plus id tiebreak
+*is* a Lamport clock, so v2's HLC work (below) becomes an additive refinement on top of this,
+not a format break.
 
 Merge rules fall straight out of semantics tswap already has, so concurrent edits
 resolve deterministically without a manual "conflict" state:
 
-- **Value edits:** last-writer-wins by (HLC, machineId) tiebreak.
+- **Value edits:** last-writer-wins by (write counter, origin id) tiebreak.
 - **Burns:** earliest-burn-wins — which *matches the existing rule* that re-burning an
   already-burned secret is rejected and preserves the original incident record.
-- **Deletes:** tombstones (a delete is a record, not a missing file), so a delete on one
-  machine is not silently resurrected by an older copy on another.
+- **Deletes:** tombstones as above. **Whether tombstones should instead be delete-wins
+  (order-independent, needs no clock, cannot silently resurrect, at the cost of a delete from a
+  stale copy beating a newer edit) is still open — leaning delete-wins for v0**, since the
+  record is retained and recoverable either way; see "Open questions" below.
+
+**Add a vault generation counter and last-writer id to the record header, in the clear**, so a
+user facing two conflicted copies can be told "generation 9 from LAPTOP vs. generation 7 from
+DESKTOP" instead of guessing between two opaque files. Refuse a save when the on-disk
+generation exceeds the loaded one. Small (~20 lines), and forward-compatible with v2's HLC
+work.
 
 Sync stays entirely external (git/Syncthing/Dropbox); per-record files also give clean,
-content-free "what changed" diffs. A `tswap sync` (or auto-merge-on-load) folds a
-freshly-synced directory into the local view.
+content-free "what changed" diffs. Splitting the blob into per-secret files is itself most of
+the mergeability mechanism — the sync tool does directory-level merge for free the moment
+there's one file per secret, and two machines editing different secrets stop conflicting
+immediately. Same-secret concurrent edits still produce a conflicted copy (sync tools like
+OneDrive/Dropbox/Syncthing detect concurrent modification and produce conflicted copies rather
+than clobbering, so this is *detected*, not silent) — but for an encrypted blob a conflicted
+copy is hard to act on without the generation counter above making the two copies diagnosable.
+A `tswap sync` (or auto-merge-on-load) folds a freshly-synced directory into the local view.
 
 #### Per-file security considerations (bake into the format, not retrofit)
 
@@ -480,20 +526,21 @@ order of how much they matter:
    individual lengths by pooling them. **Mitigation: pad every record to size buckets**
    (e.g. next multiple of 256 bytes) before encrypting. Negligible cost; removes the leak.
 
-2. **Identity + timing correlation (the real tradeoff).** Deterministic
+2. **Identity + timing correlation (the real tradeoff — settled, not open).** Deterministic
    `HMAC(K_names, name)` filenames are *stable*, so a transport observer sees "the file
    with hash `abc123…` changed again at 14:03" — the name stays hidden, but per-secret
    **edit patterns over time** become trackable and correlatable with user activity. The
    single blob leaks only "something changed." This collides with mergeability, which
    *needs* a stable per-secret identity to recognise concurrent edits of the same secret.
-   Escape hatch: randomise the *filename* per write while keeping a stable record-id
-   *inside* the AEAD (each edit becomes a fresh opaque file; supersede/delete via
+   The alternative considered: randomise the *filename* per write while keeping a stable
+   record-id *inside* the AEAD (each edit becomes a fresh opaque file; supersede/delete via
    tombstones keyed on the internal id; periodic compaction). That defeats which-secret
    correlation but not "an edit of ~this size happened around now" — hiding that needs
-   batching or decoy traffic, disproportionate for a personal fleet. **Decision to make
-   explicitly in the design doc:** deterministic filenames (simpler merge, leaks edit
-   identity/timing) vs randomised filenames + internal ids (hides identity, adds
-   compaction) — most personal threat models can accept deterministic + padding.
+   batching or decoy traffic, disproportionate for a personal fleet, and the compaction
+   machinery is real ongoing complexity for a marginal privacy gain against tswap's stated
+   threat model (a personal fleet on a semi-trusted sync transport, not a hostile
+   transport operator). **Decision: deterministic filenames.** Accept the edit-timing leak;
+   document it plainly wherever the format is described to users.
 
 3. **Nonce-management surface (subtle, mandatory fix).** N files rewritten
    independently and concurrently across machines, all under one `K_v`, vastly enlarges
@@ -511,51 +558,102 @@ format is written — they are painful to retrofit once vaults exist on disk.
 
 #### Implementation ordering (each independently shippable)
 
-1. **`IVaultStore` extraction** (the Phase 5 backlog item): carve load/save of config +
-   secrets out of `Storage` behind an interface, keeping the current single-file format
-   as the default implementation. Pure refactor, no behaviour change — the enabling step.
-2. **Per-secret record format + merge engine** (single-machine first): new store
-   implementation with keyed-hash filenames, HLC metadata, and the LWW / earliest-burn /
-   tombstone merge rules. **Bake in the per-file security fixes now** (see above):
+**v0** — per-secret records + keyring at `k = 1` + hand-carried enrollment. No revocation, no
+rotation, no merge engine.
+
+1. **`IVaultStore` extraction** (the Phase 5 backlog item) — ✅ **done**, shipped in Phase 5.
+   Carved load/save of config + secrets out of `Storage` behind an interface, keeping the
+   current single-file format as the default implementation. The enabling step for everything
+   below.
+2. **Per-secret record format** (single-machine first): new store implementation with
+   keyed-hash filenames, the write-counter ordering authority, and the value / tombstone /
+   burned record types — all four detailed above. **Bake in the per-file security fixes now**:
    size-bucket padding before encryption, and per-record keys via
    `HKDF(K_v, recordId || writeCounter)` — both change the byte layout and cannot be
-   retrofitted once vaults exist. Fuzz/property-test the merge for commutativity and
-   idempotence (merge order must not matter). Still one machine, one `KEK` — no keyring yet.
-3. **Keyring + enrollment** (multi-machine, 1-of-n): `K_v` + per-machine wrapped slots;
-   `fleet init`, `fleet enroll`, `fleet machines`. Enrollment uses an **offline, two-file
-   ephemeral X25519 exchange** (new machine emits a request file with its public key +
-   attested `KEK_m`-derived wrapping key; an enrolled machine returns a slot file), so no
-   network or simultaneous presence is required — it works over the same sync transport.
-4. **Revocation + rotation:** `fleet revoke` = remove slot, rotate `K_v`, re-encrypt all
-   records, bump a keyring epoch so stale copies are detectably outdated. This is the
-   step that makes revocation real; do not ship 3 as "secure sharing" without it.
-5. **(v2) k-of-n threshold enrollment:** Shamir-split enrollment key; `fleet enroll`
-   requires k approvals. Optional hardening layered on the same keyring.
+   retrofitted once vaults exist. Still one machine, one `KEK` — no keyring, no merge engine,
+   no HLC yet; last-writer-wins by the write counter is enough for a single machine, since
+   there's nothing to merge against.
+3. **Keyring + hand-carried enrollment** (multi-machine, `k = 1`): the keyring format,
+   `K_v` + per-machine wrapped slots (see `MULTI_MACHINE_KEYING.md`'s two-layer wrap and
+   per-slot X25519 keypair), and `slot request`/`approve`/`accept` for hand-carried enrollment
+   (files moved by the user themselves — scp, USB, paste — not over the sync transport).
+   **Fingerprint display on both sides is an explicit deliverable of this step, not an
+   afterthought detail** — even though it's defense-in-depth rather than load-bearing in v0
+   (see `MULTI_MACHINE_KEYING.md` §Hand-carried enrollment), it's the seam v1's transport-borne
+   enrollment builds on, and it's a couple dozen lines of code that are much cheaper to add now
+   than to retrofit once `slot approve` output format is settled.
+
+**v0 exit criterion:** a vault usable across machines with zero shared secrets over the
+network and zero extra hardware beyond what v0's backends already support (YubiKey, TPM, SE) —
+shippable and useful on its own, without waiting for v1/v2. "To remove a machine, re-init" is
+an acceptable v0 answer for a tool with no deployed fleets yet.
+
+**v1** — revocation, rotation, transport-borne enrollment.
+
+4. **Revocation + rotation:** slot removal, `K_v` rotation, re-encrypt all records, bump a
+   keyring generation counter so stale copies are detectably outdated. This is the step that
+   makes revocation real; do not describe step 3 as "secure sharing" without it landing.
+   **Depends on step 3's per-slot X25519 keypair** (`MULTI_MACHINE_KEYING.md` §Per-slot X25519
+   keypair) — without it, re-wrapping every slot during rotation needs every enrolled device
+   physically present again, which for a token in a drawer in another country is a migration
+   that never actually happens.
+5. **Transport-borne enrollment:** automate the step-3 file exchange over the sync folder,
+   which reinstates the enrollment fingerprint from step 3 as the *primary* defense against a
+   MITM substituting their own key, not defense-in-depth. Rotation atomicity (see "Open
+   questions" below) must be fully resolved before this step, not concurrently with it.
+
+**v2** — the merge engine and threshold enrollment.
+
+6. **HLC + merge engine:** upgrade the write-counter ordering authority to a hybrid logical
+   clock for human-readable `names` timestamps, add the LWW/earliest-burn/tombstone merge
+   rules in full, and fuzz/property-test the merge for commutativity and idempotence (merge
+   order must not matter). This is additive on top of step 2's write counter, not a format
+   break — see the ordering-authority note above.
+7. **k-of-n threshold enrollment:** Shamir-split enrollment key; extending the fleet requires
+   k approvals. Distinct from `k`-of-`n` *unlock*, which `MULTI_MACHINE_KEYING.md` demotes to a
+   rationale note rather than a roadmap item — this is enrollment governance, a different
+   property.
+
+#### Shipping posture
+
+Each v0 step above is independently mergeable and useful without the later ones existing —
+same posture as Phases 0–5 of this refactor. v0 does not need v1's revocation story or v2's
+merge engine to be a real, honest improvement over today's two-YubiKey-only vault: it already
+delivers "adopt with zero extra hardware" and "one vault across my own machines." Don't let the
+phase stall waiting for rotation atomicity (the largest open question, entirely a v1 concern)
+or the merge engine (v2) to be fully designed before shipping v0.
 
 #### Open questions to resolve before coding
 
-- **Clock model:** plain lamport is simplest but loses wall-clock intuition in `names`
-  output; HLC keeps human-readable timestamps at the cost of a few more bytes and a
-  monotonicity guard. Lean HLC.
-- **Keyring authenticity:** the keyring itself must be integrity-protected (signed by an
-  enrolled machine) so the transport cannot add a rogue slot; decide the signing key
-  (per-machine Ed25519 derived alongside `KEK_m`?) in step 3.
 - **`K_names` provenance:** deriving the filename-HMAC key from `K_v` means a rotation
-  (step 4) renames every record; deriving it from a separate, non-rotated fleet constant
-  avoids mass renames but must never be reconstructible without fleet membership.
-- **Filename identity vs edit-timing privacy** (from the per-file security notes):
-  deterministic `HMAC(name)` filenames keep merge simple but let a transport observer
-  track per-secret edit patterns; randomised filenames + internal record-ids hide that at
-  the cost of compaction. Pick one before writing the format. Padding (item 1) and
-  per-record keys (item 3) are settled — apply both regardless of this choice.
+  (v1, step 4) renames every record; deriving it from a separate, non-rotated fleet constant
+  avoids mass renames but must never be reconstructible without fleet membership. Does not
+  gate v0 (no rotation yet) — see `MULTI_MACHINE_KEYING.md` §Open questions.
+- **Delete-wins vs. last-writer-wins for tombstones:** see the mergeable-format section above.
+  Leaning delete-wins for v0 — order-independent, no clock needed, cannot silently resurrect a
+  deleted secret.
 - **Interaction with export/import:** the existing encrypted single-file export stays as
   the backup/transfer format; `IVaultStore` makes "export = serialize whatever store is
   active" fall out naturally.
+- **Rotation atomicity (v1, not v0) — the largest open design question in the whole phase.**
+  A partially rotated record directory syncing against another, not-yet-rotated copy needs a
+  rotation generation per record, a merge rule tolerating mixed generations mid-rotation, and
+  resumability if interrupted. Must be fully settled before step 4 writes a single rotated
+  record — this is a byte-layout decision, not an implementation detail, and it is exactly the
+  kind of thing that cannot be retrofitted once v1 vaults exist. See
+  `MULTI_MACHINE_KEYING.md` §Deferred to v1.
+- **Keyring authenticity / fleet signing key** — deferred to v1; see
+  `MULTI_MACHINE_KEYING.md` §Deferred to v1 for the settled reasoning (a fleet signing key
+  `K_s`, not a per-slot signature) and why AAD binding, not a keyring signature, is the
+  *primary* defense against threshold downgrade even before v1 lands.
 
-Like the refactor itself, this warrants a standalone `MULTI_MACHINE_PLAN.md` with the
-threat model, exact byte layouts, and the enrollment/revocation protocols fully specified
-**before** any code — the crypto details (AEAD choice, nonce discipline under
-concurrent writers, rotation atomicity) are where the risk lives.
+Filename determinism, padding, and per-record keys are **settled** (see the mergeable-format
+section above) — the open items above are what remain before v1/v2 code, not v0. Much of the
+groundwork a standalone design doc would otherwise need to establish first now lives directly
+in `MULTI_MACHINE_KEYING.md` (the v0 byte-layout gate: record types, the write-counter ordering
+authority, deterministic filenames, the per-slot X25519 keypair) — what's left before v0 code
+is writing golden-byte-layout tests against those four decisions and settling the two leaning
+items above.
 
 ---
 


### PR DESCRIPTION
## Summary

Folds the settled decisions from a 2026-07-27 design review session into the three Phase 6 plan
docs, and files GitHub issues for the resulting v0/v1/v2 backlog (#111–#134).

- **Bare-keypair recovery slot, no PKI** — supersedes the earlier CSR/CA-issued-certificate
  design. Revocation cannot work for an offline recovery credential (no verifier in the loop),
  expiry is actively harmful on a break-glass credential, and chain validation is a new single
  point of failure. Custody of the private key is the only real control.
- **`k ≥ 2` unlock demoted** from near-term roadmap to a rationale note — no independent
  zero-friction second factor exists on any target platform today (surveyed and rejected: file
  keypair, LocalMachine/System keychain, macOS "Always Allow", GNOME Keyring/KWallet, no-touch
  YubiKey custody).
- **Extension implies decryption** — a governance-only "add machines but can't decrypt"
  credential isn't achievable without a separate signing key; `recoveryOnly` is accident
  prevention, not a security control.
- **Enforcement-location rule** — a barrier only matters if it's enforced by a different device
  (bound into AEAD associated data or a signature), not by the binary in the attacker's hands.
- **Two-layer slot wrap + per-slot X25519 keypair + AAD binding** — `IHardwareKeyService` needs
  no interface change; backends already return the 32 bytes this design needs.
- **v0/v1/v2 scope split** — v0 (per-secret records + `k=1` keyring + hand-carried enrolment, no
  revocation/rotation/merge engine) is now clearly separated from v1 (revocation, rotation,
  transport-borne enrolment) and v2 (merge engine, threshold enrolment), so the phase can ship
  incrementally instead of stalling on rotation atomicity or the merge engine.

`MULTI_MACHINE_KEYING.md` is substantially restructured. `REFACTORING_PLAN.md` §Phase 6 gets a
matching v0/v1/v2 implementation ordering, tombstone/write-counter record details, and settles
filename determinism (previously listed as open). `HARDWARE_BACKENDS.md`'s Phase 6 pointer
section is reworded from future to present tense, plus a forward note on the unversioned
wire-format caveat and reframing TPM PIN/PCR as standalone hardening rather than a threshold
ingredient.

## Related issues

Filed alongside this PR: #111–#125 (v0, five gate items + ten non-gate), #126–#131 (v1),
#132–#134 (v2/backlog). #135 (this doc-edit ticket itself) is already closed, referencing this
branch.

## Test plan

- [ ] Docs-only change — no code touched, no build/test impact.
- [ ] Review that the recovery-slot and `k ≥ 2` reversals read as settled decisions, not just
      appended caveats, and don't contradict earlier sections left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)