### PR TITLE
Phase 6 v0: generation-guard stale-save detection (#118)

### DIFF
--- a/TswapCore/Keyring/GenerationGuard.cs
+++ b/TswapCore/Keyring/GenerationGuard.cs
@@ -1,0 +1,44 @@
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// Stale-save detection for the Phase 6 vault generation counter (issue #118). Standalone
+/// infrastructure, like #137's <see cref="DurableFileWriter"/>: this type has no dependency on
+/// any <see cref="IVaultStore"/> or real multi-machine store (that's #119/#124, not landed yet)
+/// — it just compares the generation a caller loaded a vault at against the generation currently
+/// on disk, and refuses to let a stale write clobber a newer one.
+///
+/// <para>Uses <see cref="SecretRecord.OriginId"/> as the "last-writer id" rather than inventing a
+/// second identifier — see that field's doc comment, which already reserves it for this exact
+/// purpose.</para>
+/// </summary>
+public static class GenerationGuard
+{
+    /// <summary>
+    /// True when <paramref name="onDiskGeneration"/> is strictly ahead of
+    /// <paramref name="loadedGeneration"/> — i.e. some other writer has saved since this caller
+    /// last loaded. Equal generations (the ordinary save-after-load case) are not stale, and
+    /// neither is a loaded generation ahead of disk (disk simply hasn't caught up yet, e.g.
+    /// immediately after a fresh load with nothing else having written since).
+    /// </summary>
+    public static bool IsStale(uint loadedGeneration, uint onDiskGeneration)
+        => onDiskGeneration > loadedGeneration;
+
+    /// <summary>
+    /// Throws a <see cref="TswapException"/> naming both generations and both origin ids when
+    /// <paramref name="onDiskGeneration"/> is ahead of <paramref name="loadedGeneration"/>
+    /// (see <see cref="IsStale"/>); otherwise does nothing. Origin ids are rendered as hex since
+    /// this layer has no human-readable machine-label mapping (e.g. "LAPTOP"/"DESKTOP", the
+    /// issue's own example) — a future layer that maintains such a mapping could produce a
+    /// friendlier message from the same ids.
+    /// </summary>
+    public static void CheckNotStale(uint loadedGeneration, byte[] loadedOriginId, uint onDiskGeneration, byte[] onDiskOriginId)
+    {
+        if (!IsStale(loadedGeneration, onDiskGeneration))
+            return;
+
+        throw new TswapException(
+            $"Refusing stale save: on-disk generation {onDiskGeneration} from origin {Convert.ToHexString(onDiskOriginId)} " +
+            $"is ahead of the loaded generation {loadedGeneration} from origin {Convert.ToHexString(loadedOriginId)} " +
+            "-- reload before saving.");
+    }
+}

--- a/TswapTests/GenerationGuardTests.cs
+++ b/TswapTests/GenerationGuardTests.cs
@@ -1,0 +1,60 @@
+using TswapCore;
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Standalone tests for the #118 stale-save guard, matching the issue's own "~20 lines" framing
+/// for the implementation: no store, no format round-trip -- just generation/origin-id
+/// comparisons.
+/// </summary>
+public class GenerationGuardTests
+{
+    private static readonly byte[] LaptopOriginId = Enumerable.Repeat((byte)0xAB, 16).ToArray();
+    private static readonly byte[] DesktopOriginId = Enumerable.Repeat((byte)0xCD, 16).ToArray();
+
+    [Fact]
+    public void IsStale_EqualGenerations_IsNotStale()
+    {
+        Assert.False(GenerationGuard.IsStale(loadedGeneration: 7, onDiskGeneration: 7));
+    }
+
+    [Fact]
+    public void IsStale_OnDiskAhead_IsStale()
+    {
+        Assert.True(GenerationGuard.IsStale(loadedGeneration: 7, onDiskGeneration: 9));
+    }
+
+    [Fact]
+    public void IsStale_LoadedAheadOfDisk_IsNotStale()
+    {
+        // The normal case right after a fresh load: nothing else has written since, so disk
+        // simply hasn't caught up to what's already in memory yet.
+        Assert.False(GenerationGuard.IsStale(loadedGeneration: 9, onDiskGeneration: 7));
+    }
+
+    [Fact]
+    public void CheckNotStale_EqualGenerations_DoesNotThrow()
+    {
+        GenerationGuard.CheckNotStale(7, LaptopOriginId, 7, LaptopOriginId);
+    }
+
+    [Fact]
+    public void CheckNotStale_LoadedAheadOfDisk_DoesNotThrow()
+    {
+        GenerationGuard.CheckNotStale(9, LaptopOriginId, 7, DesktopOriginId);
+    }
+
+    [Fact]
+    public void CheckNotStale_OnDiskAhead_ThrowsWithBothGenerationsAndOriginIds()
+    {
+        var ex = Assert.Throws<TswapException>(() =>
+            GenerationGuard.CheckNotStale(loadedGeneration: 7, LaptopOriginId, onDiskGeneration: 9, DesktopOriginId));
+
+        Assert.Contains("7", ex.Message);
+        Assert.Contains("9", ex.Message);
+        Assert.Contains(Convert.ToHexString(LaptopOriginId), ex.Message);
+        Assert.Contains(Convert.ToHexString(DesktopOriginId), ex.Message);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `TswapCore/Keyring/GenerationGuard.cs`: standalone, store-independent infrastructure (same posture as the already-merged #137) that compares a loaded vault generation against the on-disk generation and refuses a stale save.
- `IsStale(loadedGeneration, onDiskGeneration)` returns true only when `onDiskGeneration > loadedGeneration` — equal generations (normal save-after-load) and loaded-ahead-of-disk (normal right after a fresh load) are both not stale.
- `CheckNotStale(...)` throws a `TswapException` naming both generations and both origin ids (hex-encoded, since this layer has no human-readable machine-label mapping) when stale, matching `SecretRecordCodec`'s existing style of distinct, specific exception messages.
- Reuses `SecretRecord.OriginId` as the "last-writer id" per that field's existing doc comment (which already reserves it for this purpose) rather than inventing a second identifier.
- No changes to `SecretRecord.cs`/`SecretRecordCodec.cs` wire format or byte layout — that's settled v0 gate work. No new file added that could collide with #116/#117.
- Not wired into any `IVaultStore`/save path — there's no real multi-machine store yet (#119/#124); this is ready for when one lands.

Closes #118.

## Test plan
- [x] `./runtests.sh --unit` passes in full (432/432)
- [x] `dotnet publish -c Release TswapCli/TswapCli.csproj` succeeds (NativeAOT tripwire)
- [x] New `TswapTests/GenerationGuardTests.cs` covers: equal generations (not stale), on-disk-ahead (stale, throws with both generations/origin-ids in message), loaded-ahead-of-disk (not stale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)