### PR TITLE
Use rejection sampling for uniform password charset selection

### DIFF
--- a/TswapCli/Commands/CreateCommand.cs
+++ b/TswapCli/Commands/CreateCommand.cs
@@ -6,7 +6,20 @@ namespace TswapCli.Commands;
 
 public sealed class CreateCommand : ICliCommand
 {
-    private const string Charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+";
+    // internal (rather than private) so the rejection-sampling helpers below are unit-testable
+    // from TswapTests without needing a fake YubiKey/CommandContext.
+    internal const string Charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+";
+
+    // Largest multiple of Charset.Length that still fits in a byte (e.g. for a 76-char
+    // charset: 76 * 3 = 228). Source bytes >= this are rejected so every accepted byte maps
+    // onto the charset with exactly uniform probability (256 % Charset.Length != 0, so
+    // without rejection low charset indices would be measurably more likely than high ones).
+    // Computed from Charset.Length rather than hardcoded so it can never drift out of sync
+    // if Charset is ever edited.
+    private static readonly int RejectionCeiling = (256 / Charset.Length) * Charset.Length;
+
+    // HKDF-SHA256's hard output-length ceiling is 255 * hashLen = 255 * 32 = 8160 bytes.
+    private const int MaxHkdfOutputBytes = 255 * 32;
 
     public string Name => "create";
     public string HelpUsage => "create <name> [len]";
@@ -39,27 +52,25 @@ public sealed class CreateCommand : ICliCommand
         if (db.Secrets.ContainsKey(name))
             throw new TswapException($"Secret '{name}' already exists. Use 'delete' first to rotate.");
 
-        byte[] entropy;
+        char[] password;
         if (config.RngMode == RngMode.YubiKey && ctx.TestKey == null)
         {
             ctx.Console.Out.WriteLine("Touch YubiKey for entropy generation...");
             var entropySerial = ctx.SelectSerial();
             var challenge = RandomNumberGenerator.GetBytes(20);
             var hmac = ctx.YubiKeys.Challenge(entropySerial, Convert.ToHexString(challenge));
-            // Mix challenge + HMAC, then use HKDF to expand to exactly `length` bytes.
-            // This avoids the period-32 bias that SHA256 truncation would cause for
-            // passwords longer than 32 characters.
+            // Mix challenge + HMAC into fixed-length key material, then use HKDF (a
+            // deterministic expansion, not the CSPRNG directly) plus rejection sampling to
+            // turn it into unbiased charset characters. See DeriveYubiKeyChars.
             var ikm = SHA256.HashData([..challenge, ..hmac]);
-            entropy = HKDF.DeriveKey(HashAlgorithmName.SHA256, ikm, length, salt: null, info: Encoding.UTF8.GetBytes("tswap-create"));
+            password = DeriveYubiKeyChars(ikm, length);
         }
         else
         {
-            entropy = RandomNumberGenerator.GetBytes(length);
+            // Unbiased selection straight from the CSPRNG - the correct BCL primitive for
+            // "pick N items uniformly from a fixed set", so no manual modulo/rejection needed.
+            password = RandomNumberGenerator.GetItems<char>(Charset, length);
         }
-
-        var password = new char[length];
-        for (int i = 0; i < length; i++)
-            password[i] = Charset[entropy[i] % Charset.Length];
 
         var value = new string(password);
         db.Secrets[name] = new Secret(value, DateTime.UtcNow, DateTime.UtcNow);
@@ -68,5 +79,64 @@ public sealed class CreateCommand : ICliCommand
         ctx.Console.Out.WriteLine($"\n✓ Secret '{name}' created ({length} chars)");
         ctx.Console.Out.WriteLine("  Value was NOT displayed. Use 'run' to substitute it into commands.");
         return 0;
+    }
+
+    /// <summary>
+    /// Expands YubiKey-derived key material (<paramref name="ikm"/>) into <paramref name="length"/>
+    /// unbiased characters from <see cref="Charset"/> via HKDF + rejection sampling.
+    /// <para>
+    /// Unlike the system-RNG path, <c>ikm</c> is not itself a CSPRNG stream - it's fixed-length
+    /// derived material from a single YubiKey touch - so <see cref="RandomNumberGenerator.GetItems"/>
+    /// doesn't apply here. Instead we expand it with HKDF and reject-sample bytes >= <see
+    /// cref="RejectionCeiling"/> (see that constant for why) before taking <c>byte % Charset.Length</c>
+    /// of an accepted byte.
+    /// </para>
+    /// <para>
+    /// A little over an eighth of derived bytes are rejected ((256 - RejectionCeiling) / 256),
+    /// so we over-provision the HKDF output (up to 4x, capped at HKDF-SHA256's max output
+    /// length) to make running out of bytes astronomically unlikely. In the negligible case
+    /// that still happens, we derive one more
+    /// chunk with a distinguishing <c>info</c> suffix (not a repeat of the same HKDF call) and
+    /// keep filling. This path is not required to be reproducible in production - <c>challenge</c>
+    /// is freshly random on every `create` call - determinism-given-fixed-inputs is exercised only
+    /// by the unit tests below, for testability.
+    /// </para>
+    /// </summary>
+    internal static char[] DeriveYubiKeyChars(byte[] ikm, int length)
+    {
+        var result = new char[length];
+        var provisionLength = Math.Min(length * 4, MaxHkdfOutputBytes);
+        int filled = 0;
+        int chunk = 0;
+        while (filled < length)
+        {
+            var info = Encoding.UTF8.GetBytes(chunk == 0 ? "tswap-create" : $"tswap-create-{chunk}");
+            var buffer = HKDF.DeriveKey(HashAlgorithmName.SHA256, ikm, provisionLength, salt: null, info: info);
+            filled = RejectionSampleChars(buffer, result, filled);
+            chunk++;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Fills <paramref name="destination"/> starting at <paramref name="startIndex"/> with
+    /// <see cref="Charset"/> characters derived from <paramref name="sourceBytes"/> via rejection
+    /// sampling (bytes >= <see cref="RejectionCeiling"/> are skipped to avoid modulo bias). Stops
+    /// once <paramref name="destination"/> is full or <paramref name="sourceBytes"/> is exhausted,
+    /// whichever comes first. Returns the resulting fill count, so the caller can tell whether more
+    /// source bytes are needed.
+    /// </summary>
+    internal static int RejectionSampleChars(ReadOnlySpan<byte> sourceBytes, char[] destination, int startIndex)
+    {
+        int i = startIndex;
+        foreach (var b in sourceBytes)
+        {
+            if (i >= destination.Length)
+                break;
+            if (b >= RejectionCeiling)
+                continue;
+            destination[i++] = Charset[b % Charset.Length];
+        }
+        return i;
     }
 }

--- a/TswapCli/TswapCli.csproj
+++ b/TswapCli/TswapCli.csproj
@@ -19,4 +19,8 @@
     <PackageReference Include="RedactingPty" Version="1.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="TswapTests" />
+  </ItemGroup>
+
 </Project>

--- a/TswapTests/CommandTests.cs
+++ b/TswapTests/CommandTests.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using TswapCli;
+using TswapCli.Commands;
 using TswapCore;
 using TswapCore.Vault;
 using Xunit;
@@ -225,6 +226,32 @@ public class CommandTests : IDisposable
 
         Assert.Equal(0, exit);
         Assert.Contains("4096 chars", stdout);
+    }
+
+    [Fact]
+    public void Create_GeneratedValueIsCorrectLengthAndCharset()
+    {
+        RunTswap("init");
+        RunTswap("create", "charset-secret", "200");
+        var (exit, stdout, _) = RunTswap("get", "charset-secret");
+
+        Assert.Equal(0, exit);
+        var value = stdout.TrimEnd('\n', '\r');
+        Assert.Equal(200, value.Length);
+        Assert.All(value, c => Assert.Contains(c, CreateCommand.Charset));
+    }
+
+    [Fact]
+    public void Create_RepeatedCallsProduceDifferentValues()
+    {
+        // Regression guard: the system-RNG path must not accidentally be deterministic.
+        RunTswap("init");
+        RunTswap("create", "rand-a", "64");
+        RunTswap("create", "rand-b", "64");
+        var (_, valueA, _) = RunTswap("get", "rand-a");
+        var (_, valueB, _) = RunTswap("get", "rand-b");
+
+        Assert.NotEqual(valueA, valueB);
     }
 
     // --- Names ---

--- a/TswapTests/CreateCommandEntropyTests.cs
+++ b/TswapTests/CreateCommandEntropyTests.cs
@@ -1,0 +1,119 @@
+using TswapCli.Commands;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Unit tests for CreateCommand's YubiKey-entropy rejection-sampling helpers
+/// (<see cref="CreateCommand.DeriveYubiKeyChars"/> and <see cref="CreateCommand.RejectionSampleChars"/>),
+/// exercised directly against fixed key material rather than through a fake YubiKey/CommandContext.
+/// The system-RNG path (RandomNumberGenerator.GetItems) is covered separately in
+/// CommandTests.cs via the "create"/"get" command pair.
+/// </summary>
+public class CreateCommandEntropyTests
+{
+    private static readonly byte[] FixedIkm =
+        Convert.FromHexString("0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF");
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(8)]
+    [InlineData(32)]
+    [InlineData(64)]
+    [InlineData(256)] // large enough to plausibly stress the rejection loop / exhaustion path
+    [InlineData(1000)]
+    public void DeriveYubiKeyChars_ProducesRequestedLengthWithinCharset(int length)
+    {
+        var chars = CreateCommand.DeriveYubiKeyChars(FixedIkm, length);
+
+        Assert.Equal(length, chars.Length);
+        Assert.All(chars, c => Assert.Contains(c, CreateCommand.Charset));
+    }
+
+    [Fact]
+    public void DeriveYubiKeyChars_IsDeterministicGivenFixedInputs()
+    {
+        // Not a claim about production behavior (the real `challenge` is fresh RNG on every
+        // `create` call) - this just confirms the derivation itself has no hidden randomness
+        // (e.g. no accidental use of the ambient RNG instead of the HKDF-derived buffer).
+        var first = CreateCommand.DeriveYubiKeyChars(FixedIkm, 300);
+        var second = CreateCommand.DeriveYubiKeyChars(FixedIkm, 300);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void DeriveYubiKeyChars_DifferentIkmProducesDifferentOutput()
+    {
+        var otherIkm = Convert.FromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+
+        var a = CreateCommand.DeriveYubiKeyChars(FixedIkm, 64);
+        var b = CreateCommand.DeriveYubiKeyChars(otherIkm, 64);
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void DeriveYubiKeyChars_ZeroLengthReturnsEmpty()
+    {
+        var chars = CreateCommand.DeriveYubiKeyChars(FixedIkm, 0);
+
+        Assert.Empty(chars);
+    }
+
+    // Largest multiple of Charset.Length that still fits in a byte - mirrors CreateCommand's
+    // private RejectionCeiling computation so these tests aren't hardcoded to one charset size.
+    private static readonly int RejectionCeiling = (256 / CreateCommand.Charset.Length) * CreateCommand.Charset.Length;
+
+    [Fact]
+    public void RejectionSampleChars_SkipsBytesAtOrAboveCeiling()
+    {
+        // Bytes >= RejectionCeiling must be skipped entirely rather than reintroducing modulo
+        // bias; bytes within range map via `byte % Charset.Length`.
+        byte[] source = [(byte)RejectionCeiling, 255, 0, (byte)(CreateCommand.Charset.Length - 1), (byte)CreateCommand.Charset.Length];
+        var destination = new char[3];
+
+        var filled = CreateCommand.RejectionSampleChars(source, destination, 0);
+
+        Assert.Equal(3, filled);
+        Assert.Equal(CreateCommand.Charset[0], destination[0]);
+        Assert.Equal(CreateCommand.Charset[^1], destination[1]);
+        Assert.Equal(CreateCommand.Charset[0], destination[2]); // Charset.Length % Charset.Length == 0
+    }
+
+    [Fact]
+    public void RejectionSampleChars_StopsAtDestinationBoundsEvenWithMoreSourceBytes()
+    {
+        byte[] source = [0, 1, 2, 3, 4];
+        var destination = new char[2];
+
+        var filled = CreateCommand.RejectionSampleChars(source, destination, 0);
+
+        Assert.Equal(2, filled);
+    }
+
+    [Fact]
+    public void RejectionSampleChars_AllRejectedLeavesFillUnchanged()
+    {
+        byte[] source = [(byte)RejectionCeiling, (byte)(RejectionCeiling + 5), 255, (byte)(RejectionCeiling + 1)];
+        var destination = new char[4];
+
+        var filled = CreateCommand.RejectionSampleChars(source, destination, 1);
+
+        Assert.Equal(1, filled); // nothing accepted, so fill count is unchanged from startIndex
+    }
+
+    [Fact]
+    public void RejectionSampleChars_ContinuesFillingFromStartIndex()
+    {
+        var destination = new char[4];
+        var firstFill = CreateCommand.RejectionSampleChars([0, 1], destination, 0);
+        var secondFill = CreateCommand.RejectionSampleChars([2, 3], destination, firstFill);
+
+        Assert.Equal(4, secondFill);
+        Assert.Equal(CreateCommand.Charset[0], destination[0]);
+        Assert.Equal(CreateCommand.Charset[1], destination[1]);
+        Assert.Equal(CreateCommand.Charset[2], destination[2]);
+        Assert.Equal(CreateCommand.Charset[3], destination[3]);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #28. `CreateCommand`'s password generation mapped random bytes onto the charset via `byte % Charset.Length`, which is biased: `Charset` is 76 characters, and 256 is not a multiple of 76, so the first `256 % 76 = 28` charset indices were reachable by one extra byte value each — a measurable, non-uniform bias in generated secrets.

Two different entropy sources feed `entropy` in `CreateCommand.Execute`, and each needed a different fix since they have different statistical properties:

- **System-RNG path** (`config.RngMode != RngMode.YubiKey`, or `ctx.TestKey != null`): entropy came straight from `RandomNumberGenerator.GetBytes`. Since this *is* CSPRNG output, replaced the byte-buffer + modulo loop entirely with `RandomNumberGenerator.GetItems<char>(Charset, length)` — the correct, already-AOT-safe BCL primitive (since .NET 8) for "pick N items uniformly from a fixed set directly against the CSPRNG." No manual rejection logic needed here.
- **YubiKey-entropy path** (`config.RngMode == RngMode.YubiKey && ctx.TestKey == null`): entropy is a fixed-length deterministic HKDF expansion of the YubiKey challenge+HMAC, not the RNG itself, so `GetItems` doesn't apply. This path now does real rejection sampling: bytes at or above the largest multiple of `Charset.Length` that fits in a byte are discarded, and only accepted bytes are reduced mod `Charset.Length`. Since a bit over an eighth of bytes are rejected, the HKDF output is over-provisioned (up to 4x, capped at HKDF-SHA256's 8160-byte max) to make running out of bytes astronomically unlikely; the extremely unlikely exhaustion case is handled by deriving one more chunk from a distinguishing `info` suffix (not a repeat of the same HKDF call) rather than crashing.

The rejection-sampling logic is extracted into two small internal, unit-testable helpers on `CreateCommand`:
- `DeriveYubiKeyChars(byte[] ikm, int length)` — the full YubiKey-path derivation (HKDF + rejection sampling + retry-on-exhaustion).
- `RejectionSampleChars(ReadOnlySpan<byte> sourceBytes, char[] destination, int startIndex)` — the core byte-to-char rejection loop.

`Charset` and these helpers are `internal` rather than `private`, with `InternalsVisibleTo` added to `TswapCli.csproj` for `TswapTests`, so they're testable without a fake YubiKey/CommandContext.

Note: the rejection ceiling is computed at runtime from `Charset.Length` (`(256 / Charset.Length) * Charset.Length`) rather than hardcoded, after discovering during testing that `Charset` is actually 76 characters (not 74, as originally assumed in the issue) — computing it live means this can't drift out of sync if `Charset` is ever edited.

`CreateCommand.Execute`'s overall structure/behavior is otherwise unchanged; only the byte-to-character mapping after entropy is obtained was touched. YubiKey challenge/HMAC mechanics (`ctx.YubiKeys.Challenge`, `ctx.SelectSerial`) are untouched.

## Test plan

- [x] Added `TswapTests/CreateCommandEntropyTests.cs`: charset membership, exact requested length, determinism-given-fixed-inputs (test-only property, not a production guarantee — `challenge` is fresh RNG on every real `create` call), different-ikm produces different output, zero-length edge case, and lengths (256, 1000) large enough to stress the rejection loop, all without throwing.
- [x] Added two tests to `TswapTests/CommandTests.cs`: generated value is within `Charset` and matches requested length (via `create` + `get`), and repeated `create` calls produce different values (guards against accidental determinism in the system-RNG path).
- [x] `./runtests.sh --unit` passes in full (381/381).
- [x] `dotnet publish -c Release TswapCli/TswapCli.csproj` succeeds (NativeAOT tripwire) — `RandomNumberGenerator.GetItems<char>` and `HKDF.DeriveKey` are both AOT-safe BCL APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)