### PR TITLE
Split file-path members off IVaultStore into IFileVaultStore

### DIFF
--- a/TswapCli/Commands/InitCommand.cs
+++ b/TswapCli/Commands/InitCommand.cs
@@ -16,7 +16,12 @@ public sealed class InitCommand : ICliCommand
     {
         var c = ctx.Console;
 
-        if (File.Exists(ctx.Storage.ConfigFile))
+        // Detecting an existing config to prompt about reinitializing (and, further
+        // down, backing it up before overwriting) is inherently file-store-specific;
+        // a future non-file backend needs its own equivalent, not this one.
+        var fileStore = ctx.Storage as IFileVaultStore;
+
+        if (fileStore != null && File.Exists(fileStore.ConfigFile))
         {
             c.Out.Write("Already initialized. Reinitialize? (yes/no): ");
             if (c.ReadLine()?.ToLower() != "yes")
@@ -44,7 +49,7 @@ public sealed class InitCommand : ICliCommand
                 Convert.ToHexString(RandomNumberGenerator.GetBytes(32))
             );
             ctx.Storage.SaveConfig(testConfig);
-            if (!File.Exists(ctx.Storage.SecretsFile))
+            if (fileStore == null || !File.Exists(fileStore.SecretsFile))
                 ctx.Storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), ctx.TestKey);
             c.Out.WriteLine("Initialized (test mode)");
             return 0;
@@ -115,16 +120,18 @@ public sealed class InitCommand : ICliCommand
         // the old vault backup.
         var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
         var newVaultKey = Crypto.DeriveKey(k1, k2);
-        if (File.Exists(ctx.Storage.ConfigFile))
+        // Backing up the previous config/vault before writing over it is a file-store
+        // safety net; a non-file backend would need its own equivalent, not this one.
+        if (fileStore != null && File.Exists(fileStore.ConfigFile))
         {
-            var configBackup = ctx.Storage.ConfigFile + ".bak-" + timestamp;
-            File.Copy(ctx.Storage.ConfigFile, configBackup);
+            var configBackup = fileStore.ConfigFile + ".bak-" + timestamp;
+            File.Copy(fileStore.ConfigFile, configBackup);
         }
         ctx.Storage.SaveConfig(config);
-        if (File.Exists(ctx.Storage.SecretsFile))
+        if (fileStore != null && File.Exists(fileStore.SecretsFile))
         {
-            var vaultBackup = ctx.Storage.SecretsFile + ".bak-" + timestamp;
-            File.Move(ctx.Storage.SecretsFile, vaultBackup);
+            var vaultBackup = fileStore.SecretsFile + ".bak-" + timestamp;
+            File.Move(fileStore.SecretsFile, vaultBackup);
             c.SetForeground(ConsoleColor.Yellow);
             c.Out.WriteLine($"\nExisting vault moved to backup: {vaultBackup}");
             c.Out.WriteLine("Previous config backed up alongside it. To recover old secrets:");
@@ -168,7 +175,10 @@ public sealed class InitCommand : ICliCommand
         c.Out.WriteLine("  [ ] Printed copy (home safe)");
         c.Out.WriteLine("  [ ] Second printed copy (off-site)");
         c.Out.WriteLine("  [ ] Git repository");
-        c.Out.WriteLine($"\nConfig saved to: {ctx.Storage.ConfigFile}");
+        if (fileStore != null)
+            c.Out.WriteLine($"\nConfig saved to: {fileStore.ConfigFile}");
+        else
+            c.Out.WriteLine("\nConfig saved.");
         return 0;
     }
 
@@ -213,16 +223,19 @@ public sealed class InitCommand : ICliCommand
             SecureEnclaveWrappedKey: Convert.ToBase64String(wrapped));
 
         var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
-        if (File.Exists(ctx.Storage.ConfigFile))
+        // Backing up the previous config/vault before writing over it is a file-store
+        // safety net; a non-file backend would need its own equivalent, not this one.
+        var fileStore = ctx.Storage as IFileVaultStore;
+        if (fileStore != null && File.Exists(fileStore.ConfigFile))
         {
-            var configBackup = ctx.Storage.ConfigFile + ".bak-" + timestamp;
-            File.Copy(ctx.Storage.ConfigFile, configBackup);
+            var configBackup = fileStore.ConfigFile + ".bak-" + timestamp;
+            File.Copy(fileStore.ConfigFile, configBackup);
         }
         ctx.Storage.SaveConfig(config);
-        if (File.Exists(ctx.Storage.SecretsFile))
+        if (fileStore != null && File.Exists(fileStore.SecretsFile))
         {
-            var vaultBackup = ctx.Storage.SecretsFile + ".bak-" + timestamp;
-            File.Move(ctx.Storage.SecretsFile, vaultBackup);
+            var vaultBackup = fileStore.SecretsFile + ".bak-" + timestamp;
+            File.Move(fileStore.SecretsFile, vaultBackup);
             c.SetForeground(ConsoleColor.Yellow);
             c.Out.WriteLine($"\nExisting vault moved to backup: {vaultBackup}");
             c.Out.WriteLine("Previous config backed up alongside it. To recover old secrets:");
@@ -235,7 +248,8 @@ public sealed class InitCommand : ICliCommand
         c.Out.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");
         c.Out.WriteLine("╚════════════════════════════════════════╝\n");
         c.Out.WriteLine("Backend: Secure Enclave (this Mac only)");
-        c.Out.WriteLine($"Config saved to: {ctx.Storage.ConfigFile}");
+        if (fileStore != null)
+            c.Out.WriteLine($"Config saved to: {fileStore.ConfigFile}");
         c.Out.WriteLine("\nThere is no backup share for this backend, unlike the YubiKey XOR share:");
         c.Out.WriteLine("the wrapped key in config.json is meaningless without this machine's");
         c.Out.WriteLine("physical Secure Enclave. Losing this Mac means losing this vault — back");
@@ -321,16 +335,19 @@ public sealed class InitCommand : ICliCommand
             TpmSealedKey: Convert.ToBase64String(sealedOrWrappedKey));
 
         var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
-        if (File.Exists(ctx.Storage.ConfigFile))
+        // Backing up the previous config/vault before writing over it is a file-store
+        // safety net; a non-file backend would need its own equivalent, not this one.
+        var fileStore = ctx.Storage as IFileVaultStore;
+        if (fileStore != null && File.Exists(fileStore.ConfigFile))
         {
-            var configBackup = ctx.Storage.ConfigFile + ".bak-" + timestamp;
-            File.Copy(ctx.Storage.ConfigFile, configBackup);
+            var configBackup = fileStore.ConfigFile + ".bak-" + timestamp;
+            File.Copy(fileStore.ConfigFile, configBackup);
         }
         ctx.Storage.SaveConfig(config);
-        if (File.Exists(ctx.Storage.SecretsFile))
+        if (fileStore != null && File.Exists(fileStore.SecretsFile))
         {
-            var vaultBackup = ctx.Storage.SecretsFile + ".bak-" + timestamp;
-            File.Move(ctx.Storage.SecretsFile, vaultBackup);
+            var vaultBackup = fileStore.SecretsFile + ".bak-" + timestamp;
+            File.Move(fileStore.SecretsFile, vaultBackup);
             c.SetForeground(ConsoleColor.Yellow);
             c.Out.WriteLine($"\nExisting vault moved to backup: {vaultBackup}");
             c.Out.WriteLine("Previous config backed up alongside it. To recover old secrets:");
@@ -343,7 +360,8 @@ public sealed class InitCommand : ICliCommand
         c.Out.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");
         c.Out.WriteLine("╚════════════════════════════════════════╝\n");
         c.Out.WriteLine("Backend: TPM (this machine only)");
-        c.Out.WriteLine($"Config saved to: {ctx.Storage.ConfigFile}");
+        if (fileStore != null)
+            c.Out.WriteLine($"Config saved to: {fileStore.ConfigFile}");
         c.Out.WriteLine("\nThere is no backup share for this backend, unlike the YubiKey XOR share:");
         c.Out.WriteLine("the sealed key in config.json is meaningless without this machine's");
         c.Out.WriteLine("physical TPM. Losing this machine (or clearing its TPM) means losing this");

--- a/TswapCore/IVaultStore.cs
+++ b/TswapCore/IVaultStore.cs
@@ -9,23 +9,13 @@ namespace TswapCore;
 /// this same contract, so the composition root can swap them without touching any
 /// command.
 ///
-/// The file-path members (<see cref="ConfigFile"/>, <see cref="SecretsFile"/>) are
-/// specific to file-backed stores and exist for the few commands that manage those
-/// files directly (e.g. <c>init</c> backups). Non-file backends are free to surface
-/// synthetic paths or throw; command logic that depends on them is a known
-/// file-store coupling to revisit when a second backend lands.
+/// Deliberately keyed by nothing more than "this store" — no filesystem path is
+/// assumed here, so a future blob or row store can implement this interface
+/// without adopting file-path semantics it doesn't have (see issue #124). Backends
+/// that really are file-backed additionally implement <see cref="IFileVaultStore"/>.
 /// </summary>
 public interface IVaultStore
 {
-    /// <summary>Directory holding this store's on-disk state.</summary>
-    string ConfigDir { get; }
-
-    /// <summary>Path to the config file (file-backed stores only).</summary>
-    string ConfigFile { get; }
-
-    /// <summary>Path to the encrypted secrets file (file-backed stores only).</summary>
-    string SecretsFile { get; }
-
     /// <summary>Loads and deserializes the vault config. Throws if not initialized.</summary>
     Config LoadConfig();
 
@@ -42,4 +32,26 @@ public interface IVaultStore
 
     /// <summary>Encrypts and persists the secrets database.</summary>
     void SaveSecrets(SecretsDb db, byte[] key);
+}
+
+/// <summary>
+/// An <see cref="IVaultStore"/> that is backed by plain files on disk, and is willing
+/// to say so. The three path members exist for the few commands that manage those
+/// files directly (e.g. <c>init</c> backing up the previous config/vault before
+/// re-initializing) — they are inherently file-store-specific, so they live here
+/// rather than on the base interface. A future non-file backend (blob store, row
+/// store) simply doesn't implement this interface, and command logic that wants a
+/// path narrows to it explicitly (typically via a pattern match) instead of assuming
+/// every <see cref="IVaultStore"/> has one.
+/// </summary>
+public interface IFileVaultStore : IVaultStore
+{
+    /// <summary>Directory holding this store's on-disk state.</summary>
+    string ConfigDir { get; }
+
+    /// <summary>Path to the config file.</summary>
+    string ConfigFile { get; }
+
+    /// <summary>Path to the encrypted secrets file.</summary>
+    string SecretsFile { get; }
 }

--- a/TswapCore/Storage.cs
+++ b/TswapCore/Storage.cs
@@ -7,8 +7,10 @@ namespace TswapCore;
 /// Default <see cref="IVaultStore"/>: the single-file backend (<c>config.json</c> +
 /// <c>secrets.json.enc</c>) that has always shipped with tswap. Writes go through an
 /// atomic temp-then-rename so a crash mid-write cannot destroy an existing file.
+/// Implements <see cref="IFileVaultStore"/> (not just the base interface) since it
+/// genuinely is file-backed and exposes the paths some commands need.
 /// </summary>
-public class Storage : IVaultStore
+public class Storage : IFileVaultStore
 {
     public string ConfigDir { get; }
     public string ConfigFile { get; }

--- a/TswapTests/StorageTests.cs
+++ b/TswapTests/StorageTests.cs
@@ -213,4 +213,20 @@ public class StorageTests : IDisposable
         Assert.Equal(new List<int> { 1, 2 }, store.LoadConfig().YubiKeySerials);
         Assert.Equal("v", store.LoadSecrets(_key).Secrets["k"].Value);
     }
+
+    [Fact]
+    public void Storage_ImplementsIFileVaultStore_PathsWorkAsBefore()
+    {
+        // Issue #124: the file-path members moved off the base IVaultStore interface
+        // onto the more specific IFileVaultStore, since a future non-file backend
+        // shouldn't be forced to have a filesystem path. Storage is genuinely
+        // file-backed, so it implements the narrower interface too, and the paths
+        // it reports must be unchanged from before the split.
+        Assert.IsAssignableFrom<IFileVaultStore>(_storage);
+
+        IFileVaultStore fileStore = _storage;
+        Assert.Equal(_tempDir, fileStore.ConfigDir);
+        Assert.Equal(Path.Combine(_tempDir, "config.json"), fileStore.ConfigFile);
+        Assert.Equal(Path.Combine(_tempDir, "secrets.json.enc"), fileStore.SecretsFile);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #124. `IVaultStore` (`TswapCore/IVaultStore.cs`) baked a filesystem-path assumption into its base interface via `ConfigDir`/`ConfigFile`/`SecretsFile`, which would need an interface break the moment a non-file backend (blob store, row store) shows up. This is a pure interface/type reshape — zero behavior change for the existing YubiKey/TPM/SecureEnclave vaults.

- Moved `ConfigDir`, `ConfigFile`, `SecretsFile` off the base `IVaultStore` interface onto a new `IFileVaultStore : IVaultStore` in the same file.
- `Storage` (the only implementation today) now implements `IFileVaultStore` instead of `IVaultStore` directly — its load/save behavior is completely untouched.
- `CommandContext.Storage` stays declared as `IVaultStore` (unchanged) — every command's `LoadConfig`/`SaveConfig`/`LoadSecrets`/`SaveSecrets` calls are unaffected.
- `InitCommand.cs`'s backup-before-reinit logic (and the "already initialized?" / "config saved to" messaging, which also referenced these members) now pattern-matches `ctx.Storage is IFileVaultStore fileStore` and silently skips the file-specific safety net when the store isn't file-backed, with a comment noting a future non-file backend needs its own equivalent.
- Did not touch `TswapCore/Keyring/` (separate, already-merged Phase 6 record-format work) or `Storage`'s actual persistence logic.
- Added `StorageTests.Storage_ImplementsIFileVaultStore_PathsWorkAsBefore` confirming `Storage` implements `IFileVaultStore` and its three path properties are unchanged.

## Test plan

- [x] `./runtests.sh --unit` — 367 passed, 0 failed
- [x] `dotnet build` for `TswapCore` and `TswapCli` (Release) — succeeds
- [x] `dotnet publish -c Release TswapCli/TswapCli.csproj` (NativeAOT) — succeeds
- [x] `global.json` left at its committed value (`10.0.302`); build/test were run against a temporarily-lowered local SDK version per this sandbox's documented workaround, then reverted before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)