### PR TITLE
Phase 6 v0: per-secret record binary format (#111-#115)

### DIFF
--- a/TswapCore/Keyring/FilenameHasher.cs
+++ b/TswapCore/Keyring/FilenameHasher.cs
@@ -1,0 +1,59 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// Deterministic per-secret filenames (issue #114): <c>HMAC(K_names, secretName)</c>, hex
+/// encoded. This is what lets two synced copies of the same secret recognise each other as the
+/// same record without either side ever writing the plaintext name to disk — the property the
+/// per-secret record split (issue #112) depends on for mergeability.
+///
+/// <para><b>Settled, not open</b> (see <c>REFACTORING_PLAN.md</c> §Phase 6, "per-file security
+/// considerations", item 2, and <c>MULTI_MACHINE_KEYING.md</c>): deterministic filenames were
+/// chosen over randomizing the filename per write plus an internal record-id and a periodic
+/// compaction pass. Randomizing defeats which-secret correlation but not "an edit of about this
+/// size happened around now", and the compaction machinery needed to keep it bounded is real,
+/// ongoing complexity for a marginal privacy gain against tswap's actual threat model — a
+/// personal fleet syncing over a semi-trusted transport (git/Syncthing/Dropbox), not a hostile
+/// transport operator. Do not re-litigate this.</para>
+///
+/// <para><b>Accepted tradeoff — document this wherever the format is described to users:</b>
+/// because the filename is stable, a transport observer who cannot read any content can still
+/// see "the file with hash <c>abc123…</c> changed again at 14:03" — i.e. per-secret edit-timing
+/// patterns leak, even though the name and value do not. The old single-blob format only leaked
+/// "something changed" with no per-secret resolution. This is the price of mergeability.</para>
+///
+/// <para><b>Open, not gating v0:</b> where <c>K_names</c> itself comes from — derived from
+/// <c>K_v</c> (so a v1 rotation renames every record) versus a separate, non-rotated fleet
+/// constant (avoids mass renames, but must never be reconstructible without fleet membership) —
+/// is intentionally left to the caller. This type takes <c>K_names</c> as a plain
+/// <c>byte[]</c> and has no opinion on its provenance; see <c>MULTI_MACHINE_KEYING.md</c>
+/// §Open questions.</para>
+/// </summary>
+public static class FilenameHasher
+{
+    /// <summary>Byte length of <c>K_names</c> (HMAC-SHA256 key).</summary>
+    public const int KeyLength = 32;
+
+    /// <summary>
+    /// Computes the raw (non-hex) 32-byte record id for <paramref name="secretName"/> — the
+    /// same value <see cref="SecretRecord.RecordId"/> carries and <see cref="RecordKeyDerivation"/>
+    /// uses as its HKDF salt input, so the filename and the per-record key derivation are tied
+    /// to one shared identifier rather than two independently-computed ones.
+    /// </summary>
+    public static byte[] ComputeRecordId(byte[] kNames, string secretName)
+    {
+        if (kNames.Length != KeyLength)
+            throw new ArgumentException($"kNames must be {KeyLength} bytes", nameof(kNames));
+
+        return HMACSHA256.HashData(kNames, Encoding.UTF8.GetBytes(secretName));
+    }
+
+    /// <summary>Lowercase hex encoding of a record id, for use as an on-disk filename.</summary>
+    public static string ToFilename(byte[] recordId) => Convert.ToHexStringLower(recordId);
+
+    /// <summary>Convenience: <c>ToFilename(ComputeRecordId(kNames, secretName))</c>.</summary>
+    public static string ComputeFilename(byte[] kNames, string secretName)
+        => ToFilename(ComputeRecordId(kNames, secretName));
+}

--- a/TswapCore/Keyring/KeyringFormat.cs
+++ b/TswapCore/Keyring/KeyringFormat.cs
@@ -1,0 +1,50 @@
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// Shared constants for the Phase 6 per-secret record wire format (design: see
+/// <c>MULTI_MACHINE_KEYING.md</c> and <c>REFACTORING_PLAN.md</c> §Phase 6).
+///
+/// Deliberately fixed-binary, length-prefixed, explicitly-ordered — not
+/// <see cref="System.Text.Json"/>. JSON gives no byte-stability guarantee across versions or
+/// property reordering, and an incidental reordering would silently change every derived-key
+/// and AAD computation downstream, bricking every vault written in this format with no
+/// diagnosable cause. See <see cref="SecretRecordCodec"/> for the actual layout.
+///
+/// This is a NEW, separate format from the existing single-blob <see cref="Config"/> /
+/// <see cref="Storage"/> vault (config.json + secrets.json.enc) — it does not replace or
+/// change that format. Wiring a new <see cref="IVaultStore"/> implementation on top of this
+/// format is a later wave (#119/#124); this module only defines the bytes.
+/// </summary>
+public static class KeyringFormat
+{
+    /// <summary>
+    /// Format version of the per-secret record envelope (see <see cref="SecretRecordCodec"/>).
+    /// Present from day one (issue #111) so a v2 layout change is an additive new version
+    /// value, not a breaking rewrite of this constant's meaning.
+    /// </summary>
+    public const byte RecordFormatVersion = 1;
+
+    /// <summary>
+    /// 4-byte sanity marker at the start of every record file/blob. Distinguishes a
+    /// corrupted/truncated file or a wrong-format file from a genuine decode failure, and is
+    /// stable across format-version bumps (the version field, not the magic, carries version
+    /// information) so old and new readers agree on where the real header starts.
+    /// </summary>
+    public static readonly byte[] RecordMagic = "TSR1"u8.ToArray();
+
+    /// <summary>
+    /// Every record's plaintext is padded to the next multiple of this many bytes before
+    /// encryption (issue #113a), so raw ciphertext length reveals only a size bucket, not the
+    /// exact secret length — and so a <see cref="RecordType.Tombstone"/> or
+    /// <see cref="RecordType.Burned"/> record lands in the same buckets as a live
+    /// <see cref="RecordType.Value"/> record of similar padded size, making deletion/burn
+    /// events indistinguishable from ordinary edits by file size alone (issue #112).
+    /// </summary>
+    public const int PaddingBucketSize = 256;
+
+    /// <summary>Byte length of a record id (raw HMAC-SHA256 output — see <see cref="FilenameHasher"/>).</summary>
+    public const int RecordIdSize = 32;
+
+    /// <summary>Byte length of an origin id (opaque per-machine/per-slot tiebreak identifier).</summary>
+    public const int OriginIdSize = 16;
+}

--- a/TswapCore/Keyring/RecordKeyDerivation.cs
+++ b/TswapCore/Keyring/RecordKeyDerivation.cs
@@ -1,0 +1,53 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// Per-record key derivation (issue #113b): <c>HKDF(K_v, salt = recordId || writeCounter)</c>.
+///
+/// Splitting one vault into N independently-rewritten files (one per secret, see
+/// <see cref="FilenameHasher"/>) vastly enlarges the AES-GCM nonce-uniqueness surface versus the
+/// old single-blob format's one-fresh-nonce-per-save: N files rewritten independently and
+/// concurrently across machines, all under one key, makes nonce collision a real risk — and GCM
+/// nonce reuse under one key is catastrophic (loses both confidentiality and forgeability, for
+/// every record under that key, not just the colliding pair). Deriving a distinct key per
+/// record instead bounds each key to exactly one (record, write) pair, so even a nonce
+/// collision across two different records is a collision between independent keys, not a
+/// classic GCM nonce-reuse break. It also makes <c>K_v</c> rotation (v1) cleaner, since
+/// rotating the root key is one derivation-input change rather than a re-encrypt tied to nonce
+/// bookkeeping.
+/// </summary>
+public static class RecordKeyDerivation
+{
+    /// <summary>
+    /// Domain-separation label for the HKDF "info" parameter, so this derivation can never
+    /// collide with some other future use of <c>K_v</c> in an HKDF call over the same
+    /// (recordId, writeCounter) input space.
+    /// </summary>
+    private static readonly byte[] Info = Encoding.UTF8.GetBytes("tswap-record-key-v1");
+
+    /// <summary>Derived key length in bytes (AES-256).</summary>
+    public const int KeyLength = 32;
+
+    /// <summary>
+    /// Derives the AES-256-GCM key for one record write. <paramref name="recordId"/> must be
+    /// the raw (non-hex) <see cref="KeyringFormat.RecordIdSize"/>-byte identifier — the same
+    /// bytes used as the filename hash (see <see cref="FilenameHasher"/>) — and
+    /// <paramref name="writeCounter"/> the write that is about to be (or was) encrypted.
+    /// </summary>
+    public static byte[] Derive(byte[] vaultKey, byte[] recordId, ulong writeCounter)
+    {
+        if (vaultKey.Length != KeyLength)
+            throw new ArgumentException($"vaultKey must be {KeyLength} bytes", nameof(vaultKey));
+        if (recordId.Length != KeyringFormat.RecordIdSize)
+            throw new ArgumentException($"recordId must be {KeyringFormat.RecordIdSize} bytes", nameof(recordId));
+
+        var salt = new byte[recordId.Length + sizeof(ulong)];
+        recordId.CopyTo(salt, 0);
+        BinaryPrimitives.WriteUInt64LittleEndian(salt.AsSpan(recordId.Length), writeCounter);
+
+        return HKDF.DeriveKey(HashAlgorithmName.SHA256, vaultKey, KeyLength, salt: salt, info: Info);
+    }
+}

--- a/TswapCore/Keyring/RecordType.cs
+++ b/TswapCore/Keyring/RecordType.cs
@@ -1,0 +1,29 @@
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// The three per-secret record kinds (issue #112). A delete or burn is a <b>record</b>, not an
+/// absent file: without an explicit tombstone, machine A deletes a secret, machine B still has
+/// the old file, and a sync merge silently resurrects it — worse for <see cref="Burned"/>,
+/// where resurrection destroys the incident record the burn exists to create.
+///
+/// Encoded as a single byte inside the encrypted payload (see <see cref="SecretRecordCodec"/>)
+/// — deliberately <b>not</b> a cleartext envelope field, so a transport observer cannot tell a
+/// tombstone/burn from an ordinary edit without the vault key. That, combined with size-bucket
+/// padding (issue #113a), is what makes tombstones indistinguishable from live records by
+/// looking at the file alone.
+/// </summary>
+public enum RecordType : byte
+{
+    /// <summary>A live secret value.</summary>
+    Value = 0,
+
+    /// <summary>
+    /// The secret was deleted. Retained (not an absent file) so sync can't resurrect it.
+    /// </summary>
+    Tombstone = 1,
+
+    /// <summary>
+    /// The secret was burned (marked compromised/seen). Carries the burn reason as its value.
+    /// </summary>
+    Burned = 2,
+}

--- a/TswapCore/Keyring/SecretRecord.cs
+++ b/TswapCore/Keyring/SecretRecord.cs
@@ -1,0 +1,47 @@
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// One decoded per-secret record (issue #111/#112). This is the in-memory shape;
+/// <see cref="SecretRecordCodec"/> owns the exact on-disk byte layout.
+/// </summary>
+/// <param name="RecordId">
+/// Raw (non-hex) 32-byte identifier, shared with the filename hash (issue #114): both are
+/// <c>HMAC(K_names, secretName)</c>. Reusing the same bytes avoids inventing a second
+/// per-secret identifier, and lets the per-record key derivation (issue #113b) key off exactly
+/// the value that already ties two synced copies of the same secret together.
+/// </param>
+/// <param name="WriteCounter">
+/// The ordering authority (issue #112) — a per-item write counter, <b>not</b> a wall-clock
+/// timestamp. Combined with <paramref name="OriginId"/> as a tiebreak, this is a Lamport clock:
+/// UTC timestamps are unsafe across machines (clock skew, VM suspend/resume, manual clock
+/// changes), but a counter+id pair is not, and it makes v2's HLC work an additive refinement
+/// rather than a format break. Also feeds the per-record key derivation (issue #113b), which is
+/// why it must be readable <i>before</i> decryption — see <see cref="SecretRecordCodec"/>.
+/// </param>
+/// <param name="OriginId">
+/// Opaque 16-byte id of the machine/slot that produced this write — the tiebreak half of the
+/// ordering authority, and the "last-writer id" a future generation-counter feature (issue
+/// #118, not implemented here) can reuse rather than inventing its own field.
+/// </param>
+/// <param name="Timestamp">
+/// Wall-clock time for <b>human display only</b> (e.g. <c>names</c> output) — never consulted
+/// for ordering. See <see cref="WriteCounter"/> for why.
+/// </param>
+/// <param name="Type">Which of the three record kinds this is (issue #112).</param>
+/// <param name="Value">
+/// Type-dependent payload: the secret bytes for <see cref="RecordType.Value"/>, empty for
+/// <see cref="RecordType.Tombstone"/>, the burn reason for <see cref="RecordType.Burned"/>.
+/// </param>
+/// <param name="GenerationCounter">
+/// Reserved, always 0 in this format version. Placeholder field for the vault generation
+/// counter (issue #118, a later wave) so that feature lands as an additive use of an
+/// already-present field rather than a header layout change.
+/// </param>
+public sealed record SecretRecord(
+    byte[] RecordId,
+    ulong WriteCounter,
+    byte[] OriginId,
+    DateTimeOffset Timestamp,
+    RecordType Type,
+    byte[] Value,
+    uint GenerationCounter = 0);

--- a/TswapCore/Keyring/SecretRecordCodec.cs
+++ b/TswapCore/Keyring/SecretRecordCodec.cs
@@ -1,0 +1,154 @@
+using System.Buffers.Binary;
+
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// Encodes/decodes one <see cref="SecretRecord"/> to/from the Phase 6 per-secret record wire
+/// format (issues #111-#113). Fixed-binary, explicitly ordered — see
+/// <see cref="KeyringFormat"/> for why this is not JSON.
+///
+/// <para><b>On-disk layout</b> (all multi-byte integers little-endian):</para>
+/// <code>
+/// Cleartext envelope:
+///   magic            4 bytes   "TSR1" (KeyringFormat.RecordMagic)
+///   formatVersion    1 byte    KeyringFormat.RecordFormatVersion
+///   recordId         32 bytes  HMAC(K_names, secretName) — see FilenameHasher
+///   writeCounter     8 bytes   ordering authority; MUST be cleartext, see below
+///   payloadLength    4 bytes   length in bytes of the section that follows
+///   payload          payloadLength bytes  AES-256-GCM: nonce(12) | tag(16) | ciphertext
+///
+/// Encrypted payload (ciphertext, once decrypted), padded to the next multiple of
+/// KeyringFormat.PaddingBucketSize before encryption (issue #113a):
+///   recordType         1 byte    RecordType
+///   originId           16 bytes  ordering tiebreak / last-writer id
+///   timestampUnixMs    8 bytes   display-only, see SecretRecord.Timestamp
+///   generationCounter  4 bytes   reserved (issue #118), always 0 today
+///   valueLength        4 bytes   real length of the value that follows (pre-padding)
+///   value              valueLength bytes
+///   [zero padding to the bucket boundary]
+/// </code>
+///
+/// <para><b>Why <c>recordType</c> lives inside the encrypted payload, not the cleartext
+/// envelope:</b> per <c>REFACTORING_PLAN.md</c> §Phase 6, "record type is part of the payload" —
+/// keeping it encrypted means a transport observer sees the same shape (magic, version,
+/// recordId, writeCounter, a ciphertext of some bucketed length) for a value write, a delete,
+/// and a burn. Only the padding bucket is visible, per issue #113a; the record kind is not.</para>
+///
+/// <para><b>Why <c>writeCounter</c> must be cleartext despite that:</b> the per-record key is
+/// <c>HKDF(K_v, salt = recordId || writeCounter)</c> (issue #113b), so a reader needs
+/// <c>writeCounter</c> to derive the key before it can decrypt anything — it cannot itself be
+/// inside the thing it helps decrypt. This is a deliberate, spec-driven exception, not an
+/// oversight: it also means an on-path attacker cannot tamper with the cleartext
+/// <c>writeCounter</c> without the derived key changing and authentication failing, which is a
+/// free integrity property of this construction, not something bolted on separately (formal AAD
+/// binding is out of scope here — see issue #117, which is about the keyring's slot AEAD, not
+/// per-record envelopes).</para>
+/// </summary>
+public static class SecretRecordCodec
+{
+    // magic(4) + formatVersion(1) + recordId(32) + writeCounter(8) + payloadLength(4)
+    private const int EnvelopeHeaderSize = 4 + 1 + KeyringFormat.RecordIdSize + 8 + 4;
+
+    // recordType(1) + originId(16) + timestamp(8) + generationCounter(4) + valueLength(4)
+    private const int InnerHeaderSize = 1 + KeyringFormat.OriginIdSize + 8 + 4 + 4;
+
+    /// <summary>
+    /// Encrypts and encodes <paramref name="record"/> under the per-record key derived from
+    /// <paramref name="vaultKey"/> (<c>K_v</c>) via <see cref="RecordKeyDerivation"/>.
+    /// </summary>
+    public static byte[] Encode(SecretRecord record, byte[] vaultKey)
+    {
+        if (record.RecordId.Length != KeyringFormat.RecordIdSize)
+            throw new ArgumentException($"RecordId must be {KeyringFormat.RecordIdSize} bytes", nameof(record));
+        if (record.OriginId.Length != KeyringFormat.OriginIdSize)
+            throw new ArgumentException($"OriginId must be {KeyringFormat.OriginIdSize} bytes", nameof(record));
+
+        var rawInner = InnerHeaderSize + record.Value.Length;
+        var bucketed = BucketSize(rawInner);
+        var inner = new byte[bucketed]; // zero-initialized: the padding tail is all zero bytes
+
+        inner[0] = (byte)record.Type;
+        record.OriginId.CopyTo(inner, 1);
+        BinaryPrimitives.WriteInt64LittleEndian(inner.AsSpan(17, 8), record.Timestamp.ToUnixTimeMilliseconds());
+        BinaryPrimitives.WriteUInt32LittleEndian(inner.AsSpan(25, 4), record.GenerationCounter);
+        BinaryPrimitives.WriteUInt32LittleEndian(inner.AsSpan(29, 4), (uint)record.Value.Length);
+        record.Value.CopyTo(inner, InnerHeaderSize);
+
+        var perRecordKey = RecordKeyDerivation.Derive(vaultKey, record.RecordId, record.WriteCounter);
+        var encryptedPayload = Crypto.Encrypt(inner, perRecordKey);
+
+        var result = new byte[EnvelopeHeaderSize + encryptedPayload.Length];
+        var span = result.AsSpan();
+        KeyringFormat.RecordMagic.CopyTo(span);
+        span[4] = KeyringFormat.RecordFormatVersion;
+        record.RecordId.CopyTo(span.Slice(5, KeyringFormat.RecordIdSize));
+        BinaryPrimitives.WriteUInt64LittleEndian(span.Slice(5 + KeyringFormat.RecordIdSize, 8), record.WriteCounter);
+        BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(13 + KeyringFormat.RecordIdSize, 4), (uint)encryptedPayload.Length);
+        encryptedPayload.CopyTo(span.Slice(EnvelopeHeaderSize));
+        return result;
+    }
+
+    /// <summary>
+    /// Decodes and decrypts a record previously produced by <see cref="Encode"/>. Throws
+    /// <see cref="TswapException"/> with a distinct message for each of: too-short input, bad
+    /// magic, unsupported format version, a corrupt/overflowing length prefix, and truncated
+    /// payload — deliberately separate from whatever <see cref="Crypto.Decrypt"/> throws for a
+    /// wrong key or tampered ciphertext, so the two classes of failure aren't conflated.
+    /// </summary>
+    public static SecretRecord Decode(byte[] bytes, byte[] vaultKey)
+    {
+        if (bytes.Length < EnvelopeHeaderSize)
+            throw new TswapException("Malformed record: shorter than the envelope header");
+
+        if (!bytes.AsSpan(0, 4).SequenceEqual(KeyringFormat.RecordMagic))
+            throw new TswapException("Malformed record: bad magic bytes");
+
+        var formatVersion = bytes[4];
+        if (formatVersion != KeyringFormat.RecordFormatVersion)
+            throw new TswapException($"Unsupported record format version: {formatVersion}");
+
+        var recordId = bytes.AsSpan(5, KeyringFormat.RecordIdSize).ToArray();
+        var writeCounter = BinaryPrimitives.ReadUInt64LittleEndian(bytes.AsSpan(5 + KeyringFormat.RecordIdSize, 8));
+        var payloadLength = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(13 + KeyringFormat.RecordIdSize, 4));
+
+        // Subtraction-based bounds check (not "EnvelopeHeaderSize + payloadLength > bytes.Length"):
+        // a payloadLength near uint.MaxValue would overflow an addition-based check and pass when
+        // it shouldn't, reaching an allocation sized by attacker-controlled length.
+        if (payloadLength > bytes.Length - EnvelopeHeaderSize)
+            throw new TswapException("Malformed record: payload length prefix exceeds available data");
+
+        var encryptedPayload = bytes.AsSpan(EnvelopeHeaderSize, (int)payloadLength).ToArray();
+        var perRecordKey = RecordKeyDerivation.Derive(vaultKey, recordId, writeCounter);
+        var inner = Crypto.Decrypt(encryptedPayload, perRecordKey);
+
+        if (inner.Length < InnerHeaderSize)
+            throw new TswapException("Malformed record: decrypted payload shorter than the inner header");
+
+        var type = (RecordType)inner[0];
+        var originId = inner.AsSpan(1, KeyringFormat.OriginIdSize).ToArray();
+        var timestampMs = BinaryPrimitives.ReadInt64LittleEndian(inner.AsSpan(17, 8));
+        var generationCounter = BinaryPrimitives.ReadUInt32LittleEndian(inner.AsSpan(25, 4));
+        var valueLength = BinaryPrimitives.ReadUInt32LittleEndian(inner.AsSpan(29, 4));
+
+        if (valueLength > inner.Length - InnerHeaderSize)
+            throw new TswapException("Malformed record: value length prefix exceeds decrypted payload");
+
+        var value = inner.AsSpan(InnerHeaderSize, (int)valueLength).ToArray();
+
+        return new SecretRecord(recordId, writeCounter, originId, DateTimeOffset.FromUnixTimeMilliseconds(timestampMs), type, value, generationCounter);
+    }
+
+    /// <summary>
+    /// Rounds <paramref name="rawLength"/> up to the next multiple of
+    /// <see cref="KeyringFormat.PaddingBucketSize"/>, with a floor of one full bucket (an empty
+    /// tombstone still occupies a whole bucket, not a zero-length one, per issue #113a).
+    /// </summary>
+    internal static int BucketSize(int rawLength)
+    {
+        if (rawLength <= 0)
+            return KeyringFormat.PaddingBucketSize;
+
+        var bucket = KeyringFormat.PaddingBucketSize;
+        return ((rawLength + bucket - 1) / bucket) * bucket;
+    }
+}

--- a/TswapCore/Keyring/SecretRecordCodec.cs
+++ b/TswapCore/Keyring/SecretRecordCodec.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Security.Cryptography;
 
 namespace TswapCore.Keyring;
 
@@ -91,9 +92,10 @@ public static class SecretRecordCodec
     /// <summary>
     /// Decodes and decrypts a record previously produced by <see cref="Encode"/>. Throws
     /// <see cref="TswapException"/> with a distinct message for each of: too-short input, bad
-    /// magic, unsupported format version, a corrupt/overflowing length prefix, and truncated
-    /// payload — deliberately separate from whatever <see cref="Crypto.Decrypt"/> throws for a
-    /// wrong key or tampered ciphertext, so the two classes of failure aren't conflated.
+    /// magic, unsupported format version, a corrupt/overflowing length prefix, a payload too
+    /// short to hold AES-GCM's fixed nonce+tag overhead, and truncated payload — deliberately
+    /// separate from whatever <see cref="Crypto.Decrypt"/> throws for a wrong key or tampered
+    /// ciphertext, so the two classes of failure aren't conflated.
     /// </summary>
     public static SecretRecord Decode(byte[] bytes, byte[] vaultKey)
     {
@@ -116,6 +118,14 @@ public static class SecretRecordCodec
         // it shouldn't, reaching an allocation sized by attacker-controlled length.
         if (payloadLength > bytes.Length - EnvelopeHeaderSize)
             throw new TswapException("Malformed record: payload length prefix exceeds available data");
+
+        // A payloadLength can be internally consistent with the file's remaining bytes (passing
+        // the check above) yet still be too small to hold AES-GCM's fixed nonce+tag overhead —
+        // without this check, Crypto.Decrypt would throw a raw ArgumentOutOfRangeException while
+        // slicing out the nonce instead of a catchable TswapException.
+        var minPayloadSize = AesGcm.NonceByteSizes.MaxSize + AesGcm.TagByteSizes.MaxSize;
+        if (payloadLength < minPayloadSize)
+            throw new TswapException("Malformed record: payload too short to contain a valid encrypted payload");
 
         var encryptedPayload = bytes.AsSpan(EnvelopeHeaderSize, (int)payloadLength).ToArray();
         var perRecordKey = RecordKeyDerivation.Derive(vaultKey, recordId, writeCounter);

--- a/TswapCore/Keyring/SlotKeyPair.cs
+++ b/TswapCore/Keyring/SlotKeyPair.cs
@@ -1,0 +1,79 @@
+using RebexCurve25519 = Rebex.Security.Cryptography.Curve25519;
+
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// A keyring slot's X25519 keypair (issue #115). Every slot gets one of these: the private half
+/// is meant to eventually be wrapped by that slot's own hardware-backed <c>KEK_slot</c> (issue
+/// #116, a later wave — <b>not implemented here</b>), the public half is stored in the keyring
+/// in the clear.
+///
+/// <code>
+/// unlock: hardware -&gt; KEK_slot -&gt; slot private key -&gt; K_v
+/// </code>
+///
+/// In exchange, any holder of <c>K_v</c> can write a fresh slot for any enrolled device
+/// offline — including YubiKey slots, which otherwise have no public key to encrypt to
+/// (challenge-response yields only a symmetric KEK, never a keypair). This is also what the
+/// hand-carried enrollment exchange (<c>slot request</c>/<c>approve</c>/<c>accept</c>, issue
+/// #121, a later wave) trades between machines.
+///
+/// <para><b>Why this gates v0 specifically</b> (see <c>MULTI_MACHINE_KEYING.md</c> §Per-slot
+/// X25519 keypair): every other v0 format decision migrates mechanically later — read with the
+/// old key, rewrite with the new, one pass, no ceremony. This is the one exception: retrofitting
+/// it after the fact would need every enrolled device physically present again, which for a
+/// YubiKey or a recovery keypair sitting in a drawer in another country is a migration that
+/// never actually happens. This type only defines the keypair's shape and how to generate one;
+/// the wrap/unwrap flow and the slot request/approve/accept commands are explicitly out of
+/// scope here (issues #116 and #121).</para>
+///
+/// <para><b>Curve choice / dependency:</b> the .NET BCL has no built-in X25519 as of this SDK
+/// (its ECDH support covers only NIST curves). <c>Rebex.Elliptic.Curve25519</c> is a small,
+/// pure-managed (no native/P-Invoke) port of D.J. Bernstein's reference implementation — chosen
+/// over a libsodium binding specifically so this adds no NativeAOT publish complexity (no native
+/// binary per OS/arch to bundle), unlike the existing hardware backends' unavoidable native
+/// shims.</para>
+/// </summary>
+public sealed record SlotKeyPair(byte[] PublicKey, byte[] PrivateKey)
+{
+    /// <summary>Byte length of both the public and private key.</summary>
+    public const int KeySize = 32;
+
+    /// <summary>
+    /// Generates a fresh, randomly-clamped X25519 keypair. Each call produces an independent
+    /// keypair — callers enrolling a new slot call this once and persist both halves per the
+    /// keyring's slot schema (public in the clear, private destined for hardware wrapping by a
+    /// later wave).
+    /// </summary>
+    public static SlotKeyPair Generate()
+    {
+        var curve = new RebexCurve25519();
+        // GetPrivateKey() triggers the library's internal EnsurePrivateKey(), which generates
+        // and RFC-7748-clamps 32 random bytes on first use and caches them; GetPublicKey() then
+        // reuses that same cached private key rather than generating a second, unrelated one.
+        var privateKey = curve.GetPrivateKey();
+        var publicKey = curve.GetPublicKey();
+        return new SlotKeyPair(publicKey, privateKey);
+    }
+
+    /// <summary>
+    /// Computes the X25519 shared secret between <paramref name="privateKey"/> and
+    /// <paramref name="peerPublicKey"/>. Exposed here so this module's own tests can verify the
+    /// keys <see cref="Generate"/> produces are standard, interoperable X25519 material (see the
+    /// RFC 7748 known-answer test), and so a later wave (issue #116) doesn't need to
+    /// reintroduce this curve dependency — this method is <b>not itself</b> the wrap/unwrap
+    /// flow, just the underlying Diffie-Hellman primitive.
+    ///
+    /// <paramref name="privateKey"/> must already be RFC-7748-clamped, as any key returned by
+    /// <see cref="Generate"/> is; raw external randomness (e.g. from a known-answer test vector)
+    /// must be clamped by the caller first — <c>Rebex.Elliptic.Curve25519</c> does this
+    /// internally only for its own randomly-generated keys, not for keys supplied via
+    /// <c>FromPrivateKey</c>.
+    /// </summary>
+    public static byte[] ComputeSharedSecret(byte[] privateKey, byte[] peerPublicKey)
+    {
+        var curve = new RebexCurve25519();
+        curve.FromPrivateKey(privateKey);
+        return curve.GetSharedSecret(peerPublicKey);
+    }
+}

--- a/TswapCore/TswapCore.csproj
+++ b/TswapCore/TswapCore.csproj
@@ -11,6 +11,18 @@
   </ItemGroup>
 
   <!--
+    Phase 6 keyring (per-slot X25519 keypair, see Keyring/SlotKeyPair.cs): as of this SDK,
+    System.Security.Cryptography has no built-in X25519 (BCL ECDH only covers NIST curves).
+    Rebex.Elliptic.Curve25519 is a small, dependency-free, pure-managed (no P/Invoke) port of
+    D.J. Bernstein's reference Curve25519 implementation (Apache-2.0) — chosen over a libsodium
+    binding (e.g. NSec) specifically because it needs no native binary per OS/arch, so it adds
+    no NativeAOT publish complexity beyond what the existing hardware-backend shims already have.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Rebex.Elliptic.Curve25519" Version="1.2.2" />
+  </ItemGroup>
+
+  <!--
     Secure Enclave backend (macOS only): Vault/Interop/swift/TswapSecureEnclave.swift is a
     thin CryptoKit shim, compiled here into a dylib and copied next to the managed output —
     AppleSecureEnclaveInterop.cs P/Invokes into it. See that file's header comment for why a

--- a/TswapTests/FilenameHasherTests.cs
+++ b/TswapTests/FilenameHasherTests.cs
@@ -1,0 +1,78 @@
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Golden-value tests for the deterministic filename scheme (issue #114):
+/// <c>HMAC(K_names, secretName)</c>, hex-encoded. The expected hex below was independently
+/// computed with OpenSSL (<c>printf '%s' "github-token" | openssl dgst -sha256 -mac HMAC
+/// -macopt hexkey:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f</c>), not
+/// merely captured from this code's own output, so this pins the wire format against an
+/// independent HMAC-SHA256 implementation rather than just locking in whatever .NET happens to
+/// produce.
+/// </summary>
+public class FilenameHasherTests
+{
+    private static readonly byte[] KNames = Convert.FromHexString("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+
+    [Fact]
+    public void ComputeRecordId_MatchesIndependentlyComputedHmac()
+    {
+        var recordId = FilenameHasher.ComputeRecordId(KNames, "github-token");
+
+        Assert.Equal("1b82240342ab424d628060349762c02e4332cda59b361036c7e5f0c80f47cfde", Convert.ToHexStringLower(recordId));
+    }
+
+    [Fact]
+    public void ComputeFilename_IsLowercaseHexOfRecordId()
+    {
+        var filename = FilenameHasher.ComputeFilename(KNames, "github-token");
+
+        Assert.Equal("1b82240342ab424d628060349762c02e4332cda59b361036c7e5f0c80f47cfde", filename);
+        Assert.DoesNotContain(filename, c => char.IsUpper(c));
+    }
+
+    [Fact]
+    public void ComputeRecordId_Returns32Bytes()
+    {
+        var recordId = FilenameHasher.ComputeRecordId(KNames, "anything");
+
+        Assert.Equal(32, recordId.Length);
+    }
+
+    [Fact]
+    public void ComputeRecordId_Deterministic()
+    {
+        var a = FilenameHasher.ComputeRecordId(KNames, "aws-secret");
+        var b = FilenameHasher.ComputeRecordId(KNames, "aws-secret");
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void ComputeRecordId_DifferentNamesDifferentIds()
+    {
+        var a = FilenameHasher.ComputeRecordId(KNames, "aws-secret");
+        var b = FilenameHasher.ComputeRecordId(KNames, "gcp-secret");
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void ComputeRecordId_DifferentKeysDifferentIds()
+    {
+        var otherKey = Convert.FromHexString("1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100");
+
+        var a = FilenameHasher.ComputeRecordId(KNames, "aws-secret");
+        var b = FilenameHasher.ComputeRecordId(otherKey, "aws-secret");
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void ComputeRecordId_WrongKeyLengthThrows()
+    {
+        Assert.Throws<ArgumentException>(() => FilenameHasher.ComputeRecordId(new byte[16], "name"));
+    }
+}

--- a/TswapTests/RecordKeyDerivationTests.cs
+++ b/TswapTests/RecordKeyDerivationTests.cs
@@ -1,0 +1,92 @@
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Golden-value tests for the per-record key derivation (issue #113b):
+/// <c>HKDF-SHA256(K_v, salt = recordId || writeCounter(LE64), info = "tswap-record-key-v1")</c>.
+///
+/// The expected hex below was independently computed with OpenSSL's HKDF KDF (<c>openssl kdf
+/// -keylen 32 -kdfopt digest:SHA256 -kdfopt hexkey:&lt;ikm&gt; -kdfopt hexsalt:&lt;salt&gt;
+/// -kdfopt hexinfo:&lt;info&gt; HKDF</c>), not merely captured from this code's own output —
+/// this pins both the algorithm (standard RFC 5869 HKDF) and this format's specific
+/// salt/info encoding convention (recordId immediately followed by the 8-byte little-endian
+/// write counter; the fixed "tswap-record-key-v1" domain-separation info string) against an
+/// independent implementation.
+/// </summary>
+public class RecordKeyDerivationTests
+{
+    private static readonly byte[] VaultKey = Convert.FromHexString("202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f");
+    private static readonly byte[] RecordId = Convert.FromHexString("0101010101010101010101010101010101010101010101010101010101010101");
+
+    [Fact]
+    public void Derive_MatchesIndependentlyComputedHkdf()
+    {
+        var key = RecordKeyDerivation.Derive(VaultKey, RecordId, writeCounter: 7);
+
+        Assert.Equal("18ff83e2b3390eef6c1d5fc49f40ab6e5cf4d7e4108027749d253bcfde2e74c1", Convert.ToHexStringLower(key));
+    }
+
+    [Fact]
+    public void Derive_Returns32Bytes()
+    {
+        var key = RecordKeyDerivation.Derive(VaultKey, RecordId, writeCounter: 0);
+
+        Assert.Equal(32, key.Length);
+    }
+
+    [Fact]
+    public void Derive_Deterministic()
+    {
+        var a = RecordKeyDerivation.Derive(VaultKey, RecordId, writeCounter: 42);
+        var b = RecordKeyDerivation.Derive(VaultKey, RecordId, writeCounter: 42);
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void Derive_DifferentWriteCountersDifferentKeys()
+    {
+        // The core nonce-uniqueness-surface mitigation (issue #113b): rewriting the same
+        // secret must not reuse the same AES-GCM key.
+        var a = RecordKeyDerivation.Derive(VaultKey, RecordId, writeCounter: 1);
+        var b = RecordKeyDerivation.Derive(VaultKey, RecordId, writeCounter: 2);
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Derive_DifferentRecordIdsDifferentKeys()
+    {
+        var otherRecordId = Convert.FromHexString("0202020202020202020202020202020202020202020202020202020202020202");
+
+        var a = RecordKeyDerivation.Derive(VaultKey, RecordId, writeCounter: 1);
+        var b = RecordKeyDerivation.Derive(VaultKey, otherRecordId, writeCounter: 1);
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Derive_DifferentVaultKeysDifferentKeys()
+    {
+        var otherVaultKey = Convert.FromHexString("3f3e3d3c3b3a393837363534333231302f2e2d2c2b2a29282726252423222120");
+
+        var a = RecordKeyDerivation.Derive(VaultKey, RecordId, writeCounter: 1);
+        var b = RecordKeyDerivation.Derive(otherVaultKey, RecordId, writeCounter: 1);
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Derive_WrongVaultKeyLengthThrows()
+    {
+        Assert.Throws<ArgumentException>(() => RecordKeyDerivation.Derive(new byte[16], RecordId, writeCounter: 0));
+    }
+
+    [Fact]
+    public void Derive_WrongRecordIdLengthThrows()
+    {
+        Assert.Throws<ArgumentException>(() => RecordKeyDerivation.Derive(VaultKey, new byte[10], writeCounter: 0));
+    }
+}

--- a/TswapTests/SecretRecordCodecTests.cs
+++ b/TswapTests/SecretRecordCodecTests.cs
@@ -192,6 +192,26 @@ public class SecretRecordCodecTests
     }
 
     [Fact]
+    public void Decode_PayloadShorterThanAesGcmOverheadThrowsDistinctError()
+    {
+        // A payloadLength that is internally consistent with the array's actual remaining bytes
+        // (so it passes the existing bounds check) but smaller than AES-GCM's fixed 12-byte
+        // nonce + 16-byte tag overhead must not reach Crypto.Decrypt, which would throw a raw
+        // ArgumentOutOfRangeException while slicing out the nonce instead of a catchable
+        // TswapException.
+        var record = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, "x"u8.ToArray());
+        var encoded = SecretRecordCodec.Encode(record, VaultKey);
+
+        // Forge a record whose payload is only 5 bytes — well under the 28-byte AES-GCM minimum
+        // — and whose total length (49 header + 5) matches that payloadLength exactly.
+        var forged = encoded[..54];
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(forged.AsSpan(45, 4), 5);
+
+        var ex = Assert.Throws<TswapException>(() => SecretRecordCodec.Decode(forged, VaultKey));
+        Assert.Contains("payload", ex.Message);
+    }
+
+    [Fact]
     public void Decode_TruncatedPayloadThrows()
     {
         var record = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, "x"u8.ToArray());

--- a/TswapTests/SecretRecordCodecTests.cs
+++ b/TswapTests/SecretRecordCodecTests.cs
@@ -1,0 +1,266 @@
+using TswapCore;
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Golden-byte tests for the per-secret record wire format (issues #111-#113) — pinning the
+/// exact envelope and inner-payload layout <see cref="SecretRecordCodec"/> documents, not just
+/// round-tripping encode/decode. The envelope's cleartext fields (magic, format version,
+/// recordId, writeCounter, payload length) are fully deterministic and asserted byte-exact.
+/// The encrypted payload's plaintext (the "inner payload": type, originId, timestamp,
+/// generation counter, value, then zero padding to the bucket boundary) is also deterministic
+/// given fixed inputs, so it is independently decrypted here (bypassing
+/// <see cref="SecretRecordCodec.Decode"/>) and asserted byte-exact too. Only the AES-GCM
+/// nonce/tag are necessarily random and therefore not pinned — pinning them would be wrong for
+/// an AEAD scheme, not merely untested.
+/// </summary>
+public class SecretRecordCodecTests
+{
+    private static readonly byte[] VaultKey = Convert.FromHexString("202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f");
+    private static readonly byte[] RecordId = Convert.FromHexString("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    private static readonly byte[] OriginId = new byte[16];
+    private static readonly DateTimeOffset Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000);
+
+    static SecretRecordCodecTests()
+    {
+        Array.Fill(OriginId, (byte)0xAA);
+    }
+
+    // Independently computed (Python, struct.pack) plaintext for: type=Value(0), the fixed
+    // OriginId/Timestamp/GenerationCounter=0 above, value=UTF8("hello"), padded with zeros to
+    // the 256-byte bucket. See SecretRecordCodec's layout doc comment for the field ordering.
+    private const string ExpectedValueInnerHex = "00aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0068e5cf8b010000000000000500000068656c6c6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+    [Fact]
+    public void Encode_EnvelopeHeaderIsExactAndDeterministic()
+    {
+        var record = new SecretRecord(RecordId, WriteCounter: 5, OriginId, Timestamp, RecordType.Value, "hello"u8.ToArray());
+
+        var encoded = SecretRecordCodec.Encode(record, VaultKey);
+
+        // magic "TSR1" + formatVersion(1) + recordId(32) + writeCounter=5 LE(8) + payloadLength
+        // = nonce(12)+tag(16)+ciphertext(256) = 284 = 0x011C LE(4).
+        var expectedHeader = Convert.FromHexString(
+            "54535231" + "01" +
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" +
+            "0500000000000000" +
+            "1c010000");
+
+        Assert.Equal(expectedHeader, encoded[..49]);
+        Assert.Equal(49 + 284, encoded.Length);
+    }
+
+    [Fact]
+    public void Encode_DecryptedInnerPayloadMatchesGoldenBytesExactly()
+    {
+        var record = new SecretRecord(RecordId, WriteCounter: 5, OriginId, Timestamp, RecordType.Value, "hello"u8.ToArray());
+        var encoded = SecretRecordCodec.Encode(record, VaultKey);
+
+        var perRecordKey = RecordKeyDerivation.Derive(VaultKey, RecordId, writeCounter: 5);
+        var encryptedPayload = encoded[49..];
+        var inner = Crypto.Decrypt(encryptedPayload, perRecordKey);
+
+        Assert.Equal(256, inner.Length);
+        Assert.Equal(ExpectedValueInnerHex, Convert.ToHexStringLower(inner));
+    }
+
+    [Fact]
+    public void EncodeDecode_RoundTripsAllFields()
+    {
+        var record = new SecretRecord(RecordId, WriteCounter: 5, OriginId, Timestamp, RecordType.Value, "hello"u8.ToArray(), GenerationCounter: 0);
+
+        var encoded = SecretRecordCodec.Encode(record, VaultKey);
+        var decoded = SecretRecordCodec.Decode(encoded, VaultKey);
+
+        Assert.Equal(record.RecordId, decoded.RecordId);
+        Assert.Equal(record.WriteCounter, decoded.WriteCounter);
+        Assert.Equal(record.OriginId, decoded.OriginId);
+        Assert.Equal(record.Timestamp, decoded.Timestamp);
+        Assert.Equal(record.Type, decoded.Type);
+        Assert.Equal(record.Value, decoded.Value);
+        Assert.Equal(record.GenerationCounter, decoded.GenerationCounter);
+    }
+
+    [Fact]
+    public void EncodeDecode_RoundTripsNonZeroGenerationCounter()
+    {
+        // The field is reserved/unused today (issue #118 is a later wave), but the codec must
+        // still carry an arbitrary value through correctly so that feature is additive later.
+        var record = new SecretRecord(RecordId, WriteCounter: 3, OriginId, Timestamp, RecordType.Value, "v"u8.ToArray(), GenerationCounter: 42);
+
+        var decoded = SecretRecordCodec.Decode(SecretRecordCodec.Encode(record, VaultKey), VaultKey);
+
+        Assert.Equal(42u, decoded.GenerationCounter);
+    }
+
+    [Theory]
+    [InlineData(RecordType.Value)]
+    [InlineData(RecordType.Tombstone)]
+    [InlineData(RecordType.Burned)]
+    public void EncodeDecode_RoundTripsEveryRecordType(RecordType type)
+    {
+        var record = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, type, "payload"u8.ToArray());
+
+        var decoded = SecretRecordCodec.Decode(SecretRecordCodec.Encode(record, VaultKey), VaultKey);
+
+        Assert.Equal(type, decoded.Type);
+    }
+
+    [Fact]
+    public void Encode_TombstoneAndSmallValueRecordProduceTheSameFileSize()
+    {
+        // Issue #112: a tombstone must not be distinguishable from a live record by file size.
+        var value = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, "hello"u8.ToArray());
+        var tombstone = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Tombstone, []);
+
+        var valueEncoded = SecretRecordCodec.Encode(value, VaultKey);
+        var tombstoneEncoded = SecretRecordCodec.Encode(tombstone, VaultKey);
+
+        Assert.Equal(valueEncoded.Length, tombstoneEncoded.Length);
+    }
+
+    [Fact]
+    public void Encode_RecordTypeIsNotVisibleInCleartext()
+    {
+        // Issue #112: record type lives inside the encrypted payload, not a cleartext field —
+        // a transport observer must not be able to tell a tombstone from a value write.
+        var value = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, "x"u8.ToArray());
+        var burned = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Burned, "x"u8.ToArray());
+
+        var valueEncoded = SecretRecordCodec.Encode(value, VaultKey);
+        var burnedEncoded = SecretRecordCodec.Encode(burned, VaultKey);
+
+        // Cleartext envelope (everything but the AEAD payload) is byte-identical.
+        Assert.Equal(valueEncoded[..49], burnedEncoded[..49]);
+    }
+
+    [Theory]
+    [InlineData(0, 256)]
+    [InlineData(1, 256)]
+    [InlineData(255, 256)]
+    [InlineData(256, 256)]
+    [InlineData(257, 512)]
+    [InlineData(512, 512)]
+    [InlineData(513, 768)]
+    public void BucketSize_RoundsUpToNextMultipleWithOneBucketFloor(int rawLength, int expectedBucket)
+    {
+        Assert.Equal(expectedBucket, SecretRecordCodec.BucketSize(rawLength));
+    }
+
+    [Fact]
+    public void Decode_TooShortThrowsDistinctError()
+    {
+        var ex = Assert.Throws<TswapException>(() => SecretRecordCodec.Decode(new byte[10], VaultKey));
+        Assert.Contains("header", ex.Message);
+    }
+
+    [Fact]
+    public void Decode_BadMagicThrowsDistinctError()
+    {
+        var record = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, "x"u8.ToArray());
+        var encoded = SecretRecordCodec.Encode(record, VaultKey);
+        encoded[0] ^= 0xFF;
+
+        var ex = Assert.Throws<TswapException>(() => SecretRecordCodec.Decode(encoded, VaultKey));
+        Assert.Contains("magic", ex.Message);
+    }
+
+    [Fact]
+    public void Decode_UnsupportedFormatVersionThrowsDistinctError()
+    {
+        var record = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, "x"u8.ToArray());
+        var encoded = SecretRecordCodec.Encode(record, VaultKey);
+        encoded[4] = 99;
+
+        var ex = Assert.Throws<TswapException>(() => SecretRecordCodec.Decode(encoded, VaultKey));
+        Assert.Contains("format version", ex.Message);
+    }
+
+    [Fact]
+    public void Decode_HugePayloadLengthPrefixThrowsInsteadOfOverflowing()
+    {
+        // Mirrors SecureEnclaveHardwareServiceTests' overflow guard: a payloadLength near
+        // uint.MaxValue must not pass an addition-based bounds check via integer overflow.
+        var record = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, "x"u8.ToArray());
+        var encoded = SecretRecordCodec.Encode(record, VaultKey);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(encoded.AsSpan(45, 4), uint.MaxValue - 1);
+
+        var ex = Assert.Throws<TswapException>(() => SecretRecordCodec.Decode(encoded, VaultKey));
+        Assert.Contains("length prefix", ex.Message);
+    }
+
+    [Fact]
+    public void Decode_TruncatedPayloadThrows()
+    {
+        var record = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, "x"u8.ToArray());
+        var encoded = SecretRecordCodec.Encode(record, VaultKey);
+        var truncated = encoded[..^1];
+
+        Assert.Throws<TswapException>(() => SecretRecordCodec.Decode(truncated, VaultKey));
+    }
+
+    [Fact]
+    public void Decode_TamperedCiphertextThrows()
+    {
+        var record = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, "hello"u8.ToArray());
+        var encoded = SecretRecordCodec.Encode(record, VaultKey);
+        encoded[^1] ^= 0xFF;
+
+        Assert.ThrowsAny<Exception>(() => SecretRecordCodec.Decode(encoded, VaultKey));
+    }
+
+    [Fact]
+    public void Decode_TamperedCleartextWriteCounterFailsAuthentication()
+    {
+        // Demonstrates the free integrity property from the codec's doc comment: writeCounter
+        // feeds the per-record key derivation, so an on-path attacker flipping the cleartext
+        // writeCounter (without also re-deriving and re-encrypting) makes the reader derive a
+        // different key, which fails the AEAD tag check — no separate AAD binding needed for
+        // this specific field's integrity.
+        var record = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, "hello"u8.ToArray());
+        var encoded = SecretRecordCodec.Encode(record, VaultKey);
+        // writeCounter occupies bytes [37, 45) of the envelope header.
+        encoded[37] ^= 0xFF;
+
+        Assert.ThrowsAny<Exception>(() => SecretRecordCodec.Decode(encoded, VaultKey));
+    }
+
+    [Fact]
+    public void Decode_WrongVaultKeyThrows()
+    {
+        var record = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, "hello"u8.ToArray());
+        var encoded = SecretRecordCodec.Encode(record, VaultKey);
+        var wrongKey = new byte[32];
+
+        Assert.ThrowsAny<Exception>(() => SecretRecordCodec.Decode(encoded, wrongKey));
+    }
+
+    [Fact]
+    public void Encode_WrongRecordIdLengthThrows()
+    {
+        var record = new SecretRecord(new byte[10], WriteCounter: 1, OriginId, Timestamp, RecordType.Value, []);
+        Assert.Throws<ArgumentException>(() => SecretRecordCodec.Encode(record, VaultKey));
+    }
+
+    [Fact]
+    public void Encode_WrongOriginIdLengthThrows()
+    {
+        var record = new SecretRecord(RecordId, WriteCounter: 1, new byte[4], Timestamp, RecordType.Value, []);
+        Assert.Throws<ArgumentException>(() => SecretRecordCodec.Encode(record, VaultKey));
+    }
+
+    [Fact]
+    public void Encode_LargeValueCrossesIntoNextBucket()
+    {
+        var smallValue = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, new byte[1]);
+        var largeValue = new SecretRecord(RecordId, WriteCounter: 1, OriginId, Timestamp, RecordType.Value, new byte[300]);
+
+        var smallEncoded = SecretRecordCodec.Encode(smallValue, VaultKey);
+        var largeEncoded = SecretRecordCodec.Encode(largeValue, VaultKey);
+
+        Assert.Equal(49 + 12 + 16 + 256, smallEncoded.Length);
+        Assert.Equal(49 + 12 + 16 + 512, largeEncoded.Length);
+    }
+}

--- a/TswapTests/SlotKeyPairTests.cs
+++ b/TswapTests/SlotKeyPairTests.cs
@@ -1,0 +1,97 @@
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Tests for the per-slot X25519 keypair (issue #115) — keypair generation and its underlying
+/// Diffie-Hellman primitive only. The wrap/unwrap flow that will eventually protect the private
+/// half with a slot's hardware-backed KEK is issue #116, a later wave, and is not implemented or
+/// tested here.
+/// </summary>
+public class SlotKeyPairTests
+{
+    // RFC 7748 §6.1 X25519 test vector: an independent, published known-answer test proving
+    // the key material this type generates is standard, interoperable X25519 — not merely
+    // "whatever this library's Generate() happens to produce round-trips with itself."
+    // https://www.rfc-editor.org/rfc/rfc7748#section-6.1
+    private const string RfcAlicePrivateHex = "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a";
+    private const string RfcAlicePublicHex = "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a";
+    private const string RfcBobPrivateHex = "5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb";
+    private const string RfcBobPublicHex = "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f";
+    private const string RfcSharedSecretHex = "4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742";
+
+    // RFC 7748's test private keys are the raw scalar input to X25519(), which clamps
+    // internally (§5); Rebex.Elliptic.Curve25519's GetPublicKey/GetSharedSecret require an
+    // already-clamped key (its own random-generation path clamps for you, but FromPrivateKey
+    // does not), so the known-answer test below clamps by hand per the RFC 7748 §5 recipe.
+    private static byte[] Clamp(byte[] key)
+    {
+        key[0] &= 0xF8;
+        key[31] &= 0x7F;
+        key[31] |= 0x40;
+        return key;
+    }
+
+    [Fact]
+    public void ComputeSharedSecret_MatchesRfc7748KnownAnswerTest()
+    {
+        var alicePrivate = Clamp(Convert.FromHexString(RfcAlicePrivateHex));
+        var bobPrivate = Clamp(Convert.FromHexString(RfcBobPrivateHex));
+
+        var alicePublic = SlotKeyPair.ComputeSharedSecret(alicePrivate, PublicBasePoint());
+        var bobPublic = SlotKeyPair.ComputeSharedSecret(bobPrivate, PublicBasePoint());
+
+        Assert.Equal(RfcAlicePublicHex, Convert.ToHexStringLower(alicePublic));
+        Assert.Equal(RfcBobPublicHex, Convert.ToHexStringLower(bobPublic));
+
+        var sharedFromAlice = SlotKeyPair.ComputeSharedSecret(alicePrivate, bobPublic);
+        var sharedFromBob = SlotKeyPair.ComputeSharedSecret(bobPrivate, alicePublic);
+
+        Assert.Equal(RfcSharedSecretHex, Convert.ToHexStringLower(sharedFromAlice));
+        Assert.Equal(RfcSharedSecretHex, Convert.ToHexStringLower(sharedFromBob));
+    }
+
+    // The X25519 base point u=9, encoded little-endian over 32 bytes — RFC 7748 §6.1's
+    // "X25519(a, 9)" input, used here to derive each party's public key from their private key.
+    private static byte[] PublicBasePoint()
+    {
+        var basePoint = new byte[32];
+        basePoint[0] = 9;
+        return basePoint;
+    }
+
+    [Fact]
+    public void Generate_ReturnsDistinctThirtyTwoByteKeys()
+    {
+        var slot = SlotKeyPair.Generate();
+
+        Assert.Equal(32, slot.PublicKey.Length);
+        Assert.Equal(32, slot.PrivateKey.Length);
+        Assert.NotEqual(slot.PublicKey, slot.PrivateKey);
+    }
+
+    [Fact]
+    public void Generate_ProducesFreshKeypairEachCall()
+    {
+        var first = SlotKeyPair.Generate();
+        var second = SlotKeyPair.Generate();
+
+        Assert.NotEqual(first.PublicKey, second.PublicKey);
+        Assert.NotEqual(first.PrivateKey, second.PrivateKey);
+    }
+
+    [Fact]
+    public void Generate_KeypairIsValidForKeyAgreement()
+    {
+        // The public key Generate() returns must actually be X25519(privateKey, basepoint) —
+        // i.e. a real, usable keypair, not two unrelated random byte blobs.
+        var alice = SlotKeyPair.Generate();
+        var bob = SlotKeyPair.Generate();
+
+        var sharedFromAlice = SlotKeyPair.ComputeSharedSecret(alice.PrivateKey, bob.PublicKey);
+        var sharedFromBob = SlotKeyPair.ComputeSharedSecret(bob.PrivateKey, alice.PublicKey);
+
+        Assert.Equal(sharedFromAlice, sharedFromBob);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the byte-layout gate items for Phase 6 v0's mergeable per-secret record format, per `MULTI_MACHINE_KEYING.md` and `REFACTORING_PLAN.md` §Phase 6. Covers #111, #112, #113, #114, #115 as one coherent format module (they share one on-disk layout, so splitting them into separate PRs risked reinventing incompatible pieces of the same header).

New module: `TswapCore/Keyring/` — fixed-binary, length-prefixed, explicitly-ordered wire format (deliberately not `System.Text.Json`, since incidental property reordering would silently change derived-key inputs with no diagnosable failure).

- **`KeyringFormat`** — shared constants: `formatVersion` (present from day one, #111), a 4-byte magic, and the 256-byte padding bucket size.
- **`RecordType` / `SecretRecord`** — the three record kinds (`Value`/`Tombstone`/`Burned`, #112). Ordering authority is a write counter + origin-id tiebreak (a Lamport clock), never a wall-clock timestamp — a timestamp field exists but is display-only. A `GenerationCounter` field is reserved (always 0) so #118 lands additively rather than as a header change.
- **`SecretRecordCodec`** — the actual wire layout. Record type/originId/timestamp/generationCounter live *inside* the encrypted payload, not a cleartext field, so a transport observer can't distinguish a tombstone/burn from an ordinary edit by looking at the file. The cleartext envelope is only `magic | formatVersion | recordId | writeCounter | payloadLength`. `writeCounter` has to stay cleartext despite that, because it feeds the per-record key derivation (below) — a reader needs it to derive the key before it can decrypt anything. That has a nice side effect: tampering with the cleartext `writeCounter` changes the derived key and fails AEAD authentication for free, with no separate AAD binding needed for that one field (AAD binding proper is #117, out of scope here). Every record (including tombstones) is padded to the next 256-byte bucket before encryption (#113a), so tombstones land in the same size buckets as small live records.
- **`RecordKeyDerivation`** — `HKDF-SHA256(K_v, salt = recordId || writeCounter)` gives every record write its own AES-256-GCM key (#113b), bounding the nonce-uniqueness surface now that N files get rewritten independently and concurrently across machines under one root key.
- **`FilenameHasher`** — `HMAC(K_names, secretName)`, hex-encoded, deterministic (#114). `K_names` is taken as a plain `byte[]` parameter with no opinion on provenance (that's an explicitly open, non-gating question per the design doc).
- **`SlotKeyPair`** — per-slot X25519 keypair generation and shape only (#115). Uses `Rebex.Elliptic.Curve25519` (pure-managed, Apache-2.0 — chosen specifically because it adds no native binary per OS/arch, unlike a libsodium binding, since the BCL has no X25519 yet). Verified against the RFC 7748 §6.1 known-answer test vector.

## The delete-wins call (#112's open question)

Tombstones use **delete-wins**, not last-writer-wins, per the design doc's stated lean for v0: it's order-independent (no clock needed), a deleted secret can never be silently resurrected by a stale copy syncing back in, and the record stays recoverable either way (nothing is destroyed, since a tombstone is a retained record, not an absent file). This PR only defines the record *type* that makes delete-wins expressible correctly — the actual merge engine that applies this rule across two synced copies is v2 work (`REFACTORING_PLAN.md` §Phase 6 step 6), not implemented here.

## Explicitly NOT included (separate later waves — please don't expect these in review)

- Two-layer slot wrap / wrap-unwrap flow (#116)
- AAD binding of formatVersion/vaultId/k/slotId (#117)
- The generation-counter *feature* (#118) — only its header field is reserved
- `init`/`slot request`/`approve`/`accept` commands (#119, #121)
- `IVaultStore` wiring for this format (#119/#124)
- README updates (#125)

The existing single-blob `Config`/`Storage` format is untouched; this is new, additive code with no wiring into the CLI yet.

## Test plan

- [x] Golden-byte tests — not just round-trip — pinning the exact envelope header bytes, the decrypted inner-payload bytes, HKDF output, HMAC output, and the X25519 keypair primitive, each checked against an independently computed value (OpenSSL's HMAC-SHA256/HKDF KDF, the RFC 7748 text) rather than merely this code's own output.
- [x] `./runtests.sh --unit` passes (365/365).
- [x] `dotnet publish -c Release` for `TswapCli/TswapCli.csproj` succeeds (NativeAOT), with no new trim/AOT warnings from a clean build.
- [x] No changes to the existing `Config`/`Storage`/single-blob vault format.

References #111, #112, #113, #114, #115.