### PR TITLE
Phase 6 v0: two-layer slot AEAD wrap + formatVersion/vaultId/k/slotId AAD binding (#116, #117)

### DIFF
--- a/TswapCore/Keyring/KeyringFormat.cs
+++ b/TswapCore/Keyring/KeyringFormat.cs
@@ -47,4 +47,26 @@ public static class KeyringFormat
 
     /// <summary>Byte length of an origin id (opaque per-machine/per-slot tiebreak identifier).</summary>
     public const int OriginIdSize = 16;
+
+    /// <summary>
+    /// Byte length of a vault id (opaque, randomly generated once at vault init — see
+    /// <see cref="Keyring.SlotPayloadWrap"/>'s AAD binding, issue #117). 16 bytes (128 bits) is
+    /// not a security boundary — a vaultId is not secret, and each slot's AEAD binding already
+    /// means an attacker can't substitute a different vault's slot without possessing that
+    /// slot's <c>KEK_slot</c> — it is sized purely so two independently-created vaults collide
+    /// with negligible probability, the same reasoning as a random UUID/GUID (also 16 bytes).
+    /// </summary>
+    public const int VaultIdSize = 16;
+
+    /// <summary>
+    /// Byte length of a slot id (opaque per-slot identifier, generated once when a slot is
+    /// enrolled — see <see cref="Keyring.SlotPayloadWrap"/>'s AAD binding, issue #117). Same
+    /// size and rationale as <see cref="OriginIdSize"/>, whose doc comment already anticipates
+    /// this exact "per-slot identifier" use; kept as its own constant rather than reusing
+    /// <see cref="OriginIdSize"/> directly because the two name different things at different
+    /// layers — a slot id identifies an AEAD-bound keyring entry, an origin id identifies a
+    /// per-record last-writer tiebreak — and nothing requires their sizes to move together if
+    /// either one changes later.
+    /// </summary>
+    public const int SlotIdSize = 16;
 }

--- a/TswapCore/Keyring/SlotPayloadWrap.cs
+++ b/TswapCore/Keyring/SlotPayloadWrap.cs
@@ -105,11 +105,11 @@ public static class SlotPayloadWrap
         {
             aes.Decrypt(nonce, ciphertext, tag, payload, aad);
         }
-        catch (CryptographicException ex)
+        catch (CryptographicException)
         {
             throw new TswapException(
                 "Slot unwrap failed: authentication check failed (wrong kekSlot, tampered ciphertext, " +
-                "or a formatVersion/vaultId/k/slotId mismatch)", ex.HResult);
+                "or a formatVersion/vaultId/k/slotId mismatch)");
         }
 
         return payload;

--- a/TswapCore/Keyring/SlotPayloadWrap.cs
+++ b/TswapCore/Keyring/SlotPayloadWrap.cs
@@ -1,0 +1,159 @@
+using System.Security.Cryptography;
+
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// The AEAD "wrap" half of the Phase 6 two-layer slot scheme (issues #116/#117 — see
+/// <c>MULTI_MACHINE_KEYING.md</c> §Two-layer slot wrap and §AAD binding).
+///
+/// <para>Given a 32-byte per-slot key-encryption-key (<c>KEK_slot</c> — recovered however a
+/// backend's own wrap/seal primitive or <see cref="Vault.IHardwareKeyService.Unlock"/> produces
+/// it; this layer neither knows nor cares) and an opaque payload (in v0, eventually <c>K_v</c>
+/// itself, but nothing here assumes a specific payload shape or length), this type AES-256-GCM
+/// encrypts/decrypts the payload with associated data binding <c>formatVersion</c>,
+/// <c>vaultId</c>, <c>k</c>, and <c>slotId</c> — see <see cref="BuildAad"/> for the exact
+/// layout. Binding these fields into the AEAD is the <b>primary</b> defense against threshold
+/// downgrade: an attacker holding the synced files plus one enrolled device cannot silently
+/// rewrite <c>k = 2 -&gt; k = 1</c> (or swap in a different vault's slot, or replay an old
+/// <c>formatVersion</c>) because a mismatch on any bound field makes the AEAD unwrap itself
+/// fail, and fixing that up requires re-wrapping every slot — which needs every enrolled device
+/// physically present.</para>
+///
+/// <para><b>Why AES-256-GCM called directly here, not <see cref="Crypto.Encrypt"/>/
+/// <see cref="Crypto.Decrypt"/>:</b> those two do not expose <see cref="AesGcm"/>'s
+/// associated-data parameter at all (they call the no-AAD overload) and remain unchanged for
+/// their existing callers (the single-blob vault format, export/import) — this type calls
+/// <see cref="AesGcm"/>'s associated-data overloads directly instead of touching them.</para>
+///
+/// <para><b>Why not XOR:</b> XOR only made sense while <c>K_v</c> was itself *derived* from
+/// hardware (today's YubiKey-pair scheme, see <see cref="Crypto.DeriveKey"/>). Under two-layer
+/// slots — where each slot independently wraps a fresh, unrelated <c>KEK_slot</c> — XOR would
+/// need a public <c>K1 ⊕ K2</c> share alongside it, which is isomorphic to wrapping <c>K_v</c>
+/// directly per slot plus an extra derivation step and a one-time-pad reuse hazard on rotation
+/// (see the design doc's "The landmine"). AES-256-GCM is strictly less code with no such
+/// hazard, so this type never touches <see cref="Crypto.XorBytes"/>.</para>
+/// </summary>
+public static class SlotPayloadWrap
+{
+    /// <summary>Required length of <c>KEK_slot</c>, the AES-256 key this layer wraps under.</summary>
+    public const int KekSlotSize = 32;
+
+    /// <summary>
+    /// AES-256-GCM encrypts <paramref name="payload"/> under <paramref name="kekSlot"/>, with
+    /// associated data built from <paramref name="formatVersion"/>, <paramref name="vaultId"/>,
+    /// <paramref name="k"/>, and <paramref name="slotId"/> (see <see cref="BuildAad"/>).
+    ///
+    /// <para>Output layout mirrors <see cref="Crypto.Encrypt"/>: <c>nonce(12) || tag(16) ||
+    /// ciphertext</c>, both nonce and tag at AES-GCM's max sizes, nonce freshly random per
+    /// call.</para>
+    /// </summary>
+    public static byte[] Wrap(byte[] payload, byte[] kekSlot, byte formatVersion, byte[] vaultId, byte k, byte[] slotId)
+    {
+        ValidateKekSlot(kekSlot);
+        var aad = BuildAad(formatVersion, vaultId, k, slotId);
+
+        var nonceSize = AesGcm.NonceByteSizes.MaxSize;
+        var tagSize = AesGcm.TagByteSizes.MaxSize;
+        using var aes = new AesGcm(kekSlot, tagSize);
+
+        var result = new byte[nonceSize + tagSize + payload.Length];
+        var nonce = result.AsSpan(0, nonceSize);
+        var tag = result.AsSpan(nonceSize, tagSize);
+        var ciphertext = result.AsSpan(nonceSize + tagSize);
+
+        RandomNumberGenerator.Fill(nonce);
+        aes.Encrypt(nonce, payload, ciphertext, tag, aad);
+        return result;
+    }
+
+    /// <summary>
+    /// Decrypts and authenticates a value previously produced by <see cref="Wrap"/>. Throws
+    /// <see cref="TswapException"/> — never a raw BCL exception — for:
+    /// <list type="bullet">
+    /// <item><paramref name="wrapped"/> shorter than AES-GCM's fixed nonce+tag overhead (checked
+    /// before any AesGcm call is reached, the same lesson <see cref="SecretRecordCodec.Decode"/>
+    /// already applies to its own length-prefixed payload field);</item>
+    /// <item>a wrong <paramref name="kekSlot"/>, tampered ciphertext, or any AAD-bound field
+    /// (<paramref name="formatVersion"/>, <paramref name="vaultId"/>, <paramref name="k"/>,
+    /// <paramref name="slotId"/>) not matching what <see cref="Wrap"/> was called with — these
+    /// all surface identically as an AES-GCM authentication failure by design: an attacker
+    /// rewriting a bound field (e.g. downgrading <c>k</c>) cannot distinguish "wrong key" from
+    /// "tampered AAD" from the failure alone (see the design doc's "The landmine").</item>
+    /// </list>
+    /// </summary>
+    public static byte[] Unwrap(byte[] wrapped, byte[] kekSlot, byte formatVersion, byte[] vaultId, byte k, byte[] slotId)
+    {
+        ValidateKekSlot(kekSlot);
+
+        var nonceSize = AesGcm.NonceByteSizes.MaxSize;
+        var tagSize = AesGcm.TagByteSizes.MaxSize;
+        var minSize = nonceSize + tagSize;
+
+        if (wrapped.Length < minSize)
+            throw new TswapException("Malformed slot wrap: shorter than AES-GCM's minimum nonce+tag overhead");
+
+        var aad = BuildAad(formatVersion, vaultId, k, slotId);
+
+        var nonce = wrapped.AsSpan(0, nonceSize);
+        var tag = wrapped.AsSpan(nonceSize, tagSize);
+        var ciphertext = wrapped.AsSpan(minSize);
+
+        var payload = new byte[ciphertext.Length];
+        using var aes = new AesGcm(kekSlot, tagSize);
+
+        try
+        {
+            aes.Decrypt(nonce, ciphertext, tag, payload, aad);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new TswapException(
+                "Slot unwrap failed: authentication check failed (wrong kekSlot, tampered ciphertext, " +
+                "or a formatVersion/vaultId/k/slotId mismatch)", ex.HResult);
+        }
+
+        return payload;
+    }
+
+    /// <summary>
+    /// Builds the fixed-binary associated data for the slot AEAD layer (issue #117):
+    /// <c>formatVersion(1) || vaultId(<see cref="KeyringFormat.VaultIdSize"/>) || k(1) ||
+    /// slotId(<see cref="KeyringFormat.SlotIdSize"/>)</c>, explicit field order, deliberately not
+    /// JSON — see <see cref="KeyringFormat"/>'s doc comment for why (an incidental reordering
+    /// would silently change every AAD computation with no diagnosable cause).
+    ///
+    /// <para>Every field here has a fixed, format-version-pinned width (a single byte, or a
+    /// byte array whose exact length <see cref="KeyringFormat"/> constants pin), so — unlike
+    /// <see cref="SecretRecordCodec"/>'s envelope, which has genuinely variable-length fields
+    /// and needs explicit length prefixes to stay unambiguous — concatenating these fixed-width
+    /// fields in a fixed order already has exactly one possible decomposition. No length-prefix
+    /// bytes are added inside the AAD itself; that is a judgement call, not an oversight.</para>
+    ///
+    /// <para>Deliberately excludes the generation/epoch counter (issue #118, a separate PR):
+    /// anything in the AAD can only change if every slot is re-wrapped, which needs every
+    /// enrolled device physically present — the right property for <c>k</c> (see the design
+    /// doc's "The landmine") and exactly the wrong one for a counter that bumps on every write.
+    /// Also excludes <c>fleetSigPub</c>, which doesn't exist until v1.</para>
+    /// </summary>
+    internal static byte[] BuildAad(byte formatVersion, byte[] vaultId, byte k, byte[] slotId)
+    {
+        if (vaultId.Length != KeyringFormat.VaultIdSize)
+            throw new ArgumentException($"vaultId must be {KeyringFormat.VaultIdSize} bytes", nameof(vaultId));
+        if (slotId.Length != KeyringFormat.SlotIdSize)
+            throw new ArgumentException($"slotId must be {KeyringFormat.SlotIdSize} bytes", nameof(slotId));
+
+        var aad = new byte[1 + KeyringFormat.VaultIdSize + 1 + KeyringFormat.SlotIdSize];
+        var span = aad.AsSpan();
+        span[0] = formatVersion;
+        vaultId.CopyTo(span.Slice(1, KeyringFormat.VaultIdSize));
+        span[1 + KeyringFormat.VaultIdSize] = k;
+        slotId.CopyTo(span.Slice(2 + KeyringFormat.VaultIdSize, KeyringFormat.SlotIdSize));
+        return aad;
+    }
+
+    private static void ValidateKekSlot(byte[] kekSlot)
+    {
+        if (kekSlot.Length != KekSlotSize)
+            throw new ArgumentException($"kekSlot must be {KekSlotSize} bytes", nameof(kekSlot));
+    }
+}

--- a/TswapTests/SlotPayloadWrapTests.cs
+++ b/TswapTests/SlotPayloadWrapTests.cs
@@ -150,6 +150,22 @@ public class SlotPayloadWrapTests
     }
 
     [Fact]
+    public void Unwrap_WrongKekSlotUsesDefaultExitCode()
+    {
+        // Regression test: Unwrap's catch block must not leak the raw CryptographicException
+        // HResult into TswapException's exitCode parameter (they are different things — the
+        // second TswapException constructor parameter is a process exit code, not an inner
+        // exception). It must stay the default of 1, like every other TswapException thrown
+        // for an expected failure mode in this codebase.
+        var wrapped = SlotPayloadWrap.Wrap("payload"u8.ToArray(), KekSlot, FormatVersion, VaultId, K, SlotId);
+        var wrongKek = new byte[32];
+
+        var ex = Assert.Throws<TswapException>(() =>
+            SlotPayloadWrap.Unwrap(wrapped, wrongKek, FormatVersion, VaultId, K, SlotId));
+        Assert.Equal(1, ex.ExitCode);
+    }
+
+    [Fact]
     public void Unwrap_TruncatedInputThrowsTswapException()
     {
         var ex = Assert.Throws<TswapException>(() =>

--- a/TswapTests/SlotPayloadWrapTests.cs
+++ b/TswapTests/SlotPayloadWrapTests.cs
@@ -1,0 +1,187 @@
+using TswapCore;
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Tests for the Phase 6 two-layer slot AEAD wrap (issues #116/#117). Golden-byte tests pin the
+/// exact AAD encoding (<see cref="SlotPayloadWrap.BuildAad"/>) for known inputs, not just
+/// round-tripping. Tamper tests flip one AAD-bound field at a time after wrapping to prove each
+/// field is actually mixed into the AEAD call, not just present in a parameter list that isn't
+/// wired up — this is the primary defense against the threshold-downgrade attack described in
+/// <c>MULTI_MACHINE_KEYING.md</c> §The landmine.
+/// </summary>
+public class SlotPayloadWrapTests
+{
+    private static readonly byte[] KekSlot = Convert.FromHexString("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    private static readonly byte[] VaultId = Convert.FromHexString("101112131415161718191a1b1c1d1e1f");
+    private static readonly byte[] SlotId = Convert.FromHexString("202122232425262728292a2b2c2d2e2f");
+    private const byte FormatVersion = 1;
+    private const byte K = 1;
+
+    [Fact]
+    public void BuildAad_MatchesGoldenBytesExactly()
+    {
+        var aad = SlotPayloadWrap.BuildAad(FormatVersion, VaultId, K, SlotId);
+
+        // formatVersion(1)=01 || vaultId(16) || k(1)=01 || slotId(16), explicit field order.
+        const string expectedHex =
+            "01" +
+            "101112131415161718191a1b1c1d1e1f" +
+            "01" +
+            "202122232425262728292a2b2c2d2e2f";
+
+        Assert.Equal(34, aad.Length);
+        Assert.Equal(expectedHex, Convert.ToHexStringLower(aad));
+    }
+
+    [Fact]
+    public void BuildAad_DifferentFormatVersionProducesDifferentAad()
+    {
+        var aad1 = SlotPayloadWrap.BuildAad(1, VaultId, K, SlotId);
+        var aad2 = SlotPayloadWrap.BuildAad(2, VaultId, K, SlotId);
+
+        Assert.NotEqual(aad1, aad2);
+    }
+
+    [Fact]
+    public void WrapUnwrap_RoundTripsPayload()
+    {
+        var payload = "the quick brown fox"u8.ToArray();
+
+        var wrapped = SlotPayloadWrap.Wrap(payload, KekSlot, FormatVersion, VaultId, K, SlotId);
+        var unwrapped = SlotPayloadWrap.Unwrap(wrapped, KekSlot, FormatVersion, VaultId, K, SlotId);
+
+        Assert.Equal(payload, unwrapped);
+    }
+
+    [Fact]
+    public void WrapUnwrap_RoundTripsEmptyPayload()
+    {
+        var wrapped = SlotPayloadWrap.Wrap([], KekSlot, FormatVersion, VaultId, K, SlotId);
+        var unwrapped = SlotPayloadWrap.Unwrap(wrapped, KekSlot, FormatVersion, VaultId, K, SlotId);
+
+        Assert.Empty(unwrapped);
+    }
+
+    [Fact]
+    public void Wrap_OutputLayoutIsNoncePlusTagPlusCiphertext()
+    {
+        var payload = new byte[32];
+
+        var wrapped = SlotPayloadWrap.Wrap(payload, KekSlot, FormatVersion, VaultId, K, SlotId);
+
+        Assert.Equal(12 + 16 + 32, wrapped.Length);
+    }
+
+    [Fact]
+    public void Wrap_ProducesFreshNoncePerCall()
+    {
+        var payload = "same payload"u8.ToArray();
+
+        var wrapped1 = SlotPayloadWrap.Wrap(payload, KekSlot, FormatVersion, VaultId, K, SlotId);
+        var wrapped2 = SlotPayloadWrap.Wrap(payload, KekSlot, FormatVersion, VaultId, K, SlotId);
+
+        Assert.NotEqual(wrapped1[..12], wrapped2[..12]);
+    }
+
+    [Fact]
+    public void Unwrap_TamperedFormatVersionFailsAuthentication()
+    {
+        var wrapped = SlotPayloadWrap.Wrap("payload"u8.ToArray(), KekSlot, FormatVersion, VaultId, K, SlotId);
+
+        var ex = Assert.Throws<TswapException>(() =>
+            SlotPayloadWrap.Unwrap(wrapped, KekSlot, formatVersion: 2, VaultId, K, SlotId));
+        Assert.Contains("authentication", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_TamperedVaultIdFailsAuthentication()
+    {
+        var wrapped = SlotPayloadWrap.Wrap("payload"u8.ToArray(), KekSlot, FormatVersion, VaultId, K, SlotId);
+        var tamperedVaultId = (byte[])VaultId.Clone();
+        tamperedVaultId[0] ^= 0xFF;
+
+        Assert.Throws<TswapException>(() =>
+            SlotPayloadWrap.Unwrap(wrapped, KekSlot, FormatVersion, tamperedVaultId, K, SlotId));
+    }
+
+    [Fact]
+    public void Unwrap_TamperedKFailsAuthentication()
+    {
+        // The threshold-downgrade attack itself: rewriting k after wrapping must not unwrap.
+        var wrapped = SlotPayloadWrap.Wrap("payload"u8.ToArray(), KekSlot, FormatVersion, VaultId, K, SlotId);
+
+        Assert.Throws<TswapException>(() =>
+            SlotPayloadWrap.Unwrap(wrapped, KekSlot, FormatVersion, VaultId, k: 2, SlotId));
+    }
+
+    [Fact]
+    public void Unwrap_TamperedSlotIdFailsAuthentication()
+    {
+        var wrapped = SlotPayloadWrap.Wrap("payload"u8.ToArray(), KekSlot, FormatVersion, VaultId, K, SlotId);
+        var tamperedSlotId = (byte[])SlotId.Clone();
+        tamperedSlotId[0] ^= 0xFF;
+
+        Assert.Throws<TswapException>(() =>
+            SlotPayloadWrap.Unwrap(wrapped, KekSlot, FormatVersion, VaultId, K, tamperedSlotId));
+    }
+
+    [Fact]
+    public void Unwrap_TamperedCiphertextFailsAuthentication()
+    {
+        var wrapped = SlotPayloadWrap.Wrap("payload"u8.ToArray(), KekSlot, FormatVersion, VaultId, K, SlotId);
+        wrapped[^1] ^= 0xFF;
+
+        Assert.Throws<TswapException>(() =>
+            SlotPayloadWrap.Unwrap(wrapped, KekSlot, FormatVersion, VaultId, K, SlotId));
+    }
+
+    [Fact]
+    public void Unwrap_WrongKekSlotFailsCleanly()
+    {
+        var wrapped = SlotPayloadWrap.Wrap("payload"u8.ToArray(), KekSlot, FormatVersion, VaultId, K, SlotId);
+        var wrongKek = new byte[32];
+
+        var ex = Assert.Throws<TswapException>(() =>
+            SlotPayloadWrap.Unwrap(wrapped, wrongKek, FormatVersion, VaultId, K, SlotId));
+        Assert.Contains("authentication", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_TruncatedInputThrowsTswapException()
+    {
+        var ex = Assert.Throws<TswapException>(() =>
+            SlotPayloadWrap.Unwrap(new byte[10], KekSlot, FormatVersion, VaultId, K, SlotId));
+        Assert.Contains("nonce+tag", ex.Message);
+    }
+
+    [Fact]
+    public void Unwrap_EmptyInputThrowsTswapException()
+    {
+        Assert.Throws<TswapException>(() =>
+            SlotPayloadWrap.Unwrap([], KekSlot, FormatVersion, VaultId, K, SlotId));
+    }
+
+    [Fact]
+    public void Wrap_WrongKekSlotLengthThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SlotPayloadWrap.Wrap("x"u8.ToArray(), new byte[16], FormatVersion, VaultId, K, SlotId));
+    }
+
+    [Fact]
+    public void Wrap_WrongVaultIdLengthThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SlotPayloadWrap.Wrap("x"u8.ToArray(), KekSlot, FormatVersion, new byte[4], K, SlotId));
+    }
+
+    [Fact]
+    public void Wrap_WrongSlotIdLengthThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SlotPayloadWrap.Wrap("x"u8.ToArray(), KekSlot, FormatVersion, VaultId, K, new byte[4]));
+    }
+}


### PR DESCRIPTION
## Summary

Implements #116 and #117 together, as the design doc requires (they're the two halves of one AEAD layer):

- **`TswapCore/Keyring/SlotPayloadWrap.cs`** — `Wrap`/`Unwrap`: AES-256-GCM encrypt/decrypt of an opaque payload under a 32-byte `KEK_slot`, calling `AesGcm`'s associated-data overloads directly (`Crypto.Encrypt`/`Decrypt` don't expose AAD and are left untouched, per the issue's explicit note). No XOR anywhere, per the design doc's "landmine" warning about one-time-pad reuse on rotation.
- **`BuildAad`** (internal, `InternalsVisibleTo`-testable) — the fixed-binary AAD encoding: `formatVersion(1) || vaultId(16) || k(1) || slotId(16)`, explicit field order, no JSON. Deliberately excludes the generation/epoch counter (#118, separate PR) and `fleetSigPub` (v1, doesn't exist yet).
- **`KeyringFormat.cs`** — two new constants, `VaultIdSize = 16` and `SlotIdSize = 16`, documented with the same rigor as the existing `RecordIdSize`/`OriginIdSize` constants.

This is only the AEAD primitive — not wired into `IHardwareKeyService`, `VaultUnlocker`, or any backend (that's #119/#121, later waves), per the issue's explicit scope.

## Judgement calls

- **`vaultId`/`slotId` = 16 bytes each.** Neither field is a security boundary on its own (both are already bound into the AEAD and can't be forged without the matching `KEK_slot`); they only need to make accidental collisions between independently-created vaults/slots negligible — the same reasoning as a random UUID/GUID, which is also 16 bytes. Kept as two separate constants (rather than both reusing the existing `OriginIdSize`) because a slot id and an origin id name different things at different layers (an AEAD-bound keyring entry vs. a per-record last-writer tiebreak) and nothing requires their sizes to move together later, even though they happen to match today.
- **No length-prefix bytes inside the AAD itself.** The design doc's "fixed binary, length-prefixed" language describes the format family as a whole (as codified in `SecretRecordCodec`'s envelope, which genuinely has variable-length fields). Every field going into this AAD, by contrast, has a fixed, format-version-pinned width (a single byte, or a byte array whose length a `KeyringFormat` constant pins) — concatenating fixed-width fields in a fixed order already has exactly one possible decomposition, so adding explicit length-prefix bytes would be redundant. Documented as a deliberate judgement call in `BuildAad`'s doc comment, not an oversight.
- **`k` as a single byte.** Matches the design doc's `k: 1` as a small integer; a byte comfortably covers any realistic slot-threshold value and mirrors `formatVersion`'s own byte width.
- **Tag-mismatch error message.** `Unwrap` catches `CryptographicException` (the base type; covers `AuthenticationTagMismatchException` on newer runtimes too) and rethrows as `TswapException` with one message covering wrong-key, tampered-ciphertext, and AAD-mismatch uniformly — by design, per the issue: an attacker rewriting a bound field (e.g. downgrading `k`) must not be able to distinguish "wrong key" from "tampered AAD" from the failure shape.

## Test plan

- [x] Golden-byte test pinning the exact `BuildAad` output for known inputs (not just round-trip)
- [x] Round-trip `Wrap`/`Unwrap` (including an empty payload)
- [x] One tamper test per AAD-bound field (`formatVersion`, `vaultId`, `k`, `slotId`) proving each is actually mixed into the AEAD call
- [x] Tampered-ciphertext and wrong-`kekSlot` tests
- [x] Truncated/empty input throws `TswapException`, not a raw BCL exception
- [x] Malformed key-length inputs throw `ArgumentException`
- [x] `./runtests.sh --unit` passes in full (443/443)
- [x] `dotnet publish -c Release TswapCli/TswapCli.csproj` still succeeds (NativeAOT tripwire)

Refs #116, #117.