### PR TITLE
Durable atomic writes + directory-scan tolerance for synced vault dirs (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,66 @@ helm upgrade myapp ./chart -f /tmp/values.deployed.yaml
 rm /tmp/values.deployed.yaml
 ```
 
+## Sync transports
+
+tswap never syncs anything itself — it only writes files under its config directory
+(`TSWAP_CONFIG_DIR`, see [Files](#files) below) that a separate sync tool can replicate to other
+machines. This section covers what makes that safe and what doesn't.
+
+**The rule: point `TSWAP_CONFIG_DIR` at a directory on local disk, and let a sync tool (Dropbox,
+OneDrive, Google Drive, Syncthing, Nextcloud, Seafile, git, ...) replicate that directory. Do not
+point `TSWAP_CONFIG_DIR` directly at a network mount** — an SMB share, an NFS export, an rclone
+mount, or a WebDAV mount.
+
+**Why this is a protocol distinction, not a hosting one.** Where the sync tool's *server* runs
+doesn't matter — a container on your own NAS running Syncthing, Nextcloud, or Seafile is fine,
+because each machine still keeps and writes to its own local copy of the directory and the sync
+tool reconciles copies afterward. A container on that same NAS running Samba or an NFS server
+gives you exactly what a raw NAS export gives you, because that *is* what it gives you: every
+read and write goes over the wire synchronously, with no local copy in between. Containerizing a
+network filesystem doesn't change its protocol. Same reasoning applies to mounting a cloud
+drive's WebDAV endpoint or an rclone mount instead of running its actual sync client — if
+`TSWAP_CONFIG_DIR` sees a mount, not a plain local directory with a sync daemon watching it, this
+guidance treats it as a network mount regardless of what's behind the mount.
+
+**Why network mounts specifically:** client-side caching over SMB/NFS means a write can
+complete from the writing process's point of view, and even rename successfully server-side,
+while the underlying data was never actually flushed to the server. That produces a truncated or
+zero-length record with a single writer and no concurrency involved — not a race condition, just
+a weaker durability guarantee than local disk gives you. `TswapCore/Keyring/DurableFileWriter.cs`
+implements the portable mitigation for this (temp file in the same directory, `WriteThrough` +
+`Flush(flushToDisk: true)`, then a plain rename) for the future per-secret record format
+(`TswapCore/Keyring/SecretRecordCodec.cs` et al. — issues #111-#115), which is what makes
+per-machine, per-record sync viable in the first place. **That mitigation is unit-tested only for
+its happy path** (write bytes, read them back, byte-exact) — durability under a killed process or
+a real SMB/NFS server's specific flush behavior has not been tested and isn't claimed here; see
+that file's doc comment.
+
+**NAS: supported with caveats, not prohibited.** If you genuinely want a NAS as the sync
+destination rather than a cloud provider, run an actual sync daemon against it (see above) and
+treat it as one-machine-at-a-time: no offline access on the non-primary machine, and an
+interrupted write costs at most one record, not the whole vault, once the per-secret record
+format lands. The generation counter (issue #118, not yet implemented) will eventually detect a
+broken one-machine assumption — two machines that both believe they're the only writer — but
+until it exists, that assumption is enforced by discipline, not by tswap. **NAS setups have not
+been tested by this project**; the caveats above are what the protocol-level reasoning predicts,
+not a verified result, and the honest position given that is to treat NAS as unsupported until
+someone tests it, not to claim it works.
+
+**No lock files.** tswap does not write or honor any lock file in the config directory. Advisory
+locking over NFS is unreliable enough that a lock file would be a false sense of safety rather
+than real protection; the generation counter (#118) is the intended mechanism for catching a
+conflicting write after the fact, not preventing one in advance.
+
+**Cloud placeholder files.** Google Drive for Desktop and OneDrive Files On-Demand both stream
+files from the cloud by default, leaving a placeholder/stub on disk until something reads the
+real file. Reads usually hydrate the placeholder transparently, but not when the machine is
+offline — an offline read of a not-yet-hydrated record will fail or return the wrong thing.
+**Mark the tswap config directory "always available offline"** in your sync client's settings
+(Google Drive is the worst offender of the four major providers for this; OneDrive, Dropbox, and
+Syncthing/Nextcloud either don't do on-demand streaming by default or make the always-available
+setting easy to find).
+
 ## Files
 
 | Platform | Config directory |

--- a/TswapCore/Keyring/DurableFileWriter.cs
+++ b/TswapCore/Keyring/DurableFileWriter.cs
@@ -1,0 +1,116 @@
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// Atomic, explicitly-flushed single-file write (issue #137, work item 1): write to a temp file
+/// in the <b>same directory</b> as the target, force the data to durable storage, then rename
+/// into place. Standalone infrastructure — this type has no dependency on any
+/// <see cref="IVaultStore"/> or on the record wire format in <see cref="SecretRecordCodec"/>; it
+/// operates on a plain directory, filename, and byte array so it can be dropped into whatever
+/// store eventually reads/writes per-secret record files (issues #119/#124), without needing
+/// that store to exist yet.
+///
+/// <para><b>Why a temp file in the same directory, not <see cref="Path.GetTempPath"/>:</b> a
+/// cross-device rename is not atomic — most OSes silently fall back to copy-then-delete, which
+/// reintroduces exactly the "torn write on crash" failure mode this class exists to avoid. Same
+/// directory guarantees same filesystem/volume, so <see cref="File.Move(string, string, bool)"/>
+/// is a single rename syscall.</para>
+///
+/// <para><b>Why <see cref="FileOptions.WriteThrough"/> <i>and</i>
+/// <see cref="FileStream.Flush(bool)"/> with <c>flushToDisk: true</c>, not just one:</b>
+/// <c>WriteThrough</c> alone is not honoured on every code path; <c>Flush(flushToDisk: true)</c>
+/// is the portable guarantee — it becomes a real SMB2 FLUSH or an NFS COMMIT when the target is
+/// a network share, not only a local <c>fsync</c>/<c>FlushFileBuffers</c>. Records are a few
+/// hundred padded bytes written occasionally, so the write-through cost this normally buys you
+/// out of does not apply here.</para>
+///
+/// <para><b>Why <see cref="File.Move(string, string, bool)"/> with <c>overwrite: true</c>, not
+/// <see cref="File.Replace(string, string, string?)"/>:</b> <c>File.Replace</c> carries
+/// backup-file semantics that some SMB servers implement badly or not at all. Plain rename is
+/// the primitive every server handles correctly. (<c>File.Replace</c> may still be the right
+/// choice elsewhere in this codebase, on paths that are known-local — this class only asserts
+/// that record files, which may live on a synced/network directory, should not use it.)</para>
+///
+/// <para><b>What this is actually verified to do, and no more:</b> unit tests cover the
+/// happy path only — write bytes, read them back, byte-exact (see
+/// <c>TswapTests/DurableFileWriterTests.cs</c>). Durability under a killed process, a dropped
+/// network mount mid-write, or a real SMB/NFS server's specific FLUSH/COMMIT behaviour is not
+/// something an honest unit test can claim — see the parent issue's testing notes. This class
+/// implements the documented portable pattern; it does not carry proof that pattern survives
+/// every real transport's failure modes.</para>
+/// </summary>
+public static class DurableFileWriter
+{
+    /// <summary>
+    /// Writes <paramref name="bytes"/> to <paramref name="targetFileName"/> inside
+    /// <paramref name="directory"/>, atomically: temp file in the same directory, flushed to
+    /// durable storage, then renamed over any existing file of that name.
+    /// </summary>
+    /// <param name="directory">
+    /// The directory the record lives in. Must already exist — this method does not create it
+    /// (directory creation is a store-level concern, not a write-primitive one).
+    /// </param>
+    /// <param name="targetFileName">
+    /// Bare filename (no directory component) to write, e.g. a record's hex filename from
+    /// <see cref="FilenameHasher.ToFilename"/>.
+    /// </param>
+    /// <param name="bytes">The exact bytes to write.</param>
+    public static void WriteAtomic(DirectoryInfo directory, string targetFileName, byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(directory);
+        ArgumentException.ThrowIfNullOrEmpty(targetFileName);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        if (!directory.Exists)
+            throw new DirectoryNotFoundException($"Directory does not exist: {directory.FullName}");
+
+        // Path.GetRandomFileName() produces the same short "8chars.3chars" shape
+        // RecordDirectoryScanner recognises as tswap's own in-flight temp file (see that
+        // class's TswapTempFile pattern) -- keep the two in sync if this ever changes.
+        var tmpPath = Path.Combine(directory.FullName, Path.GetRandomFileName());
+        var targetPath = Path.Combine(directory.FullName, targetFileName);
+
+        try
+        {
+            using (var fs = new FileStream(tmpPath, new FileStreamOptions
+                   {
+                       Mode = FileMode.CreateNew,
+                       Access = FileAccess.Write,
+                       Options = FileOptions.WriteThrough,
+                   }))
+            {
+                fs.Write(bytes);
+                fs.Flush(flushToDisk: true); // FlushFileBuffers (Windows) / fsync (Unix)
+            }
+
+            File.Move(tmpPath, targetPath, overwrite: true);
+        }
+        catch
+        {
+            TryDeleteBestEffort(tmpPath);
+            throw;
+        }
+
+        // Flushing the file does not flush the directory entry the rename above created.
+        // Best-effort only -- see UnixDirectoryFsync's doc comment for why this can't be more
+        // than that, and why there is no Windows equivalent.
+        UnixDirectoryFsync.TryFsync(directory.FullName);
+    }
+
+    /// <summary>Convenience overload taking a directory path instead of a <see cref="DirectoryInfo"/>.</summary>
+    public static void WriteAtomic(string directoryPath, string targetFileName, byte[] bytes)
+        => WriteAtomic(new DirectoryInfo(directoryPath), targetFileName, bytes);
+
+    private static void TryDeleteBestEffort(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+            // Best effort cleanup of a stray temp file after a failed write; the original
+            // exception from the write/move above is what the caller needs to see, not this.
+        }
+    }
+}

--- a/TswapCore/Keyring/RecordDirectoryScanner.cs
+++ b/TswapCore/Keyring/RecordDirectoryScanner.cs
@@ -1,0 +1,200 @@
+using System.Text.RegularExpressions;
+
+namespace TswapCore.Keyring;
+
+/// <summary>Which sync tool's conflicted-copy naming convention matched a given filename.</summary>
+public enum SyncConflictTool
+{
+    /// <summary><c>&lt;name&gt; (conflicted copy 2026-07-27)</c> / <c>&lt;name&gt; (1)</c>.</summary>
+    DropboxOrGoogleDrive,
+
+    /// <summary><c>&lt;name&gt;-DESKTOP-ABC123</c>.</summary>
+    OneDrive,
+
+    /// <summary><c>&lt;name&gt;.sync-conflict-20260727-120000-XXXXXX</c>.</summary>
+    Syncthing,
+}
+
+/// <summary>
+/// One conflicted copy found beside a record. <see cref="RecordFilename"/> is the hashed on-disk
+/// name of the record that appears to be affected — the plaintext secret name is never available
+/// at this layer, since this scanner never has the vault key (see
+/// <see cref="RecordDirectoryScanner"/>'s class doc). This is filename-level triage only: it does
+/// not read record contents, so it cannot yet report the "generation 9 from LAPTOP vs generation
+/// 7 from DESKTOP" detail the parent issue describes -- that needs the vault key to decrypt each
+/// side's header and belongs in whatever layer has it (the future <c>IVaultStore</c>, #119/#124),
+/// not here.
+/// </summary>
+public sealed record ConflictWarning(string RecordFilename, string ConflictingFilename, SyncConflictTool Tool);
+
+/// <summary>
+/// Result of scanning one record directory: which filenames look like real records, which look
+/// like a conflicted copy a sync tool left behind (and therefore need a human, not silent
+/// dropping), and which are everything else (sync-tool artefacts, tswap's own in-flight temp
+/// files, or any other junk) -- ignored without warning, per the parent issue's explicit
+/// instruction that only conflicts should be surfaced.
+/// </summary>
+public sealed record DirectoryScanResult(
+    IReadOnlyList<string> ValidRecordFilenames,
+    IReadOnlyList<ConflictWarning> Conflicts,
+    IReadOnlyList<string> IgnoredFilenames);
+
+/// <summary>
+/// Filename-only triage of a record directory (issue #137, work item 2). Standalone
+/// infrastructure — no dependency on any <see cref="IVaultStore"/> or on
+/// <see cref="SecretRecordCodec"/>; it takes a directory and returns filenames, so it can be
+/// dropped into whatever store eventually enumerates real record files (issues #119/#124)
+/// without needing that store to exist yet.
+///
+/// <para>Record filenames are <c>HMAC(K_names, secretName)</c>, hex-encoded, exactly
+/// <see cref="KeyringFormat.RecordIdSize"/> * 2 = 64 lowercase hex characters, no extension (see
+/// <see cref="FilenameHasher"/>). Nothing else on disk shares that exact shape by construction,
+/// but sync tools routinely leave files beside the records that must not be mistaken for one —
+/// or, worse, silently thrown away when they are actually a record in trouble. This class draws
+/// that line by filename shape alone; it never opens or decrypts a file's contents, because
+/// nothing at this layer has the vault key.</para>
+/// </summary>
+public static class RecordDirectoryScanner
+{
+    private static readonly Regex ValidRecordFilename = new("^[0-9a-f]{64}$", RegexOptions.None, TimeSpan.FromSeconds(1));
+
+    // tswap's own in-flight temp file, per DurableFileWriter.WriteAtomic: Path.GetRandomFileName()
+    // always produces an 8-char + '.' + 3-char lowercase alphanumeric name. Deliberately
+    // permissive about the exact character set (real GetRandomFileName output uses a narrower
+    // alphabet) -- this only needs to not collide with the 64-hex-no-extension record shape or
+    // any of the conflict patterns below, not to validate GetRandomFileName precisely.
+    private static readonly Regex TswapTempFile = new(@"^[a-z0-9]{8}\.[a-z0-9]{3}$", RegexOptions.None, TimeSpan.FromSeconds(1));
+
+    // Dropbox / Google Drive: "<name> (conflicted copy 2026-07-27)" or a bare duplicate suffix
+    // "<name> (1)". Both insert a space before the parenthesised suffix.
+    private static readonly Regex DropboxGoogleDriveConflictedCopy =
+        new(@"^(?<base>[0-9a-f]{64}) \(conflicted copy[^)]*\)$", RegexOptions.None, TimeSpan.FromSeconds(1));
+    private static readonly Regex DropboxGoogleDriveNumbered =
+        new(@"^(?<base>[0-9a-f]{64}) \(\d+\)$", RegexOptions.None, TimeSpan.FromSeconds(1));
+
+    // OneDrive: "<name>-DESKTOP-ABC123" -- appends "-<machine name>" directly, no separating
+    // extension dot (our records have no extension for OneDrive to preserve).
+    private static readonly Regex OneDriveConflict =
+        new(@"^(?<base>[0-9a-f]{64})-[A-Za-z0-9][A-Za-z0-9-]*$", RegexOptions.None, TimeSpan.FromSeconds(1));
+
+    // Syncthing: "<name>.sync-conflict-20260727-120000-XXXXXX".
+    private static readonly Regex SyncthingConflict =
+        new(@"^(?<base>[0-9a-f]{64})\.sync-conflict-\d{8}-\d{6}-[A-Za-z0-9]+$", RegexOptions.None, TimeSpan.FromSeconds(1));
+
+    // Known sync-tool artefacts that are never records and never conflicts -- silently ignored.
+    // Matched by exact name or prefix; see the parent issue's artefact table.
+    private static readonly string[] ExactArtifactNames = [".DS_Store", ".stfolder", ".stversions"];
+    private static readonly string[] CaseInsensitiveExactArtifactNames = ["Thumbs.db", "desktop.ini"];
+    private static readonly string[] ArtifactPrefixes = ["._", "~syncthing~", ".nextcloud", ".dropbox"];
+
+    /// <summary>
+    /// Scans <paramref name="directory"/> and classifies every entry by filename shape alone.
+    /// Directory does not need to exist beforehand from this method's point of view beyond
+    /// <see cref="DirectoryInfo.EnumerateFileSystemInfos()"/>'s own requirements — it throws
+    /// whatever that throws (e.g. <see cref="DirectoryNotFoundException"/>) if it doesn't.
+    /// </summary>
+    public static DirectoryScanResult Scan(DirectoryInfo directory)
+    {
+        ArgumentNullException.ThrowIfNull(directory);
+
+        var validRecords = new List<string>();
+        var conflicts = new List<ConflictWarning>();
+        var ignored = new List<string>();
+
+        // Do NOT use FileInfo.LastWriteTimeUtc (or any other filesystem mtime) anywhere in or
+        // after this enumeration to decide which copy of a record is newer. Sync tools rewrite
+        // mtime freely and on their own schedule -- it reflects when a copy last landed on this
+        // machine, not when it was actually written relative to any other copy. The only
+        // ordering authority is the per-record write counter inside the record's own cleartext
+        // envelope header (see SecretRecordCodec), with an origin-id tiebreak; this scanner
+        // never reads either, deliberately, so it can't be tempted to substitute mtime for them.
+        foreach (var entry in directory.EnumerateFileSystemInfos())
+        {
+            var name = entry.Name;
+
+            if (ValidRecordFilename.IsMatch(name))
+            {
+                validRecords.Add(name);
+                continue;
+            }
+
+            var conflict = TryMatchConflict(name);
+            if (conflict is not null)
+            {
+                conflicts.Add(conflict);
+                continue;
+            }
+
+            // Everything else -- named artefact, tswap's own temp file, or genuinely unknown
+            // junk -- is ignored without warning. IsKnownSyncArtifact/TswapTempFile are not
+            // consulted here: whether or not a filename matches a specific known pattern, the
+            // outcome for anything that isn't a record or a conflict is the same, per the parent
+            // issue's "skip everything else silently" instruction. The named checks exist as a
+            // documented, independently testable surface (see
+            // TswapTests/RecordDirectoryScannerTests.cs) for "this specific artefact is
+            // recognised", not because the classification result differs.
+            ignored.Add(name);
+        }
+
+        return new DirectoryScanResult(validRecords, conflicts, ignored);
+    }
+
+    /// <summary>Convenience overload taking a directory path instead of a <see cref="DirectoryInfo"/>.</summary>
+    public static DirectoryScanResult Scan(string directoryPath) => Scan(new DirectoryInfo(directoryPath));
+
+    /// <summary>
+    /// True if <paramref name="filename"/> matches one of the named sync-tool artefact patterns
+    /// from the parent issue's table (<c>.DS_Store</c>, AppleDouble <c>._*</c>, <c>Thumbs.db</c>,
+    /// <c>desktop.ini</c>, Syncthing's <c>.stfolder</c>/<c>.stversions</c>/<c>~syncthing~*</c>,
+    /// <c>.nextcloud*</c>, <c>.dropbox*</c>) or tswap's own in-flight temp file shape. Exposed
+    /// separately from <see cref="Scan"/> so each named pattern is independently testable —
+    /// <see cref="Scan"/> itself does not branch on this result (see the comment at its
+    /// enumeration site).
+    /// </summary>
+    public static bool IsKnownSyncArtifact(string filename)
+    {
+        ArgumentNullException.ThrowIfNull(filename);
+
+        if (Array.IndexOf(ExactArtifactNames, filename) >= 0)
+            return true;
+
+        foreach (var name in CaseInsensitiveExactArtifactNames)
+        {
+            if (string.Equals(filename, name, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        foreach (var prefix in ArtifactPrefixes)
+        {
+            if (filename.StartsWith(prefix, StringComparison.Ordinal))
+                return true;
+        }
+
+        return TswapTempFile.IsMatch(filename);
+    }
+
+    private static ConflictWarning? TryMatchConflict(string name)
+    {
+        var match = DropboxGoogleDriveConflictedCopy.Match(name);
+        if (match.Success)
+            return new ConflictWarning(match.Groups["base"].Value, name, SyncConflictTool.DropboxOrGoogleDrive);
+
+        match = DropboxGoogleDriveNumbered.Match(name);
+        if (match.Success)
+            return new ConflictWarning(match.Groups["base"].Value, name, SyncConflictTool.DropboxOrGoogleDrive);
+
+        // Syncthing before OneDrive: Syncthing's pattern also contains hyphens after the base,
+        // but is introduced by a literal '.', which OneDriveConflict's leading '-' would never
+        // match anyway (its regex requires '-' as the very next character after the 64 hex
+        // chars) -- checked first regardless, so this stays true even if either pattern changes.
+        match = SyncthingConflict.Match(name);
+        if (match.Success)
+            return new ConflictWarning(match.Groups["base"].Value, name, SyncConflictTool.Syncthing);
+
+        match = OneDriveConflict.Match(name);
+        if (match.Success)
+            return new ConflictWarning(match.Groups["base"].Value, name, SyncConflictTool.OneDrive);
+
+        return null;
+    }
+}

--- a/TswapCore/Keyring/UnixDirectoryFsync.cs
+++ b/TswapCore/Keyring/UnixDirectoryFsync.cs
@@ -1,0 +1,75 @@
+using System.Runtime.InteropServices;
+
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// Best-effort <c>fsync</c> on a directory's own file descriptor (Unix only) — the optional
+/// sub-item of issue #137's work item 1. <see cref="FileStream.Flush(bool)"/> flushes a file's
+/// contents to durable storage but not the directory entry a rename creates; on Unix the fix is
+/// <c>fsync</c> on the directory itself, which .NET has no managed API for.
+///
+/// <para><b>Windows has no directory-fsync concept</b> (there is no POSIX-style directory file
+/// descriptor to open/fsync); on Windows <see cref="TryFsync"/> is a deliberate no-op and this
+/// codebase relies on the server/filesystem instead, matching the parent issue's guidance.</para>
+///
+/// <para>Uses <see cref="LibraryImport"/>, not <c>DllImport</c> — source-generated marshalling,
+/// AOT/trim-safe by construction, matching the interop style this codebase already uses for
+/// P/Invoke bridges (see <c>TswapCore/Vault/Interop/</c>).</para>
+///
+/// <para><b>Best-effort by design, not a correctness dependency:</b> <see cref="TryFsync"/>
+/// never throws. If the directory can't be opened (permissions, an exotic filesystem, a
+/// misbehaving container overlay) this silently degrades to "the file's own contents are
+/// durable, the directory entry for the rename might not be yet" — exactly the guarantee this
+/// codebase already had before this class existed. That degraded case is not covered by any
+/// automated test (see <see cref="DurableFileWriter"/>'s doc comment on what is/isn't verified);
+/// only the happy path — open/fsync/close succeed — is exercised by
+/// <c>TswapTests/DurableFileWriterTests.cs</c>, indirectly, via a successful write.</para>
+/// </summary>
+internal static partial class UnixDirectoryFsync
+{
+    private const int ORdOnly = 0x0000;
+
+    [LibraryImport("libc", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int open(string pathname, int flags);
+
+    [LibraryImport("libc", SetLastError = true)]
+    private static partial int fsync(int fd);
+
+    [LibraryImport("libc", SetLastError = true)]
+    private static partial int close(int fd);
+
+    /// <summary>
+    /// Opens <paramref name="directoryPath"/> read-only and fsyncs it. Never throws: any
+    /// failure (unsupported platform, permission denied, fd exhaustion) is swallowed and this
+    /// simply does nothing, per this class's doc comment.
+    /// </summary>
+    public static void TryFsync(string directoryPath)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        int fd;
+        try
+        {
+            fd = open(directoryPath, ORdOnly);
+        }
+        catch
+        {
+            // e.g. libc not resolvable on this platform at all -- treat exactly like a failed
+            // open() below.
+            return;
+        }
+
+        if (fd < 0)
+            return;
+
+        try
+        {
+            fsync(fd);
+        }
+        finally
+        {
+            close(fd);
+        }
+    }
+}

--- a/TswapCore/TswapCore.csproj
+++ b/TswapCore/TswapCore.csproj
@@ -4,6 +4,14 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!--
+      Required by the source-generated LibraryImport marshalling stubs (see
+      Keyring/UnixDirectoryFsync.cs): LibraryImportGenerator emits pointer-based marshalling
+      code that needs /unsafe, even though LibraryImport itself (unlike DllImport) is AOT/trim
+      safe by construction. Unsafe code has always been NativeAOT-compatible; it is reflection
+      that AOT dislikes, not pointers.
+    -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TswapTests/DurableFileWriterTests.cs
+++ b/TswapTests/DurableFileWriterTests.cs
@@ -1,0 +1,98 @@
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Happy-path only, per the parent issue's testing notes and
+/// <see cref="DurableFileWriter"/>'s own doc comment: write bytes, read them back, byte-exact.
+/// Durability under a killed process or a real network mount's specific failure modes is not
+/// something an honest unit test can claim and is not attempted here.
+/// </summary>
+public class DurableFileWriterTests
+{
+    [Fact]
+    public void WriteAtomic_WritesBytesReadableAfterward()
+    {
+        using var tempDir = new TempDirectory();
+        var bytes = new byte[] { 1, 2, 3, 4, 5, 250, 251, 252 };
+
+        DurableFileWriter.WriteAtomic(tempDir.Info, "target-file", bytes);
+
+        var readBack = File.ReadAllBytes(Path.Combine(tempDir.Path, "target-file"));
+        Assert.Equal(bytes, readBack);
+    }
+
+    [Fact]
+    public void WriteAtomic_OverwritesExistingTargetFile()
+    {
+        using var tempDir = new TempDirectory();
+        var targetPath = Path.Combine(tempDir.Path, "target-file");
+        File.WriteAllBytes(targetPath, [9, 9, 9, 9]);
+
+        DurableFileWriter.WriteAtomic(tempDir.Info, "target-file", [1, 2, 3]);
+
+        Assert.Equal([1, 2, 3], File.ReadAllBytes(targetPath));
+    }
+
+    [Fact]
+    public void WriteAtomic_DoesNotLeaveATempFileBehind()
+    {
+        using var tempDir = new TempDirectory();
+
+        DurableFileWriter.WriteAtomic(tempDir.Info, "target-file", [1, 2, 3]);
+
+        var entries = Directory.GetFileSystemEntries(tempDir.Path);
+        Assert.Equal(["target-file"], entries.Select(Path.GetFileName));
+    }
+
+    [Fact]
+    public void WriteAtomic_StringDirectoryOverloadMatchesDirectoryInfoOverload()
+    {
+        using var tempDir = new TempDirectory();
+
+        DurableFileWriter.WriteAtomic(tempDir.Path, "target-file", [7, 8, 9]);
+
+        Assert.Equal([7, 8, 9], File.ReadAllBytes(Path.Combine(tempDir.Path, "target-file")));
+    }
+
+    [Fact]
+    public void WriteAtomic_MissingDirectoryThrowsDirectoryNotFound()
+    {
+        using var tempDir = new TempDirectory();
+        var missing = new DirectoryInfo(Path.Combine(tempDir.Path, "does-not-exist"));
+
+        Assert.Throws<DirectoryNotFoundException>(() => DurableFileWriter.WriteAtomic(missing, "target-file", [1]));
+    }
+
+    [Fact]
+    public void WriteAtomic_EmptyBytesRoundTrips()
+    {
+        using var tempDir = new TempDirectory();
+
+        DurableFileWriter.WriteAtomic(tempDir.Info, "target-file", []);
+
+        Assert.Empty(File.ReadAllBytes(Path.Combine(tempDir.Path, "target-file")));
+    }
+
+    /// <summary>Wraps <see cref="Directory.CreateTempSubdirectory"/> so every test cleans up after itself.</summary>
+    private sealed class TempDirectory : IDisposable
+    {
+        private readonly DirectoryInfo _dir = Directory.CreateTempSubdirectory("tswap-durable-write-tests-");
+
+        public string Path => _dir.FullName;
+        public DirectoryInfo Info => _dir;
+
+        public void Dispose()
+        {
+            try
+            {
+                _dir.Delete(recursive: true);
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+    }
+}

--- a/TswapTests/RecordDirectoryScannerTests.cs
+++ b/TswapTests/RecordDirectoryScannerTests.cs
@@ -1,0 +1,182 @@
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Plain unit tests per the parent issue's own testing notes: seed a real temp directory with
+/// files matching every artefact/conflict pattern, no network involved. These are filename-shape
+/// assertions only -- this scanner never reads file contents.
+/// </summary>
+public class RecordDirectoryScannerTests
+{
+    private const string RecordA = "3891556c9fbaea798948ce68d2de628b389e67e061e3f4c7d73abaf4c826c113";
+    private const string RecordB = "bfdb72de6f2ab369a9560931b221f4c425118410529865f9e9acaed3f5591682";
+
+    [Fact]
+    public void Scan_RecognisesValidRecordFilenames()
+    {
+        using var dir = new TempDirectory();
+        dir.Touch(RecordA);
+        dir.Touch(RecordB);
+
+        var result = RecordDirectoryScanner.Scan(dir.Info);
+
+        Assert.Equal([RecordA, RecordB], result.ValidRecordFilenames.OrderBy(n => n));
+        Assert.Empty(result.Conflicts);
+    }
+
+    [Theory]
+    [InlineData(".DS_Store")]
+    [InlineData("._AppleDouble")]
+    [InlineData("._" + RecordA)]
+    [InlineData("Thumbs.db")]
+    [InlineData("thumbs.db")]
+    [InlineData("desktop.ini")]
+    [InlineData("Desktop.ini")]
+    [InlineData(".stfolder")]
+    [InlineData(".stversions")]
+    [InlineData("~syncthing~sometemp")]
+    [InlineData(".nextcloudsync.log")]
+    [InlineData(".dropbox")]
+    [InlineData(".dropbox.cache")]
+    [InlineData("a1b2c3d4.e5f")] // tswap's own in-flight temp file shape (DurableFileWriter)
+    public void Scan_IgnoresKnownSyncArtifactsWithoutWarning(string artifactName)
+    {
+        using var dir = new TempDirectory();
+        dir.Touch(artifactName);
+        dir.Touch(RecordA); // control: a real record must still come through
+
+        var result = RecordDirectoryScanner.Scan(dir.Info);
+
+        Assert.Equal([RecordA], result.ValidRecordFilenames);
+        Assert.Empty(result.Conflicts);
+        Assert.Contains(artifactName, result.IgnoredFilenames);
+        Assert.True(RecordDirectoryScanner.IsKnownSyncArtifact(artifactName));
+    }
+
+    [Fact]
+    public void Scan_IgnoresGenuinelyUnrecognisedFilesWithoutError()
+    {
+        using var dir = new TempDirectory();
+        dir.Touch("some-random-file.txt");
+
+        var result = RecordDirectoryScanner.Scan(dir.Info);
+
+        Assert.Empty(result.ValidRecordFilenames);
+        Assert.Empty(result.Conflicts);
+        Assert.Contains("some-random-file.txt", result.IgnoredFilenames);
+    }
+
+    [Theory]
+    [InlineData($"{RecordA} (conflicted copy 2026-07-27)")]
+    [InlineData($"{RecordA} (1)")]
+    public void Scan_ReportsDropboxOrGoogleDriveConflictedCopy(string conflictName)
+    {
+        using var dir = new TempDirectory();
+        dir.Touch(RecordA);
+        dir.Touch(conflictName);
+
+        var result = RecordDirectoryScanner.Scan(dir.Info);
+
+        var warning = Assert.Single(result.Conflicts);
+        Assert.Equal(RecordA, warning.RecordFilename);
+        Assert.Equal(conflictName, warning.ConflictingFilename);
+        Assert.Equal(SyncConflictTool.DropboxOrGoogleDrive, warning.Tool);
+        Assert.DoesNotContain(conflictName, result.ValidRecordFilenames);
+        Assert.DoesNotContain(conflictName, result.IgnoredFilenames);
+    }
+
+    [Fact]
+    public void Scan_ReportsOneDriveConflictedCopy()
+    {
+        using var dir = new TempDirectory();
+        var conflictName = $"{RecordA}-DESKTOP-ABC123";
+        dir.Touch(RecordA);
+        dir.Touch(conflictName);
+
+        var result = RecordDirectoryScanner.Scan(dir.Info);
+
+        var warning = Assert.Single(result.Conflicts);
+        Assert.Equal(RecordA, warning.RecordFilename);
+        Assert.Equal(conflictName, warning.ConflictingFilename);
+        Assert.Equal(SyncConflictTool.OneDrive, warning.Tool);
+        Assert.DoesNotContain(conflictName, result.ValidRecordFilenames);
+        Assert.DoesNotContain(conflictName, result.IgnoredFilenames);
+    }
+
+    [Fact]
+    public void Scan_ReportsSyncthingConflictedCopy()
+    {
+        using var dir = new TempDirectory();
+        var conflictName = $"{RecordA}.sync-conflict-20260727-120000-ABCDEF";
+        dir.Touch(RecordA);
+        dir.Touch(conflictName);
+
+        var result = RecordDirectoryScanner.Scan(dir.Info);
+
+        var warning = Assert.Single(result.Conflicts);
+        Assert.Equal(RecordA, warning.RecordFilename);
+        Assert.Equal(conflictName, warning.ConflictingFilename);
+        Assert.Equal(SyncConflictTool.Syncthing, warning.Tool);
+        Assert.DoesNotContain(conflictName, result.ValidRecordFilenames);
+        Assert.DoesNotContain(conflictName, result.IgnoredFilenames);
+    }
+
+    [Fact]
+    public void Scan_MixedDirectorySeparatesAllThreeCategories()
+    {
+        using var dir = new TempDirectory();
+        dir.Touch(RecordA);
+        dir.Touch(RecordB);
+        dir.Touch(".DS_Store");
+        dir.Touch("Thumbs.db");
+        dir.Touch(".stfolder");
+        var dropboxConflict = $"{RecordA} (conflicted copy 2026-07-27)";
+        var oneDriveConflict = $"{RecordB}-DESKTOP-ABC123";
+        dir.Touch(dropboxConflict);
+        dir.Touch(oneDriveConflict);
+
+        var result = RecordDirectoryScanner.Scan(dir.Info);
+
+        Assert.Equal([RecordA, RecordB], result.ValidRecordFilenames.OrderBy(n => n));
+        Assert.Equal(2, result.Conflicts.Count);
+        Assert.Contains(result.Conflicts, c => c.ConflictingFilename == dropboxConflict && c.RecordFilename == RecordA);
+        Assert.Contains(result.Conflicts, c => c.ConflictingFilename == oneDriveConflict && c.RecordFilename == RecordB);
+        Assert.Equal(3, result.IgnoredFilenames.Count);
+    }
+
+    [Fact]
+    public void Scan_StringDirectoryOverloadMatchesDirectoryInfoOverload()
+    {
+        using var dir = new TempDirectory();
+        dir.Touch(RecordA);
+
+        var result = RecordDirectoryScanner.Scan(dir.Path);
+
+        Assert.Equal([RecordA], result.ValidRecordFilenames);
+    }
+
+    /// <summary>Wraps <see cref="Directory.CreateTempSubdirectory"/> so every test cleans up after itself.</summary>
+    private sealed class TempDirectory : IDisposable
+    {
+        private readonly DirectoryInfo _dir = Directory.CreateTempSubdirectory("tswap-record-scanner-tests-");
+
+        public string Path => _dir.FullName;
+        public DirectoryInfo Info => _dir;
+
+        public void Touch(string filename) => File.WriteAllBytes(System.IO.Path.Combine(Path, filename), []);
+
+        public void Dispose()
+        {
+            try
+            {
+                _dir.Delete(recursive: true);
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the reusable infrastructure from #137 as new, standalone, unit-testable code in `TswapCore/Keyring/` — decoupled from any actual `IVaultStore`, since the per-secret record store this eventually plugs into isn't wired up yet (that's #119/#124, not this PR). Operates on plain directories/paths/byte arrays/filenames so it's ready to be dropped in later without needing that store to exist now.

## What's done, per the issue's 4 work items

- **Work item 1 — durable write path: fully done.** `TswapCore/Keyring/DurableFileWriter.cs` implements the exact pattern from the issue: temp file in the same directory (never `Path.GetTempPath()`), `FileOptions.WriteThrough` + `fs.Flush(flushToDisk: true)`, then `File.Move(overwrite: true)` (not `File.Replace`). The optional Unix directory-fsync sub-item is also included: `TswapCore/Keyring/UnixDirectoryFsync.cs` P/Invokes `open`/`fsync`/`close` via `LibraryImport` (matching this codebase's AOT-safe interop convention), best-effort, silent no-op on Windows. Required adding `<AllowUnsafeBlocks>true</AllowUnsafeBlocks>` to `TswapCore.csproj` — `LibraryImport`'s generated marshalling code needs `/unsafe` even though `LibraryImport` itself is AOT/trim-safe by construction; verified `dotnet publish -c Release` for `TswapCli` still succeeds (NativeAOT tripwire).
- **Work item 2 — directory scan tolerance: fully done.** `TswapCore/Keyring/RecordDirectoryScanner.cs` classifies every filename in a directory into: a valid record (64-char lowercase hex, no extension), a known sync-tool artefact (`.DS_Store`, `._*`, `Thumbs.db`, `desktop.ini`, Syncthing's `.stfolder`/`.stversions`/`~syncthing~*`, `.nextcloud*`, `.dropbox*`, tswap's own in-flight temp files) silently ignored, or a conflicted copy (Dropbox/Google Drive `<name> (conflicted copy ...)` / `<name> (1)`, OneDrive `<name>-DESKTOP-ABC123`, Syncthing `<name>.sync-conflict-...`) surfaced as a `ConflictWarning`, never silently dropped. A comment at the enumeration site explicitly warns against ever using `FileInfo.LastWriteTimeUtc` for ordering. Deliberately filename-only — no record content is read (no vault key available at this layer), so it cannot yet report the "generation N from LAPTOP vs generation M from DESKTOP" detail the issue describes; that needs the vault key and belongs in the future store layer.
- **Work item 3 — cloud placeholder files: documentation-only**, per the issue's own "Minimum: document..." framing. No placeholder-detection code was written (the optional Windows `FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS` detection was skipped as genuinely optional). Covered in the new README section.
- **Work item 4 — README: done.** New "Sync transports" section covers the local-disk-plus-sync-tool rule, why it's a protocol distinction and not a hosting one, NAS as supported-with-caveats (not a flat prohibition, but explicitly noted as untested), no lock files, and the cloud-placeholder-files caveat.

## Deliberately not done / out of scope

- Wiring any of this into `TswapCore/Storage.cs` or a new `IVaultStore` — explicitly out of scope per the task brief and the issue's own dependency on #119/#124.
- Reading record contents (generation counter, write counter) to enrich conflict warnings — needs the vault key, which this filename-only layer doesn't have.
- Real durability testing under a killed process or a real SMB/NFS server — the issue itself calls this "harder to test honestly" and out of scope for an honest unit-test claim. Only the happy path (write bytes, read back, byte-exact) is tested.
- NAS support is documented as "supported with caveats" per the issue's framing, but explicitly flagged in the README as untested by this project — the honest position given no testing was done.
- Windows on-demand-file (`FILE_ATTRIBUTE_OFFLINE`) detection — the issue lists this as optional.

## Testing

- `TswapTests/DurableFileWriterTests.cs` — happy-path only (write, overwrite, no leftover temp file, empty payload, missing-directory error, string/DirectoryInfo overload parity).
- `TswapTests/RecordDirectoryScannerTests.cs` — seeds a real temp directory (`Directory.CreateTempSubdirectory`, cleaned up after) with every artefact pattern from the issue's table plus valid 64-hex record names, and separately with each of the three conflicted-copy naming patterns; asserts correct 3-way separation and that conflicts are never silently dropped or misclassified as records.
- `./runtests.sh --unit` passes in full (394/394).
- `dotnet publish -c Release` for `TswapCli/TswapCli.csproj` still succeeds.

Sandbox note: this environment only had .NET SDK 10.0.301 installed while `global.json` pins 10.0.302; `global.json` was temporarily edited to build/test locally and reverted to the committed value before this commit (per an established workaround other agents on this repo have used).

## Test plan

- [x] `./runtests.sh --unit` — 394 passed, 0 failed
- [x] `dotnet publish -c Release` for `TswapCli/TswapCli.csproj` succeeds
- [x] Manually ran the published binary (`tswap prompt-hash`) to confirm the AOT build still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)