### PR TITLE
Move hardcoded master-key salt into Config.MasterKeySalt (#110)

### DIFF
--- a/TswapCli/Commands/InitCommand.cs
+++ b/TswapCli/Commands/InitCommand.cs
@@ -98,6 +98,13 @@ public sealed class InitCommand : ICliCommand
         var rngChoice = c.ReadLine()?.Trim();
         var rngMode = rngChoice == "2" ? RngMode.YubiKey : RngMode.System;
 
+        // Every fresh init gets its own random master-key salt rather than the legacy shared
+        // constant (see Crypto.MasterKeySalt) — init already mints a brand-new XOR share and
+        // challenge per vault, so doing the same for the salt is free and closes off the
+        // "every tswap vault uses the identical salt" property without touching any existing
+        // vault (those have no MasterKeySalt in config.json and keep using the constant).
+        var masterKeySalt = RandomNumberGenerator.GetBytes(32);
+
         // Save config
         var config = new Config(
             new List<int> { serial1, serial2 },
@@ -105,7 +112,8 @@ public sealed class InitCommand : ICliCommand
             DateTime.UtcNow,
             requiresTouch,
             rngMode,
-            unlockChallenge
+            unlockChallenge,
+            MasterKeySalt: Convert.ToBase64String(masterKeySalt)
         );
 
         // Re-initialisation generates a new master key (new challenge + new XOR share), so any
@@ -114,7 +122,7 @@ public sealed class InitCommand : ICliCommand
         // Config is backed up first — if anything fails mid-init the old config still matches
         // the old vault backup.
         var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
-        var newVaultKey = Crypto.DeriveKey(k1, k2);
+        var newVaultKey = Crypto.DeriveKey(k1, k2, masterKeySalt);
         if (File.Exists(ctx.Storage.ConfigFile))
         {
             var configBackup = ctx.Storage.ConfigFile + ".bak-" + timestamp;

--- a/TswapCore/Crypto.cs
+++ b/TswapCore/Crypto.cs
@@ -23,7 +23,14 @@ public static class Crypto
         return result;
     }
 
-    public static byte[] DeriveKey(byte[] k1, byte[] k2)
+    /// <summary>
+    /// Derives the vault master key from the two XOR-redundant YubiKey responses.
+    /// <paramref name="salt"/> is <see cref="Config.MasterKeySalt"/> (already base64-decoded
+    /// by the caller) when set; <c>null</c> falls back to the legacy hardcoded
+    /// <see cref="MasterKeySalt"/> constant, so existing vaults (which have no
+    /// <c>MasterKeySalt</c> in their config.json) keep deriving the identical key.
+    /// </summary>
+    public static byte[] DeriveKey(byte[] k1, byte[] k2, byte[]? salt = null)
     {
         var combined = new byte[k1.Length + k2.Length];
         k1.CopyTo(combined, 0);
@@ -31,7 +38,7 @@ public static class Crypto
 
         return Rfc2898DeriveBytes.Pbkdf2(
             combined,
-            MasterKeySalt,
+            salt ?? MasterKeySalt,
             Pbkdf2Iterations,
             HashAlgorithmName.SHA256,
             32

--- a/TswapCore/Models.cs
+++ b/TswapCore/Models.cs
@@ -68,7 +68,15 @@ public record Config(List<int> YubiKeySerials, string RedundancyXor, DateTime Cr
     // multi-machine keyring — irrelevant, so omitted, for other backends. Simulator/VM-only
     // status: see HARDWARE_BACKENDS.md's TPM sections before treating this as verified against
     // real hardware.
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? TpmSealedKey = null);
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? TpmSealedKey = null,
+    // Base64-encoded PBKDF2 salt for master-key derivation (see Crypto.DeriveKey). Null means
+    // "use the legacy hardcoded Crypto.MasterKeySalt constant" — every vault created before
+    // this field existed has no MasterKeySalt in its config.json and must keep deriving the
+    // exact same master key, so null here is not "unset" but a deliberate, permanent fallback.
+    // Set for vaults that opt into a random per-vault salt (currently: every vault created by
+    // a fresh 'tswap init' of the default YubiKey backend). Additive/backward-compatible,
+    // following the same pattern as SecureEnclaveWrappedKey/TpmSealedKey above.
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? MasterKeySalt = null);
 public record Secret(string Value, DateTime Created, DateTime Modified, DateTime? BurnedAt = null, string? BurnReason = null);
 public record SecretsDb(Dictionary<string, Secret> Secrets);
 

--- a/TswapCore/Vault/YubiKeyHardwareService.cs
+++ b/TswapCore/Vault/YubiKeyHardwareService.cs
@@ -58,7 +58,10 @@ public sealed class YubiKeyHardwareService(IYubiKeyService yubiKeys, byte[]? ove
             k2 = k_current;
         }
 
-        return Crypto.DeriveKey(k1, k2);
+        // Null means this config predates per-vault salts (or never opted in) and must keep
+        // deriving via the legacy hardcoded Crypto.MasterKeySalt constant — see Config.MasterKeySalt.
+        var salt = config.MasterKeySalt != null ? Convert.FromBase64String(config.MasterKeySalt) : null;
+        return Crypto.DeriveKey(k1, k2, salt);
     }
 
     /// <summary>

--- a/TswapTests/CryptoTests.cs
+++ b/TswapTests/CryptoTests.cs
@@ -96,6 +96,71 @@ public class CryptoTests
     }
 
     [Fact]
+    public void DeriveKey_NoSaltMatchesLegacyHardcodedSalt()
+    {
+        // The single hardest requirement in this change: every vault that exists today (no
+        // MasterKeySalt in its config.json) must derive the exact same master key after
+        // introducing the optional-salt overload as it did before. Pin the byte-for-byte
+        // output against the legacy hardcoded "tswap-poc-v1" salt directly, independent of
+        // Crypto's private constant, so a future accidental edit to that constant is caught.
+        var k1 = Encoding.UTF8.GetBytes("key-one-padded!!");
+        var k2 = Encoding.UTF8.GetBytes("key-two-padded!!");
+
+        var viaDefaultOverload = Crypto.DeriveKey(k1, k2);
+        var viaExplicitNullSalt = Crypto.DeriveKey(k1, k2, null);
+        byte[] combined = [.. k1, .. k2];
+        var viaHandRolledLegacySalt = Rfc2898DeriveBytes.Pbkdf2(
+            combined,
+            Encoding.UTF8.GetBytes("tswap-poc-v1"),
+            Crypto.Pbkdf2Iterations,
+            HashAlgorithmName.SHA256,
+            32);
+
+        Assert.Equal(viaHandRolledLegacySalt, viaDefaultOverload);
+        Assert.Equal(viaHandRolledLegacySalt, viaExplicitNullSalt);
+    }
+
+    [Fact]
+    public void DeriveKey_CustomSaltDiffersFromDefaultSalt()
+    {
+        var k1 = Encoding.UTF8.GetBytes("key-one-padded!!");
+        var k2 = Encoding.UTF8.GetBytes("key-two-padded!!");
+        var customSalt = RandomNumberGenerator.GetBytes(32);
+
+        var withDefaultSalt = Crypto.DeriveKey(k1, k2);
+        var withCustomSalt = Crypto.DeriveKey(k1, k2, customSalt);
+
+        Assert.NotEqual(withDefaultSalt, withCustomSalt);
+    }
+
+    [Fact]
+    public void DeriveKey_DifferentCustomSaltsProduceDifferentOutput()
+    {
+        var k1 = Encoding.UTF8.GetBytes("key-one-padded!!");
+        var k2 = Encoding.UTF8.GetBytes("key-two-padded!!");
+        var salt1 = RandomNumberGenerator.GetBytes(32);
+        var salt2 = RandomNumberGenerator.GetBytes(32);
+
+        var derived1 = Crypto.DeriveKey(k1, k2, salt1);
+        var derived2 = Crypto.DeriveKey(k1, k2, salt2);
+
+        Assert.NotEqual(derived1, derived2);
+    }
+
+    [Fact]
+    public void DeriveKey_CustomSaltIsDeterministic()
+    {
+        var k1 = Encoding.UTF8.GetBytes("key-one-padded!!");
+        var k2 = Encoding.UTF8.GetBytes("key-two-padded!!");
+        var salt = RandomNumberGenerator.GetBytes(32);
+
+        var derived1 = Crypto.DeriveKey(k1, k2, salt);
+        var derived2 = Crypto.DeriveKey(k1, k2, salt);
+
+        Assert.Equal(derived1, derived2);
+    }
+
+    [Fact]
     public void EncryptDecrypt_RoundTrip()
     {
         var key = RandomNumberGenerator.GetBytes(32);

--- a/TswapTests/ModelsTests.cs
+++ b/TswapTests/ModelsTests.cs
@@ -117,6 +117,44 @@ public class ModelsTests
     }
 
     [Fact]
+    public void Config_NullMasterKeySalt_IsOmittedFromJson()
+    {
+        // Same backward-compat guarantee as TpmSealedKey/SecureEnclaveWrappedKey: a vault
+        // that hasn't opted into a per-vault salt must serialize with no MasterKeySalt field
+        // at all, so every existing config.json on disk stays byte-for-byte unchanged.
+        var config = new Config([1, 2], "aabb", DateTime.UtcNow, RngMode: RngMode.System);
+        var json = JsonSerializer.Serialize(config, TswapJsonContext.Default.Config);
+        Assert.DoesNotContain("MasterKeySalt", json);
+        Assert.Null(config.MasterKeySalt);
+    }
+
+    [Fact]
+    public void Config_MasterKeySalt_RoundTrips()
+    {
+        var config = new Config([1, 2], "aabb", DateTime.UtcNow, MasterKeySalt: "c2FsdHNhbHQ=");
+        var json = JsonSerializer.Serialize(config, TswapJsonContext.Default.Config);
+        Assert.Contains("\"MasterKeySalt\": \"c2FsdHNhbHQ=\"", json);
+        Assert.Equal("c2FsdHNhbHQ=", JsonSerializer.Deserialize(json, TswapJsonContext.Default.Config)!.MasterKeySalt);
+    }
+
+    [Fact]
+    public void Config_LegacyJsonWithoutMasterKeySalt_DeserializesAsNull()
+    {
+        // A config from before this field existed has no MasterKeySalt key; it must load
+        // with MasterKeySalt == null, which Crypto.DeriveKey treats as "use the legacy
+        // hardcoded salt constant".
+        const string legacy = """
+            {
+              "YubiKeySerials": [11111111, 22222222],
+              "RedundancyXor": "00ff",
+              "Created": "2024-05-01T00:00:00Z"
+            }
+            """;
+        var config = JsonSerializer.Deserialize(legacy, TswapJsonContext.Default.Config)!;
+        Assert.Null(config.MasterKeySalt);
+    }
+
+    [Fact]
     public void ExportFile_VersionTag_Unchanged()
     {
         Assert.Equal("tswap-export-v1", ExportFile.CurrentVersion);

--- a/TswapTests/VaultUnlockerTests.cs
+++ b/TswapTests/VaultUnlockerTests.cs
@@ -73,6 +73,39 @@ public class VaultUnlockerTests
     }
 
     [Fact]
+    public void Unlock_WithMasterKeySalt_ProducesDifferentKeyThanLegacySalt()
+    {
+        // A vault with a per-vault MasterKeySalt set (see Config.MasterKeySalt) must derive
+        // its master key using that salt instead of the legacy hardcoded constant.
+        var (yubi, config, k1, k2) = MakeVault();
+        yubi.Connected = [11111111];
+        var salt = RandomNumberGenerator.GetBytes(32);
+        var saltedConfig = config with { MasterKeySalt = Convert.ToBase64String(salt) };
+
+        var keyWithSalt = new VaultUnlocker(yubi).Unlock(saltedConfig, NoSelection);
+        var expectedWithSalt = Crypto.DeriveKey(k1, k2, salt);
+        var expectedLegacy = Crypto.DeriveKey(k1, k2);
+
+        Assert.Equal(expectedWithSalt, keyWithSalt);
+        Assert.NotEqual(expectedLegacy, keyWithSalt);
+    }
+
+    [Fact]
+    public void Unlock_NullMasterKeySalt_MatchesLegacyDerivation()
+    {
+        // A config with no MasterKeySalt (every vault that exists today) must keep deriving
+        // via the legacy hardcoded Crypto.MasterKeySalt constant — the core backward-compat
+        // guarantee this feature depends on.
+        var (yubi, config, k1, k2) = MakeVault();
+        yubi.Connected = [11111111];
+        Assert.Null(config.MasterKeySalt);
+
+        var key = new VaultUnlocker(yubi).Unlock(config, NoSelection);
+
+        Assert.Equal(Crypto.DeriveKey(k1, k2), key);
+    }
+
+    [Fact]
     public void Unlock_LegacyConfigWithoutChallenge_UsesFixedChallenge()
     {
         var (yubi, config, _, _) = MakeVault();


### PR DESCRIPTION
## Summary

Closes #110. `Crypto.MasterKeySalt` was a hardcoded constant (`"tswap-poc-v1"`) shared by every tswap vault everywhere for master-key PBKDF2 derivation. This PR moves it into an optional, per-vault `Config.MasterKeySalt` field, following the exact additive pattern already used for `SecureEnclaveWrappedKey`/`TpmSealedKey`.

- `Config.MasterKeySalt` — new optional `string?` (base64), added last in the positional parameter list, `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]` so it's omitted from `config.json` when null and existing files stay byte-for-byte unchanged.
- `Crypto.DeriveKey(byte[] k1, byte[] k2, byte[]? salt = null)` — new optional third parameter. `salt ?? MasterKeySalt` internally. **The hardcoded `MasterKeySalt` constant and its value/comment are untouched.**
- `InitCommand.cs` (the default YubiKey init path — the only init variant that actually calls `Crypto.DeriveKey`; Secure Enclave and TPM init both generate a random vault key directly and never touch this salt) now generates a fresh `RandomNumberGenerator.GetBytes(32)` salt, stores it base64-encoded in the new config, and passes it into `DeriveKey`.
- `YubiKeyHardwareService.Unlock` decodes `config.MasterKeySalt` (or passes `null`) into `Crypto.DeriveKey` so both legacy and new vaults unlock correctly.

## Judgement call — please weigh in

The issue frames the opt-in as "new vaults, or via an explicit migrate-style opt-in for existing ones," without mandating a specific mechanism. I chose the minimal option: **every fresh `tswap init` (default YubiKey backend) now unconditionally gets a new random `MasterKeySalt`** — no new flag, no separate migrate command. Rationale: `init` already always mints a brand-new XOR share and unlock challenge for the new vault it creates, so generating a new salt alongside them is free and consistent with existing behavior, and it cannot affect any vault that already exists (those simply have no `MasterKeySalt` in their `config.json` and keep using the legacy constant, forever, unless someone hand-edits their config). There's no separate "migrate my existing vault to a fresh salt" path in this PR — re-running `init` already re-derives a brand-new key from a brand-new XOR share/challenge/salt, which is the existing re-init behavior, just now also salted. If a reviewer wants an explicit `migrate`-style command instead of (or in addition to) this default-on-init behavior, that's a small follow-up.

Note that Secure Enclave and TPM `init` paths don't use `Crypto.DeriveKey` at all (they generate `vaultKey = RandomNumberGenerator.GetBytes(32)` directly and wrap/seal it), so `MasterKeySalt` is a YubiKey-backend-only concept for now — nothing to change there.

## Backward compatibility

The hard requirement — every vault with no `MasterKeySalt` in its `config.json` must derive the exact same master key as before — is covered by `CryptoTests.DeriveKey_NoSaltMatchesLegacyHardcodedSalt`, which independently reconstructs the legacy PBKDF2 call (hand-rolled, not reusing `Crypto`'s internals) and asserts byte-for-byte equality against both `Crypto.DeriveKey(k1, k2)` and `Crypto.DeriveKey(k1, k2, null)`. Also covered end-to-end via `VaultUnlockerTests.Unlock_NullMasterKeySalt_MatchesLegacyDerivation`.

## Tests

- `TswapTests/CryptoTests.cs`: no-salt-matches-legacy (byte-for-byte), custom-salt-differs-from-default, two-different-custom-salts-differ, custom-salt-is-deterministic.
- `TswapTests/ModelsTests.cs`: `MasterKeySalt` omitted from JSON when null, round-trips when set, legacy JSON without the field deserializes to null.
- `TswapTests/VaultUnlockerTests.cs`: `Unlock` with a `MasterKeySalt` set produces a different (and correctly salt-derived) key than the legacy path; `Unlock` with no `MasterKeySalt` matches legacy derivation exactly.

## Test plan

- [x] `./runtests.sh --unit` passes in full (375/375)
- [x] `dotnet publish -c Release TswapCli/TswapCli.csproj` succeeds (NativeAOT tripwire)
- [x] `global.json` left unchanged (temporarily bumped to 10.0.301 locally to work around this sandbox's SDK availability, reverted before committing)

Does not touch `DeriveKeyFromPassphrase`/`Pbkdf2Iterations` (export KDF, #108) or `TswapCore/Keyring/` (Phase 6 record format), per the issue's stated scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)