### PR TITLE
Export KDF params + Argon2id for export/import passphrase (#30, #108)

### DIFF
--- a/TswapCli/Commands/ExportCommand.cs
+++ b/TswapCli/Commands/ExportCommand.cs
@@ -41,7 +41,8 @@ public sealed class ExportCommand : ICliCommand
         var db = ctx.LoadSecrets(key);
 
         var salt = RandomNumberGenerator.GetBytes(32);
-        var exportKey = Crypto.DeriveKeyFromPassphrase(passphrase, salt);
+        var kdf = ExportCrypto.DefaultArgon2idParams;
+        var exportKey = ExportCrypto.DeriveArgon2id(passphrase, salt, kdf);
         var plaintext = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(db, TswapJsonContext.Default.SecretsDb));
         var ciphertext = Crypto.Encrypt(plaintext, exportKey);
 
@@ -49,7 +50,8 @@ public sealed class ExportCommand : ICliCommand
             ExportFile.CurrentVersion,
             DateTime.UtcNow,
             Convert.ToBase64String(salt),
-            Convert.ToBase64String(ciphertext)
+            Convert.ToBase64String(ciphertext),
+            kdf
         );
         File.WriteAllText(path, JsonSerializer.Serialize(exportFile, TswapJsonContext.Default.ExportFile));
 

--- a/TswapCli/Commands/ImportCommand.cs
+++ b/TswapCli/Commands/ImportCommand.cs
@@ -39,11 +39,8 @@ public sealed class ImportCommand : ICliCommand
             throw new TswapException($"Export file is not valid JSON: {ex.Message}");
         }
 
-        if (exportFile.Version != ExportFile.CurrentVersion)
-            throw new TswapException($"Unsupported export version: {exportFile.Version}");
-
         var salt = Convert.FromBase64String(exportFile.Salt);
-        var exportKey = Crypto.DeriveKeyFromPassphrase(passphrase, salt);
+        var exportKey = ExportCrypto.DeriveKey(passphrase, salt, exportFile);
 
         byte[] plaintext;
         try { plaintext = Crypto.Decrypt(Convert.FromBase64String(exportFile.Ciphertext), exportKey); }

--- a/TswapCore/ExportCrypto.cs
+++ b/TswapCore/ExportCrypto.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using Konscious.Security.Cryptography;
+
+namespace TswapCore;
+
+/// <summary>
+/// Passphrase-based key derivation for the export/import file format (#108) — deliberately
+/// separate from <see cref="Crypto.DeriveKeyFromPassphrase"/>. That method (and
+/// <see cref="Crypto.Pbkdf2Iterations"/>) stays exactly as-is: it's also used for the internal
+/// master-key path (<see cref="Crypto.DeriveKey"/>), which is unrelated to passphrases and must
+/// not change behavior for existing YubiKey/TPM/Secure Enclave vaults. This class is where the
+/// export format's KDF is free to evolve across <see cref="ExportFile"/> versions instead.
+/// </summary>
+public static class ExportCrypto
+{
+    // Argon2id parameters for export/import passphrase derivation (tswap-export-v2, #108).
+    // Picked for an interactive CLI: the derivation should feel instant (well under a second),
+    // not the multi-second delays appropriate for, say, a server-side password hash.
+    //
+    //   - MemoryKiB = 19 * 1024 (19 MiB): the OWASP Password Storage Cheat Sheet's recommended
+    //     minimum memory cost for Argon2id when time cost is 2 and parallelism is 1. Memory
+    //     cost is what actually buys resistance to GPU/ASIC cracking (PBKDF2 has none of this),
+    //     so this is the parameter doing the real work here.
+    //   - TimeCost = 2: the iteration count paired with the above memory cost per the same
+    //     OWASP guidance.
+    //   - Parallelism = 1: single-lane, so timing is consistent across machines with different
+    //     core counts and a one-shot CLI invocation doesn't spin up a thread pool for it.
+    //
+    // Measured locally (Argon2idTests.Argon2id_CompletesWithinBudget): well under a second on
+    // ordinary current hardware.
+    public const int Argon2idMemoryKiB = 19 * 1024;
+    public const int Argon2idTimeCost = 2;
+    public const int Argon2idParallelism = 1;
+
+    /// <summary>The <see cref="KdfParams"/> a fresh v2 export stamps into its <c>Kdf</c> field.</summary>
+    public static KdfParams DefaultArgon2idParams => new(
+        KdfAlgorithm.Argon2id,
+        MemoryKiB: Argon2idMemoryKiB,
+        TimeCost: Argon2idTimeCost,
+        Parallelism: Argon2idParallelism);
+
+    /// <summary>Derives a 32-byte key from a passphrase and salt using Argon2id with the given parameters.</summary>
+    public static byte[] DeriveArgon2id(string passphrase, byte[] salt, KdfParams kdf)
+    {
+        if (kdf.Algorithm != KdfAlgorithm.Argon2id)
+            throw new TswapException($"Export file's KDF algorithm is '{kdf.Algorithm}', not Argon2id");
+
+        var memoryKiB = kdf.MemoryKiB ?? throw new TswapException("Export file is missing its Argon2id memory cost parameter");
+        var timeCost = kdf.TimeCost ?? throw new TswapException("Export file is missing its Argon2id time cost parameter");
+        var parallelism = kdf.Parallelism ?? throw new TswapException("Export file is missing its Argon2id parallelism parameter");
+
+        using var argon2 = new Argon2id(Encoding.UTF8.GetBytes(passphrase))
+        {
+            Salt = salt,
+            MemorySize = memoryKiB,
+            Iterations = timeCost,
+            DegreeOfParallelism = parallelism,
+        };
+        return argon2.GetBytes(32);
+    }
+
+    /// <summary>
+    /// Derives the export/import key for <paramref name="exportFile"/>, dispatching on its
+    /// <see cref="ExportFile.Version"/>: <see cref="ExportFile.V1"/> uses the original hardcoded
+    /// PBKDF2 path unchanged (bit-for-bit as always — see <see cref="Crypto.DeriveKeyFromPassphrase"/>),
+    /// <see cref="ExportFile.V2"/> uses Argon2id with the parameters stored in the file itself.
+    /// Unrecognized versions throw a clear <see cref="TswapException"/> rather than guessing.
+    /// </summary>
+    public static byte[] DeriveKey(string passphrase, byte[] salt, ExportFile exportFile) => exportFile.Version switch
+    {
+        ExportFile.V1 => Crypto.DeriveKeyFromPassphrase(passphrase, salt),
+        ExportFile.V2 => DeriveArgon2id(passphrase, salt,
+            exportFile.Kdf ?? throw new TswapException("Export file is missing required KDF parameters")),
+        _ => throw new TswapException($"Unsupported export version: {exportFile.Version}"),
+    };
+}

--- a/TswapCore/Models.cs
+++ b/TswapCore/Models.cs
@@ -72,14 +72,65 @@ public record Config(List<int> YubiKeySerials, string RedundancyXor, DateTime Cr
 public record Secret(string Value, DateTime Created, DateTime Modified, DateTime? BurnedAt = null, string? BurnReason = null);
 public record SecretsDb(Dictionary<string, Secret> Secrets);
 
-public record ExportFile(string Version, DateTime Created, string Salt, string Ciphertext)
+/// <summary>
+/// KDF algorithm identifiers for an export file's passphrase-derived key (#30). Serialized as
+/// lowercase hyphenated strings so the raw JSON is self-describing without a lookup table.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<KdfAlgorithm>))]
+public enum KdfAlgorithm
 {
-    public const string CurrentVersion = "tswap-export-v1";
+    [JsonStringEnumMemberName("pbkdf2-sha256")]
+    Pbkdf2Sha256,
+    [JsonStringEnumMemberName("argon2id")]
+    Argon2id,
+}
+
+/// <summary>
+/// Explicit KDF parameters for an export file's passphrase-derived key (#30). One record covers
+/// both algorithms — fields not used by <see cref="Algorithm"/> are left null — rather than a
+/// polymorphic hierarchy, so this stays trivially source-gen JSON serializable for NativeAOT.
+/// Only present on "tswap-export-v2"+ files; v1 files have no <c>Kdf</c> at all (see
+/// <see cref="ExportFile.V1"/>) because their KDF is implied/hardcoded, not stored.
+/// </summary>
+public record KdfParams(
+    KdfAlgorithm Algorithm,
+    // PBKDF2 only.
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? Iterations = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? HashAlgorithm = null,
+    // Argon2id only.
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? MemoryKiB = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? TimeCost = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? Parallelism = null);
+
+public record ExportFile(string Version, DateTime Created, string Salt, string Ciphertext,
+    // Explicit KDF parameters (#30). Omitted for v1 files (KDF is implied: PBKDF2-SHA256 at
+    // Crypto.Pbkdf2Iterations, see Crypto.DeriveKeyFromPassphrase) and always present on v2+
+    // files, describing exactly how Salt should be turned into the export key — see
+    // ExportCrypto.DeriveKey for the version dispatch that reads this back.
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] KdfParams? Kdf = null)
+{
+    /// <summary>
+    /// Original export format: salt + ciphertext only, no explicit KDF parameters. The KDF is
+    /// implied to be PBKDF2-SHA256 at Crypto.Pbkdf2Iterations iterations. This string and its
+    /// derivation must never change — every export file ever produced with this version tag
+    /// must keep importing bit-for-bit as before (#108).
+    /// </summary>
+    public const string V1 = "tswap-export-v1";
+
+    /// <summary>
+    /// Current export format (#30 + #108): adds explicit <see cref="Kdf"/> parameters and moves
+    /// the passphrase KDF to Argon2id. See ExportCrypto for the parameter choices/rationale.
+    /// </summary>
+    public const string V2 = "tswap-export-v2";
+
+    /// <summary>The version <c>export</c> now produces. Import accepts this and all older versions.</summary>
+    public const string CurrentVersion = V2;
 }
 
 [JsonSerializable(typeof(Config))]
 [JsonSerializable(typeof(SecretsDb))]
 [JsonSerializable(typeof(ExportFile))]
+[JsonSerializable(typeof(KdfParams))]
 [JsonSourceGenerationOptions(WriteIndented = true)]
 public partial class TswapJsonContext : JsonSerializerContext { }
 

--- a/TswapCore/TswapCore.csproj
+++ b/TswapCore/TswapCore.csproj
@@ -23,6 +23,18 @@
   </ItemGroup>
 
   <!--
+    Export/import passphrase KDF (#108): as of this SDK, System.Security.Cryptography has no
+    built-in Argon2 (only PBKDF2 via Rfc2898DeriveBytes — verified by grepping the net10.0
+    reference assembly for "Argon2" and finding nothing). Konscious.Security.Cryptography.Argon2
+    is a pure-managed (no P/Invoke, no native binaries in its .nupkg — verified directly) MIT-
+    licensed implementation of the Argon2 1.3 spec, so like Rebex.Elliptic.Curve25519 above it
+    adds no NativeAOT publish complexity. See TswapCore/ExportCrypto.cs for parameter choices.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1" />
+  </ItemGroup>
+
+  <!--
     Secure Enclave backend (macOS only): Vault/Interop/swift/TswapSecureEnclave.swift is a
     thin CryptoKit shim, compiled here into a dylib and copied next to the managed output —
     AppleSecureEnclaveInterop.cs P/Invokes into it. See that file's header comment for why a

--- a/TswapTests/Argon2idTests.cs
+++ b/TswapTests/Argon2idTests.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using TswapCore;
+using Xunit;
+
+namespace TswapTests;
+
+public class Argon2idTests
+{
+    [Fact]
+    public void Argon2id_CompletesWithinBudget()
+    {
+        var salt = RandomNumberGenerator.GetBytes(32);
+
+        var stopwatch = Stopwatch.StartNew();
+        var derived = ExportCrypto.DeriveArgon2id("correct-horse-battery-staple", salt, ExportCrypto.DefaultArgon2idParams);
+        stopwatch.Stop();
+
+        Assert.Equal(32, derived.Length);
+
+        // The doc comment on ExportCrypto's Argon2id constants claims this is "well under a
+        // second on ordinary current hardware." Budget generously (well beyond that claim) to
+        // leave headroom for slower/loaded CI runners without making this flaky, while still
+        // catching a regression if someone bumps the parameters to something absurdly slow.
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+            $"Argon2id derivation took {stopwatch.Elapsed.TotalSeconds:F2}s, expected under 3s");
+    }
+
+    [Fact]
+    public void Argon2id_Deterministic()
+    {
+        var salt = RandomNumberGenerator.GetBytes(32);
+
+        var k1 = ExportCrypto.DeriveArgon2id("correct-horse-battery-staple", salt, ExportCrypto.DefaultArgon2idParams);
+        var k2 = ExportCrypto.DeriveArgon2id("correct-horse-battery-staple", salt, ExportCrypto.DefaultArgon2idParams);
+
+        Assert.Equal(k1, k2);
+    }
+}

--- a/TswapTests/CommandTests.cs
+++ b/TswapTests/CommandTests.cs
@@ -766,9 +766,12 @@ password2: """"  # tswap: missing-mixed-secret");
 
         Assert.Equal(0, exit);
         Assert.True(File.Exists(exportPath));
+        var written = File.ReadAllText(exportPath);
         // File must not contain the plaintext secret name
-        Assert.DoesNotContain("my-secret", File.ReadAllText(exportPath));
-        Assert.Contains("tswap-export-v1", File.ReadAllText(exportPath));
+        Assert.DoesNotContain("my-secret", written);
+        // Fresh exports now produce v2 with explicit Argon2id KDF params (#30, #108).
+        Assert.Contains("tswap-export-v2", written);
+        Assert.Contains("argon2id", written);
     }
 
     [Fact]
@@ -990,6 +993,86 @@ password2: """"  # tswap: missing-mixed-secret");
 
         Assert.NotEqual(0, exit);
         Assert.Contains("not valid JSON", stderr, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Import_V1ExportFile_ImportsViaLegacyPbkdf2Path()
+    {
+        // A v1-shaped ExportFile has no Kdf field at all (it didn't exist yet — #30/#108).
+        // Its key must still be derivable exactly as it always was: Crypto.DeriveKeyFromPassphrase
+        // (plain PBKDF2-SHA256 at Crypto.Pbkdf2Iterations), dispatched via ExportFile.V1.
+        RunTswap("init");
+
+        const string passphrase = "legacy-passphrase";
+        var salt = RandomNumberGenerator.GetBytes(32);
+        var exportKey = Crypto.DeriveKeyFromPassphrase(passphrase, salt);
+        var dbJson = JsonSerializer.Serialize(
+            new SecretsDb(new Dictionary<string, Secret> { ["legacy-secret"] = new("legacy-value", DateTime.UtcNow, DateTime.UtcNow) }),
+            TswapJsonContext.Default.SecretsDb);
+        var ciphertext = Crypto.Encrypt(Encoding.UTF8.GetBytes(dbJson), exportKey);
+
+        var exportFile = new ExportFile(
+            ExportFile.V1, DateTime.UtcNow,
+            Convert.ToBase64String(salt),
+            Convert.ToBase64String(ciphertext));
+        Assert.Null(exportFile.Kdf);
+        var exportPath = Path.Combine(_tempDir, "legacy-v1.enc");
+        File.WriteAllText(exportPath, JsonSerializer.Serialize(exportFile, TswapJsonContext.Default.ExportFile));
+
+        var (exit, stdout, _) = RunTswapWithStdin(passphrase + "\n", "import", exportPath);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Imported 1 secret(s)", stdout);
+        var (_, namesOut, _) = RunTswap("names");
+        Assert.Contains("legacy-secret", namesOut);
+    }
+
+    [Fact]
+    public void Import_V2ExportFile_UsesArgon2idParamsFromFile()
+    {
+        // A v2 file carries its own explicit Kdf params (#30); import must derive using those,
+        // not any hardcoded default, and must use Argon2id rather than PBKDF2 (#108).
+        RunTswap("init");
+
+        const string passphrase = "v2-passphrase";
+        var salt = RandomNumberGenerator.GetBytes(32);
+        var kdf = ExportCrypto.DefaultArgon2idParams;
+        Assert.Equal(KdfAlgorithm.Argon2id, kdf.Algorithm);
+        var exportKey = ExportCrypto.DeriveArgon2id(passphrase, salt, kdf);
+        var dbJson = JsonSerializer.Serialize(
+            new SecretsDb(new Dictionary<string, Secret> { ["v2-secret"] = new("v2-value", DateTime.UtcNow, DateTime.UtcNow) }),
+            TswapJsonContext.Default.SecretsDb);
+        var ciphertext = Crypto.Encrypt(Encoding.UTF8.GetBytes(dbJson), exportKey);
+
+        var exportFile = new ExportFile(
+            ExportFile.V2, DateTime.UtcNow,
+            Convert.ToBase64String(salt),
+            Convert.ToBase64String(ciphertext),
+            kdf);
+        var exportPath = Path.Combine(_tempDir, "v2.enc");
+        File.WriteAllText(exportPath, JsonSerializer.Serialize(exportFile, TswapJsonContext.Default.ExportFile));
+
+        var (exit, stdout, _) = RunTswapWithStdin(passphrase + "\n", "import", exportPath);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Imported 1 secret(s)", stdout);
+        var (_, namesOut, _) = RunTswap("names");
+        Assert.Contains("v2-secret", namesOut);
+    }
+
+    [Fact]
+    public void Import_UnrecognizedVersion_ThrowsClearError()
+    {
+        RunTswap("init");
+
+        var exportFile = new ExportFile("tswap-export-v99", DateTime.UtcNow, "c2FsdA==", "Y2lwaGVy");
+        var exportPath = Path.Combine(_tempDir, "future.enc");
+        File.WriteAllText(exportPath, JsonSerializer.Serialize(exportFile, TswapJsonContext.Default.ExportFile));
+
+        var (exit, _, stderr) = RunTswapWithStdin("anypassphrase\n", "import", exportPath);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("Unsupported export version: tswap-export-v99", stderr);
     }
 
     // --- Migrate ---

--- a/TswapTests/ModelsTests.cs
+++ b/TswapTests/ModelsTests.cs
@@ -117,12 +117,51 @@ public class ModelsTests
     }
 
     [Fact]
-    public void ExportFile_VersionTag_Unchanged()
+    public void ExportFile_V1VersionTag_Unchanged()
     {
-        Assert.Equal("tswap-export-v1", ExportFile.CurrentVersion);
-        var export = new ExportFile(ExportFile.CurrentVersion, DateTime.UtcNow, "c2FsdA==", "Y2lwaGVy");
+        // The v1 tag and its (Kdf-less) shape must never change — every export file ever
+        // produced with this version tag must keep importing bit-for-bit as before (#108).
+        Assert.Equal("tswap-export-v1", ExportFile.V1);
+        var export = new ExportFile(ExportFile.V1, DateTime.UtcNow, "c2FsdA==", "Y2lwaGVy");
         var json = JsonSerializer.Serialize(export, TswapJsonContext.Default.ExportFile);
         Assert.Contains("\"Version\": \"tswap-export-v1\"", json);
+        Assert.DoesNotContain("Kdf", json);
+        Assert.Null(export.Kdf);
+    }
+
+    [Fact]
+    public void ExportFile_CurrentVersion_IsV2WithExplicitKdfParams()
+    {
+        // #30 + #108: fresh exports now stamp v2 and explicit Argon2id KDF params.
+        Assert.Equal("tswap-export-v2", ExportFile.V2);
+        Assert.Equal(ExportFile.V2, ExportFile.CurrentVersion);
+
+        var kdf = new KdfParams(KdfAlgorithm.Argon2id, MemoryKiB: 19 * 1024, TimeCost: 2, Parallelism: 1);
+        var export = new ExportFile(ExportFile.CurrentVersion, DateTime.UtcNow, "c2FsdA==", "Y2lwaGVy", kdf);
+        var json = JsonSerializer.Serialize(export, TswapJsonContext.Default.ExportFile);
+
+        Assert.Contains("\"Version\": \"tswap-export-v2\"", json);
+        Assert.Contains("\"Algorithm\": \"argon2id\"", json);
+        Assert.Contains("\"MemoryKiB\": 19456", json);
+
+        var roundTripped = JsonSerializer.Deserialize(json, TswapJsonContext.Default.ExportFile)!;
+        Assert.Equal(kdf, roundTripped.Kdf);
+    }
+
+    [Fact]
+    public void KdfParams_Pbkdf2Shape_RoundTrips()
+    {
+        // Even though nothing writes this today (v1 leaves Kdf null and implies PBKDF2), the
+        // PBKDF2 shape of KdfParams must itself serialize/deserialize correctly per #30, since
+        // the whole point is a format that can describe either algorithm.
+        var kdf = new KdfParams(KdfAlgorithm.Pbkdf2Sha256, Iterations: 100_000, HashAlgorithm: "SHA256");
+        var json = JsonSerializer.Serialize(kdf, TswapJsonContext.Default.KdfParams);
+        Assert.Contains("\"Algorithm\": \"pbkdf2-sha256\"", json);
+        Assert.Contains("\"Iterations\": 100000", json);
+        Assert.DoesNotContain("MemoryKiB", json);
+
+        var roundTripped = JsonSerializer.Deserialize(json, TswapJsonContext.Default.KdfParams);
+        Assert.Equal(kdf, roundTripped);
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #30 and #108 together, in the order #108 asks for ("do #30's versioning first, then land the stronger KDF as a new version").

- **#30**: `ExportFile` gains a new optional `Kdf` field (`KdfParams`: an algorithm tag — `pbkdf2-sha256` or `argon2id` — plus whichever parameters that algorithm needs) so the export format's KDF is explicit and self-describing instead of implicit/hardcoded on both the write and read side.
- **#108**: `export` now produces `tswap-export-v2` files whose passphrase key is derived with Argon2id instead of PBKDF2-SHA256. `import` dispatches on `ExportFile.Version` and derives the key accordingly.

## Versioning scheme

- **`tswap-export-v1`** (unchanged, forever): salt + ciphertext only, no `Kdf` field. Its key derivation is still exactly `Crypto.DeriveKeyFromPassphrase` — plain PBKDF2-SHA256 at `Crypto.Pbkdf2Iterations` (100k). Every export file ever produced with this tag keeps importing bit-for-bit as before.
- **`tswap-export-v2`** (new `CurrentVersion`, what `export` now writes): adds the `Kdf` field, populated with Argon2id parameters. Its key is derived via the new `ExportCrypto.DeriveArgon2id`, using the parameters stored *in the file itself* — not a hardcoded default — so future parameter tuning doesn't retroactively break v2 files already on disk.
- `import`'s old `if (exportFile.Version != ExportFile.CurrentVersion) throw` single-equality check is now `ExportCrypto.DeriveKey`, a switch over `ExportFile.Version` (`V1` → legacy PBKDF2 path, `V2` → Argon2id via stored params, anything else → a clear `TswapException`, not a crash).

`Crypto.DeriveKey`/`Crypto.Pbkdf2Iterations` (the internal master-key derivation used by YubiKey/TPM/Secure Enclave vaults) are untouched — this PR is scoped to the export/import passphrase path only, per #108 and independent of #110.

## Argon2id package and parameters

- **Package**: `Konscious.Security.Cryptography.Argon2` 1.3.1 (MIT). Verified directly (not from memory): the net10.0 reference assembly (`System.Security.Cryptography.dll`) has no `Argon2` type at all, confirming the BCL still lacks it. Downloaded and inspected the `.nupkg` for both this package and its `Konscious.Security.Cryptography.Blake2` dependency — both ship only managed `net6.0`/`net8.0`/`net46`/`netstandard1.3` DLLs, no native binaries, so it adds no NativeAOT publish complexity (same rationale as the existing `Rebex.Elliptic.Curve25519` dependency). `dotnet publish -c Release` for `TswapCli` still succeeds.
- **Parameters** (see comment in `TswapCore/ExportCrypto.cs`): memory cost 19 MiB, time cost 2, parallelism 1 — the OWASP Password Storage Cheat Sheet's recommended minimum for that memory/time pairing. Memory hardness is what actually buys resistance to GPU/ASIC cracking (PBKDF2 has none), so that's the parameter doing the real work; parallelism is kept at 1 for consistent timing across machines and because this is a one-shot CLI call, not a server-side hasher. Comfortably under a second on ordinary current hardware, well within the "should feel instant" target for an interactive CLI.

## Tests

Extended `TswapTests/CommandTests.cs` and `TswapTests/ModelsTests.cs`:
- `Import_V1ExportFile_ImportsViaLegacyPbkdf2Path` — a v1-shaped `ExportFile` (no `Kdf` field) still imports via the untouched PBKDF2 path.
- `Export_CreatesEncryptedFile` (updated) / `Export_Import_RoundTrip` — a fresh `export` now produces `tswap-export-v2` with an `argon2id` `Kdf` block, and round-trips through `import`.
- `Import_V2ExportFile_UsesArgon2idParamsFromFile` — a v2 file's own stored `Kdf` params (not a hardcoded default) are what `import` uses.
- `Import_UnrecognizedVersion_ThrowsClearError` — a future/unknown version string fails with a clear `TswapException`, not a crash.
- `ExportFile_V1VersionTag_Unchanged`, `ExportFile_CurrentVersion_IsV2WithExplicitKdfParams`, `KdfParams_Pbkdf2Shape_RoundTrips` — golden-file-style coverage of both `KdfParams` shapes and the JSON they produce (source-gen serializable, `KdfParams` added to `TswapJsonContext`).

## Verification

- `./runtests.sh --unit`: 371/371 passing (sandbox only had .NET SDK 10.0.301 installed vs. `global.json`'s pinned 10.0.302 — temporarily edited `global.json` to build/test, then reverted it to the committed value before committing, per the repo's documented workaround).
- `dotnet publish -c Release TswapCli/TswapCli.csproj`: succeeds (NativeAOT tripwire).

Refs #30, #108.