### PR TITLE
Phase 6: init --keyring generates random K_v wrapped by a single YubiKey slot (#119)

### DIFF
--- a/TswapCli/Commands/InitCommand.cs
+++ b/TswapCli/Commands/InitCommand.cs
@@ -1,6 +1,7 @@
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using TswapCore;
+using TswapCore.Keyring;
 using TswapCore.Vault;
 
 namespace TswapCli.Commands;
@@ -8,8 +9,8 @@ namespace TswapCli.Commands;
 public sealed class InitCommand : ICliCommand
 {
     public string Name => "init";
-    public string HelpUsage => "init [--secure-enclave|--tpm]";
-    public string Description => "Initialize with 2 YubiKeys (or --secure-enclave on macOS, --tpm on Windows/Linux)";
+    public string HelpUsage => "init [--secure-enclave|--tpm|--keyring]";
+    public string Description => "Initialize with 2 YubiKeys (or --secure-enclave on macOS, --tpm on Windows/Linux, --keyring for a random-K_v YubiKey vault)";
     public bool RequiresSudo => false;
 
     public int Execute(CommandContext ctx, string[] args)
@@ -28,14 +29,18 @@ public sealed class InitCommand : ICliCommand
                 return 0;
         }
 
-        if (args.Contains("--secure-enclave") && args.Contains("--tpm"))
-            throw new UsageException($"{ctx.Prefix} init [--secure-enclave|--tpm] (mutually exclusive)");
+        var initFlagCount = new[] { "--secure-enclave", "--tpm", "--keyring" }.Count(args.Contains);
+        if (initFlagCount > 1)
+            throw new UsageException($"{ctx.Prefix} init [--secure-enclave|--tpm|--keyring] (mutually exclusive)");
 
         if (args.Contains("--secure-enclave"))
             return ExecuteSecureEnclave(ctx);
 
         if (args.Contains("--tpm"))
             return ExecuteTpm(ctx);
+
+        if (args.Contains("--keyring"))
+            return ExecuteKeyring(ctx);
 
         if (ctx.TestKey != null)
         {
@@ -188,6 +193,216 @@ public sealed class InitCommand : ICliCommand
         else
             c.Out.WriteLine("\nConfig saved.");
         return 0;
+    }
+
+    /// <summary>
+    /// Phase 6 keyring init (issue #119, <c>MULTI_MACHINE_KEYING.md</c> §Implementation ordering
+    /// step 1): a random 256-bit <c>K_v</c> wrapped by a single YubiKey-backed slot
+    /// (<c>k = 1</c>), instead of <c>K_v</c> being derived directly from the two YubiKeys'
+    /// challenge responses the way the default <c>init</c> above does. Same two-YubiKey
+    /// enrollment UX as the default flow — this is still "one machine, one enrolled key pair"
+    /// for now, not multi-machine (that is issue #121's <c>slot request/approve/accept</c>,
+    /// layered on top of the <see cref="Slot"/>/<see cref="Keyring"/> shapes this defines).
+    ///
+    /// <para>The payoff of the extra indirection: once <c>K_v</c> is a fixed, backend-independent
+    /// random value, a future <c>slot approve</c> can wrap it for a brand-new machine's slot
+    /// without decrypting-and-re-encrypting anything belonging to this machine — appending a
+    /// slot is additive. Under the default flow's derived key, there is no <c>K_v</c> to hand to
+    /// another machine at all; a second machine could only ever be added by re-deriving a
+    /// completely different master key from scratch (i.e. re-init, losing the old vault).</para>
+    /// </summary>
+    private static int ExecuteKeyring(CommandContext ctx)
+    {
+        var c = ctx.Console;
+
+        if (ctx.TestKey != null)
+        {
+            // Test mode: bypass YubiKey entirely, same idea as the default flow's test branch
+            // above. KEK_slot here is ctx.TestKey directly — the exact 32 bytes
+            // YubiKeyHardwareService.Unlock returns for *any* config once its overrideKey is
+            // set (see that method's first line) — so wrapping the slot payload under
+            // ctx.TestKey now is what makes VaultUnlocker's keyring unwrap succeed later, in
+            // test mode, without ever touching real hardware.
+            var (testConfig, testVaultKey) = BuildKeyringConfig(
+                ctx.TestKey,
+                new List<int> { TestKeyYubiKeyService.Serial1, TestKeyYubiKeyService.Serial2 },
+                new string('0', 40), // 20-byte zero XOR share (hex) — unused in test mode
+                requiresTouch: null,
+                RngMode.System,
+                Convert.ToHexString(RandomNumberGenerator.GetBytes(32)),
+                RandomNumberGenerator.GetBytes(32));
+
+            ctx.Storage.SaveConfig(testConfig);
+            // Unlike the default test-mode branch, K_v is freshly random on every call (it is
+            // never derived from ctx.TestKey), so an existing secrets.json from a prior init
+            // would be undecryptable with this run's key — always write a fresh empty vault.
+            ctx.Storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), testVaultKey);
+            c.Out.WriteLine("Initialized (keyring, test mode)");
+            return 0;
+        }
+
+        c.Out.WriteLine("\n╔════════════════════════════════════════╗");
+        c.Out.WriteLine("║  tswap - Keyring Initialization        ║");
+        c.Out.WriteLine("╚════════════════════════════════════════╝\n");
+        c.Out.WriteLine("This vault's master key (K_v) is random and wrapped by this YubiKey");
+        c.Out.WriteLine("pair's slot (k = 1), rather than derived from it — see");
+        c.Out.WriteLine("MULTI_MACHINE_KEYING.md. Still one machine for now: enrolling a second");
+        c.Out.WriteLine("machine's slot ('slot request/approve/accept') is future work (#121).\n");
+
+        var unlockChallenge = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+
+        c.Out.WriteLine("Insert YubiKey #1 and press Enter...");
+        if (!c.IsInputRedirected)
+            c.ReadLine();
+        var serial1 = ctx.SelectSerial();
+        var k1 = ctx.YubiKeys.Challenge(serial1, unlockChallenge);
+
+        c.Out.WriteLine("\nRemove YubiKey #1, insert YubiKey #2, press Enter...");
+        if (!c.IsInputRedirected)
+            c.ReadLine();
+        var serial2 = ctx.SelectSerial();
+
+        if (serial1 == serial2)
+            throw new TswapException("Same YubiKey detected. Please use two different YubiKeys.");
+
+        var k2 = ctx.YubiKeys.Challenge(serial2, unlockChallenge);
+
+        c.Out.WriteLine("\nDetecting YubiKey slot configuration...");
+        var touch1 = ctx.YubiKeys.DetectTouchRequirement(serial1);
+        var touch2 = ctx.YubiKeys.DetectTouchRequirement(serial2);
+        bool? requiresTouch = touch1.HasValue && touch2.HasValue ? touch1.Value && touch2.Value : null;
+
+        c.Out.WriteLine("\nPassword generation entropy source:");
+        c.Out.WriteLine("  [1] System RNG  — one YubiKey touch per create (default)");
+        c.Out.WriteLine("  [2] YubiKey     — two YubiKey touches per create; hardware-primary, immune to OS RNG compromise");
+        c.Out.Write("Choose [1/2, default 1]: ");
+        var rngChoice = c.ReadLine()?.Trim();
+        var rngMode = rngChoice == "2" ? RngMode.YubiKey : RngMode.System;
+
+        var xorShare = Crypto.XorBytes(k1, k2);
+        var masterKeySalt = RandomNumberGenerator.GetBytes(32);
+
+        var (config, vaultKey) = BuildKeyringConfig(
+            // KEK_slot: exactly the value the default flow above uses as K_v directly
+            // (Crypto.DeriveKey(k1, k2, salt)) — here it instead unwraps a random K_v. This is
+            // also exactly what YubiKeyHardwareService.Unlock recomputes later from the Config
+            // fields this method saves, with no change to that class at all.
+            Crypto.DeriveKey(k1, k2, masterKeySalt),
+            new List<int> { serial1, serial2 },
+            Convert.ToHexString(xorShare),
+            requiresTouch,
+            rngMode,
+            unlockChallenge,
+            masterKeySalt);
+
+        // Same re-init backup dance as the default flow: back up config first (if anything
+        // fails mid-init the old config still matches the old vault backup), then move the old
+        // vault aside rather than overwrite it outright.
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
+        var fileStore = ctx.Storage as IFileVaultStore;
+        if (fileStore != null && File.Exists(fileStore.ConfigFile))
+        {
+            var configBackup = fileStore.ConfigFile + ".bak-" + timestamp;
+            File.Copy(fileStore.ConfigFile, configBackup);
+        }
+        ctx.Storage.SaveConfig(config);
+        if (fileStore != null && File.Exists(fileStore.SecretsFile))
+        {
+            var vaultBackup = fileStore.SecretsFile + ".bak-" + timestamp;
+            File.Move(fileStore.SecretsFile, vaultBackup);
+            c.SetForeground(ConsoleColor.Yellow);
+            c.Out.WriteLine($"\nExisting vault moved to backup: {vaultBackup}");
+            c.Out.WriteLine("Previous config backed up alongside it. To recover old secrets:");
+            c.Out.WriteLine("  restore both .bak files under their original names.");
+            c.ResetColor();
+        }
+        ctx.Storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), vaultKey);
+
+        c.Out.WriteLine("\n╔════════════════════════════════════════╗");
+        c.Out.WriteLine("║  ✓ INITIALIZATION COMPLETE            ║");
+        c.Out.WriteLine("╚════════════════════════════════════════╝\n");
+        c.Out.WriteLine($"YubiKey Serials: {serial1}, {serial2}");
+        c.Out.WriteLine("Backend: YubiKey keyring (k = 1, single slot)");
+
+        if (requiresTouch == true)
+        {
+            c.SetForeground(ConsoleColor.Green);
+            c.Out.WriteLine("✓ Touch requirement: ENABLED (recommended)");
+            c.ResetColor();
+        }
+        else if (requiresTouch == false)
+        {
+            c.SetForeground(ConsoleColor.Yellow);
+            c.Out.WriteLine("⚠️  Touch requirement: DISABLED");
+            c.Out.WriteLine("\nSECURITY NOTICE: Your YubiKeys are configured without button press");
+            c.Out.WriteLine("requirement. Any process with access to inserted keys can unlock vault.");
+            c.ResetColor();
+        }
+
+        c.Out.WriteLine($"Entropy mode:    {(rngMode == RngMode.YubiKey ? "YubiKey hardware (two touches per create)" : "System RNG (one touch per create)")}");
+
+        c.Out.WriteLine("\n⚠️  CRITICAL: BACKUP XOR SHARE NOW\n");
+        c.Out.WriteLine("XOR Share (hex):");
+        c.Out.WriteLine(config.RedundancyXor);
+        c.Out.WriteLine("\nThis share reconstructs this slot's key-encryption key (KEK_slot),");
+        c.Out.WriteLine("which unwraps K_v — losing it plus one physical YubiKey still loses");
+        c.Out.WriteLine("the vault, exactly as with the default init flow. Backup locations required:");
+        c.Out.WriteLine("  [ ] Password manager (Bitwarden/1Password)");
+        c.Out.WriteLine("  [ ] Printed copy (home safe)");
+        c.Out.WriteLine("  [ ] Second printed copy (off-site)");
+        c.Out.WriteLine("  [ ] Git repository");
+        if (fileStore != null)
+            c.Out.WriteLine($"\nConfig saved to: {fileStore.ConfigFile}");
+        else
+            c.Out.WriteLine("\nConfig saved.");
+        return 0;
+    }
+
+    /// <summary>
+    /// Shared by both the interactive and test-mode <c>--keyring</c> paths (issue #119):
+    /// generates a random <c>K_v</c> and this machine's X25519 slot keypair
+    /// (<see cref="SlotKeyPair.Generate"/>), wraps <c>(K_v || slot private key)</c>
+    /// (<see cref="SlotSecretPayload.Encode"/>) under <paramref name="kekSlot"/> via
+    /// <see cref="SlotPayloadWrap.Wrap"/>, and assembles the resulting single-slot,
+    /// <c>k = 1</c> <see cref="Keyring"/> plus the <see cref="Config"/> that carries it.
+    ///
+    /// <para>The returned <see cref="Config"/> still carries the same
+    /// <c>YubiKeySerials</c>/<c>RedundancyXor</c>/<c>UnlockChallenge</c>/<c>MasterKeySalt</c>
+    /// fields the default flow's config does — so <see cref="VaultUnlocker"/>'s YubiKey backend
+    /// recovers this exact <paramref name="kekSlot"/> value again at unlock time, unmodified.
+    /// Only <see cref="Config.Keyring"/> being non-null tells <see cref="VaultUnlocker"/> to
+    /// treat that recovered value as <c>KEK_slot</c> and unwrap <c>K_v</c>, instead of using it
+    /// as the master key directly.</para>
+    /// </summary>
+    private static (Config Config, byte[] VaultKey) BuildKeyringConfig(
+        byte[] kekSlot, List<int> serials, string redundancyXorHex, bool? requiresTouch,
+        RngMode rngMode, string unlockChallenge, byte[] masterKeySalt)
+    {
+        var vaultKey = RandomNumberGenerator.GetBytes(KeyringFormat.VaultKeySize);
+        var slotKeyPair = SlotKeyPair.Generate();
+        var vaultId = RandomNumberGenerator.GetBytes(KeyringFormat.VaultIdSize);
+        var slotId = RandomNumberGenerator.GetBytes(KeyringFormat.SlotIdSize);
+        const byte k = 1;
+
+        var payload = SlotSecretPayload.Encode(vaultKey, slotKeyPair.PrivateKey);
+        var wrapped = SlotPayloadWrap.Wrap(payload, kekSlot, KeyringFormat.KeyringFormatVersion, vaultId, k, slotId);
+
+        var slot = new Slot(slotId, slotKeyPair.PublicKey, wrapped);
+        var keyring = new TswapCore.Keyring.Keyring(KeyringFormat.KeyringFormatVersion, vaultId, k, [slot]);
+        var keyringBlob = Convert.ToBase64String(KeyringCodec.Encode(keyring));
+
+        var config = new Config(
+            serials,
+            redundancyXorHex,
+            DateTime.UtcNow,
+            requiresTouch,
+            rngMode,
+            unlockChallenge,
+            MasterKeySalt: Convert.ToBase64String(masterKeySalt),
+            Keyring: keyringBlob
+        );
+
+        return (config, vaultKey);
     }
 
     /// <summary>

--- a/TswapCore/Keyring/Keyring.cs
+++ b/TswapCore/Keyring/Keyring.cs
@@ -1,0 +1,168 @@
+using System.Buffers.Binary;
+
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// One entry in a vault's <see cref="Keyring"/> (issue #119, design: <c>MULTI_MACHINE_KEYING.md</c>
+/// §The model / §Two-layer slot wrap / §Per-slot X25519 keypair). A slot is one machine's share
+/// of the vault: an opaque identifier, an X25519 public key kept in the clear (so any holder of
+/// <c>K_v</c> can wrap a fresh slot for this device offline — see the design doc), and the
+/// AEAD-wrapped payload (<see cref="SlotPayloadWrap"/> around a <see cref="SlotSecretPayload"/>)
+/// that recovers <c>K_v</c> plus this slot's own X25519 private key once its <c>KEK_slot</c> is
+/// available.
+///
+/// <para><b>No per-slot hardware blob field.</b> The design doc's slot sketch includes a
+/// <c>hwBlob: backendWrap(KEK_slot)</c> field alongside <c>wrapped</c>. For this issue
+/// (YubiKey only, one slot), that role is already filled by <see cref="Config"/>'s existing
+/// <c>YubiKeySerials</c>/<c>RedundancyXor</c>/<c>UnlockChallenge</c>/<c>MasterKeySalt</c>
+/// fields — <see cref="Vault.YubiKeyHardwareService.Unlock"/> already recovers
+/// <c>KEK_slot</c> from those (see <c>HARDWARE_BACKENDS.md</c>'s "no interface change needed"
+/// point). Adding a redundant per-slot <c>hwBlob</c> here would just duplicate what
+/// <see cref="Config"/> already carries at the vault level. A second, non-YubiKey backend
+/// (design doc's v0 step 2) is exactly where a real per-slot <c>hwBlob</c> becomes necessary,
+/// since Config has no vault-wide equivalent for a TPM/Secure-Enclave-wrapped KEK_slot — that
+/// is deliberately deferred, not overlooked.</para>
+///
+/// <para><b>Deliberately minimal otherwise.</b> No <c>label</c>/<c>backend</c>/<c>enrolledAt</c>
+/// fields. Every field a future <c>slots</c> listing (#123) or fingerprint display (#122) would
+/// want is either derivable from context that doesn't exist yet (there is exactly one machine,
+/// one backend, per vault right now) or is an additive field this format can grow later without
+/// touching what's already here — appending a new field after <see cref="Wrapped"/> in
+/// <see cref="KeyringCodec"/>'s slot layout is a mechanical, backward-compatible change, not a
+/// redesign.</para>
+/// </summary>
+public sealed record Slot(byte[] SlotId, byte[] PublicKey, byte[] Wrapped);
+
+/// <summary>
+/// A vault's keyring (issue #119): the format version and vault id that feed every slot's AEAD
+/// associated data (see <see cref="SlotPayloadWrap.BuildAad"/>), the unlock threshold <c>k</c>
+/// (always 1 in v0 — see <c>MULTI_MACHINE_KEYING.md</c> §Why not k >= 2), and the list of slots
+/// (always exactly one in v0, this machine's; #121 is where a second machine's slot gets
+/// appended via hand-carried enrollment).
+/// </summary>
+public sealed record Keyring(byte FormatVersion, byte[] VaultId, byte K, IReadOnlyList<Slot> Slots);
+
+/// <summary>
+/// Encodes/decodes a <see cref="Keyring"/> to/from the fixed-binary blob stored (base64) in
+/// <see cref="Config.Keyring"/>. Fixed-binary, length-prefixed, explicitly ordered — not JSON —
+/// for the exact reason <see cref="KeyringFormat"/>'s doc comment gives for the per-secret
+/// record format: this structure's own bytes (<c>vaultId</c>, <c>k</c>, each slot's
+/// <c>slotId</c>) directly feed <see cref="SlotPayloadWrap"/>'s AAD, so an incidental JSON
+/// reordering or whitespace change would silently change every AAD computation and brick every
+/// keyring vault on disk with no diagnosable cause.
+///
+/// <para><b>On-disk layout</b> (all multi-byte integers little-endian, matching
+/// <see cref="SecretRecordCodec"/>'s convention):</para>
+/// <code>
+/// formatVersion   1 byte    KeyringFormat.KeyringFormatVersion
+/// vaultId         KeyringFormat.VaultIdSize bytes (16)
+/// k               1 byte
+/// slotCount       4 bytes
+/// slots[slotCount]:
+///   slotId          KeyringFormat.SlotIdSize bytes (16)
+///   publicKey       SlotKeyPair.KeySize bytes (32)
+///   wrappedLength   4 bytes
+///   wrapped         wrappedLength bytes
+/// </code>
+///
+/// <para>v0 always writes exactly one slot; <c>slotCount</c> is still explicit (not assumed to
+/// be 1) so a future multi-slot keyring (#121) is purely an additive change to how many times
+/// the slot loop below runs, not a format bump.</para>
+/// </summary>
+public static class KeyringCodec
+{
+    // formatVersion(1) + vaultId + k(1) + slotCount(4)
+    private const int HeaderSize = 1 + KeyringFormat.VaultIdSize + 1 + 4;
+
+    // slotId + publicKey + wrappedLength(4)
+    private const int SlotHeaderSize = KeyringFormat.SlotIdSize + SlotKeyPair.KeySize + 4;
+
+    /// <summary>
+    /// Encodes <paramref name="keyring"/>. Throws <see cref="ArgumentException"/> (a programmer
+    /// error, not a data-corruption case) if <see cref="Keyring.VaultId"/> or any slot's
+    /// <see cref="Slot.SlotId"/>/<see cref="Slot.PublicKey"/> is the wrong fixed width.
+    /// </summary>
+    public static byte[] Encode(Keyring keyring)
+    {
+        if (keyring.VaultId.Length != KeyringFormat.VaultIdSize)
+            throw new ArgumentException($"VaultId must be {KeyringFormat.VaultIdSize} bytes", nameof(keyring));
+
+        var totalSize = HeaderSize;
+        foreach (var slot in keyring.Slots)
+        {
+            if (slot.SlotId.Length != KeyringFormat.SlotIdSize)
+                throw new ArgumentException($"SlotId must be {KeyringFormat.SlotIdSize} bytes", nameof(keyring));
+            if (slot.PublicKey.Length != SlotKeyPair.KeySize)
+                throw new ArgumentException($"PublicKey must be {SlotKeyPair.KeySize} bytes", nameof(keyring));
+            totalSize += SlotHeaderSize + slot.Wrapped.Length;
+        }
+
+        var result = new byte[totalSize];
+        var span = result.AsSpan();
+        span[0] = keyring.FormatVersion;
+        keyring.VaultId.CopyTo(span.Slice(1, KeyringFormat.VaultIdSize));
+        span[1 + KeyringFormat.VaultIdSize] = keyring.K;
+        BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(2 + KeyringFormat.VaultIdSize, 4), (uint)keyring.Slots.Count);
+
+        var offset = HeaderSize;
+        foreach (var slot in keyring.Slots)
+        {
+            slot.SlotId.CopyTo(span.Slice(offset, KeyringFormat.SlotIdSize));
+            offset += KeyringFormat.SlotIdSize;
+            slot.PublicKey.CopyTo(span.Slice(offset, SlotKeyPair.KeySize));
+            offset += SlotKeyPair.KeySize;
+            BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(offset, 4), (uint)slot.Wrapped.Length);
+            offset += 4;
+            slot.Wrapped.CopyTo(span.Slice(offset, slot.Wrapped.Length));
+            offset += slot.Wrapped.Length;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Decodes a keyring previously produced by <see cref="Encode"/>. Throws
+    /// <see cref="TswapException"/> — never a raw slicing/index exception — for a truncated
+    /// header, a truncated slot header, or a length prefix (<c>slotCount</c> implied bytes, or
+    /// an individual slot's <c>wrappedLength</c>) that exceeds the data actually available.
+    /// Bounds checks are subtraction-based, not addition-based (<c>x > bytes.Length - offset</c>,
+    /// not <c>offset + x > bytes.Length</c>) — see <see cref="SecretRecordCodec.Decode"/>'s own
+    /// comment on why an addition-based check can overflow and silently pass for an
+    /// attacker-controlled length near <see cref="uint.MaxValue"/>.
+    /// </summary>
+    public static Keyring Decode(byte[] bytes)
+    {
+        if (bytes.Length < HeaderSize)
+            throw new TswapException("Malformed keyring: shorter than the header");
+
+        var formatVersion = bytes[0];
+        var vaultId = bytes.AsSpan(1, KeyringFormat.VaultIdSize).ToArray();
+        var k = bytes[1 + KeyringFormat.VaultIdSize];
+        var slotCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(2 + KeyringFormat.VaultIdSize, 4));
+
+        var slots = new List<Slot>();
+        var offset = HeaderSize;
+        for (uint i = 0; i < slotCount; i++)
+        {
+            if (SlotHeaderSize > bytes.Length - offset)
+                throw new TswapException("Malformed keyring: truncated slot header");
+
+            var slotId = bytes.AsSpan(offset, KeyringFormat.SlotIdSize).ToArray();
+            offset += KeyringFormat.SlotIdSize;
+            var publicKey = bytes.AsSpan(offset, SlotKeyPair.KeySize).ToArray();
+            offset += SlotKeyPair.KeySize;
+            var wrappedLength = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(offset, 4));
+            offset += 4;
+
+            if (wrappedLength > bytes.Length - offset)
+                throw new TswapException("Malformed keyring: wrapped-slot length prefix exceeds available data");
+
+            var wrapped = bytes.AsSpan(offset, (int)wrappedLength).ToArray();
+            offset += (int)wrappedLength;
+
+            slots.Add(new Slot(slotId, publicKey, wrapped));
+        }
+
+        return new Keyring(formatVersion, vaultId, k, slots);
+    }
+}

--- a/TswapCore/Keyring/KeyringFormat.cs
+++ b/TswapCore/Keyring/KeyringFormat.cs
@@ -69,4 +69,24 @@ public static class KeyringFormat
     /// either one changes later.
     /// </summary>
     public const int SlotIdSize = 16;
+
+    /// <summary>
+    /// Format version of the Phase 6 keyring envelope (<see cref="Keyring"/>/<see cref="Slot"/>,
+    /// issue #119) — the value stored in <see cref="Keyring.FormatVersion"/> and fed into
+    /// <see cref="Keyring.SlotPayloadWrap"/>'s AAD as its <c>formatVersion</c> parameter.
+    /// Deliberately a separate constant from <see cref="RecordFormatVersion"/>: that one
+    /// versions the per-secret record envelope (issues #111-#115), a completely different wire
+    /// format this issue does not touch — bumping one must never accidentally bump the other.
+    /// </summary>
+    public const byte KeyringFormatVersion = 1;
+
+    /// <summary>
+    /// Byte length of the vault master key <c>K_v</c> — 256 bits, the same size as
+    /// <see cref="Keyring.SlotKeyPair.KeySize"/> (an X25519 key) and the AES-256 key
+    /// <see cref="SecretRecordCodec"/> already uses elsewhere. Not a coincidence:
+    /// <see cref="Keyring.SlotSecretPayload"/> relies on both halves of its payload being
+    /// exactly 32 bytes so <c>vaultKey || slotPrivateKey</c> concatenates into one unambiguous
+    /// fixed-width blob with no length prefix needed.
+    /// </summary>
+    public const int VaultKeySize = 32;
 }

--- a/TswapCore/Keyring/SlotSecretPayload.cs
+++ b/TswapCore/Keyring/SlotSecretPayload.cs
@@ -1,0 +1,65 @@
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// The plaintext payload wrapped by <see cref="SlotPayloadWrap"/> inside a <see cref="Slot"/>
+/// (issue #119): the vault master key <c>K_v</c> and this slot's own X25519 private key (see
+/// <see cref="SlotKeyPair"/>), concatenated into one fixed-width blob and protected by a single
+/// AEAD call rather than two independent ones.
+///
+/// <para><b>Why one wrap, not two:</b> both values are protected by the exact same
+/// <c>KEK_slot</c> and the exact same AAD (<c>formatVersion</c>/<c>vaultId</c>/<c>k</c>/
+/// <c>slotId</c>) — splitting them into two independent <see cref="SlotPayloadWrap.Wrap"/>
+/// calls would mean two nonces, two tags, and twice the bookkeeping for no additional
+/// isolation: compromising <c>KEK_slot</c> exposes both values under either scheme. This is the
+/// judgement call issue #119's design section calls out explicitly.</para>
+///
+/// <para><b>Why no length prefix:</b> both fields are fixed-width —
+/// <see cref="KeyringFormat.VaultKeySize"/> and <see cref="SlotKeyPair.KeySize"/> are both 32
+/// bytes today, pinned constants rather than incidental — so <c>vaultKey || slotPrivateKey</c>
+/// has exactly one possible decomposition. A length prefix would only earn its keep if either
+/// field's width could vary independently of a format-version bump, which neither does.</para>
+/// </summary>
+public static class SlotSecretPayload
+{
+    /// <summary>Total encoded length: <see cref="KeyringFormat.VaultKeySize"/> + <see cref="SlotKeyPair.KeySize"/>.</summary>
+    public const int EncodedSize = KeyringFormat.VaultKeySize + SlotKeyPair.KeySize;
+
+    /// <summary>
+    /// Concatenates <paramref name="vaultKey"/> and <paramref name="slotPrivateKey"/> — the
+    /// payload later handed to <see cref="SlotPayloadWrap.Wrap"/>. Throws
+    /// <see cref="ArgumentException"/> (a programmer error — both inputs are freshly generated
+    /// by this codebase, never attacker-controlled) if either is not exactly its fixed width.
+    /// </summary>
+    public static byte[] Encode(byte[] vaultKey, byte[] slotPrivateKey)
+    {
+        if (vaultKey.Length != KeyringFormat.VaultKeySize)
+            throw new ArgumentException($"vaultKey must be {KeyringFormat.VaultKeySize} bytes", nameof(vaultKey));
+        if (slotPrivateKey.Length != SlotKeyPair.KeySize)
+            throw new ArgumentException($"slotPrivateKey must be {SlotKeyPair.KeySize} bytes", nameof(slotPrivateKey));
+
+        var result = new byte[EncodedSize];
+        vaultKey.CopyTo(result, 0);
+        slotPrivateKey.CopyTo(result, KeyringFormat.VaultKeySize);
+        return result;
+    }
+
+    /// <summary>
+    /// Decodes a payload previously produced by <see cref="Encode"/> — normally the output of
+    /// <see cref="SlotPayloadWrap.Unwrap"/>. Throws <see cref="TswapException"/> (not a raw
+    /// slicing exception) when the length doesn't match: since the AEAD layer above this already
+    /// authenticated the bytes, a wrong length here means either a bug (this codec's own
+    /// <see cref="EncodedSize"/> changed without a matching format-version bump) or a
+    /// same-vintage payload that was tampered with in a way that happened to keep the AEAD tag
+    /// consistent under a *different* key — either way this must fail loudly, not silently
+    /// truncate or overrun.
+    /// </summary>
+    public static (byte[] VaultKey, byte[] SlotPrivateKey) Decode(byte[] payload)
+    {
+        if (payload.Length != EncodedSize)
+            throw new TswapException($"Malformed slot payload: expected {EncodedSize} bytes, got {payload.Length}");
+
+        var vaultKey = payload.AsSpan(0, KeyringFormat.VaultKeySize).ToArray();
+        var slotPrivateKey = payload.AsSpan(KeyringFormat.VaultKeySize, SlotKeyPair.KeySize).ToArray();
+        return (vaultKey, slotPrivateKey);
+    }
+}

--- a/TswapCore/Models.cs
+++ b/TswapCore/Models.cs
@@ -76,7 +76,19 @@ public record Config(List<int> YubiKeySerials, string RedundancyXor, DateTime Cr
     // Set for vaults that opt into a random per-vault salt (currently: every vault created by
     // a fresh 'tswap init' of the default YubiKey backend). Additive/backward-compatible,
     // following the same pattern as SecureEnclaveWrappedKey/TpmSealedKey above.
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? MasterKeySalt = null);
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? MasterKeySalt = null,
+    // Phase 6 keyring vault only (issue #119, 'tswap init --keyring'): base64 of a
+    // Keyring.KeyringCodec-encoded Keyring holding a random K_v wrapped by this machine's slot,
+    // instead of K_v being derived directly from k1/k2 (see Crypto.DeriveKey). Backend-agnostic
+    // and purely additive on top of the existing YubiKey fields above: a keyring vault still
+    // populates YubiKeySerials/RedundancyXor/UnlockChallenge/MasterKeySalt exactly like a
+    // classic YubiKey vault, because VaultUnlocker still recovers this machine's KEK_slot via
+    // the unmodified YubiKeyHardwareService challenge/XOR/PBKDF2 dance — the mere presence of
+    // this field is what tells VaultUnlocker to treat that recovered 32 bytes as KEK_slot and
+    // unwrap K_v from the keyring, rather than use it as the master key directly (see
+    // VaultUnlocker.Unlock). Null (omitted from config.json) for every vault that predates this
+    // field or never opts in — those are completely unaffected.
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Keyring = null);
 public record Secret(string Value, DateTime Created, DateTime Modified, DateTime? BurnedAt = null, string? BurnReason = null);
 public record SecretsDb(Dictionary<string, Secret> Secrets);
 

--- a/TswapCore/Vault/VaultUnlocker.cs
+++ b/TswapCore/Vault/VaultUnlocker.cs
@@ -1,3 +1,5 @@
+using TswapCore.Keyring;
+
 namespace TswapCore.Vault;
 
 /// <summary>
@@ -66,7 +68,55 @@ public sealed class VaultUnlocker
             throw new TswapException(
                 $"This vault uses the '{backend.DisplayName()}' hardware backend, which this build of tswap does not support. " +
                 "Use a build that includes it, or restore a vault created with a supported backend.");
-        return service.Unlock(config, chooseSerial);
+
+        var recovered = service.Unlock(config, chooseSerial);
+
+        // A keyring vault (issue #119, 'tswap init --keyring'): `recovered` is this machine's
+        // slot key-encryption key (KEK_slot), not the vault master key directly — unwrap K_v
+        // from the keyring. This check is backend-agnostic and sits after backend dispatch on
+        // purpose: whichever backend recovered the 32 bytes, a keyring vault always needs this
+        // same extra unwrap step (see MULTI_MACHINE_KEYING.md §Two-layer slot wrap), so a future
+        // second backend (v0 step 2) needs no change here at all.
+        return config.Keyring == null ? recovered : UnlockKeyring(config, recovered);
+    }
+
+    /// <summary>
+    /// Decodes <see cref="Config.Keyring"/> and unwraps this machine's slot (always the
+    /// keyring's first and, in v0, only slot) to recover <c>K_v</c>. <paramref name="kekSlot"/>
+    /// is the 32 bytes the hardware backend just recovered. The slot's own X25519 private key
+    /// (the payload's other half — see <see cref="SlotSecretPayload"/>) is decoded but unused
+    /// until #121 adds slot request/approve/accept.
+    ///
+    /// <para>Throws <see cref="TswapException"/> — never a raw crash — for a non-base64
+    /// <see cref="Config.Keyring"/>, a malformed keyring blob (<see cref="KeyringCodec.Decode"/>),
+    /// an empty slot list, or a slot that fails to unwrap (<see cref="SlotPayloadWrap.Unwrap"/>:
+    /// wrong KEK_slot, tampered ciphertext, or a tampered AAD-bound field).</para>
+    /// </summary>
+    private static byte[] UnlockKeyring(Config config, byte[] kekSlot)
+    {
+        byte[] keyringBytes;
+        try
+        {
+            keyringBytes = Convert.FromBase64String(config.Keyring!);
+        }
+        catch (FormatException)
+        {
+            throw new TswapException(
+                "Config is corrupted: Keyring is not valid base64. Restore config.json from backup or re-run 'tswap init --keyring'.");
+        }
+
+        var keyring = KeyringCodec.Decode(keyringBytes);
+
+        if (keyring.Slots.Count == 0)
+            throw new TswapException(
+                "Config is corrupted: keyring has no slots. Restore config.json from backup or re-run 'tswap init --keyring'.");
+
+        // v0 is single-slot only: the keyring's first slot is always this machine's. #121 adds
+        // real slot identity/lookup once a keyring can hold more than one.
+        var slot = keyring.Slots[0];
+        var payload = SlotPayloadWrap.Unwrap(slot.Wrapped, kekSlot, keyring.FormatVersion, keyring.VaultId, keyring.K, slot.SlotId);
+        var (vaultKey, _slotPrivateKey) = SlotSecretPayload.Decode(payload);
+        return vaultKey;
     }
 
     /// <summary>

--- a/TswapTests/CommandTests.cs
+++ b/TswapTests/CommandTests.cs
@@ -93,6 +93,68 @@ public class CommandTests : IDisposable
         Assert.Contains("Usage:", stderr);
     }
 
+    [Fact]
+    public void Init_KeyringAndTpmBothPassed_RejectsAsUsageError()
+    {
+        var (exit, _, stderr) = RunTswap("init", "--keyring", "--tpm");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Usage:", stderr);
+    }
+
+    // --- Init --keyring (Phase 6, issue #119) ---
+
+    [Fact]
+    public void InitKeyring_CreatesConfigWithKeyringFieldAndNoBackend()
+    {
+        var (exit, stdout, _) = RunTswap("init", "--keyring");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("keyring", stdout);
+
+        var json = File.ReadAllText(Path.Combine(_tempDir, "config.json"));
+        var config = JsonSerializer.Deserialize(json, TswapJsonContext.Default.Config)!;
+
+        Assert.NotNull(config.Keyring);
+        // Still a YubiKey vault as far as VaultUnlocker's backend dispatch is concerned —
+        // only the presence of Keyring changes how the recovered 32 bytes are used.
+        Assert.Null(config.Backend);
+        Assert.Equal(new List<int> { 99999999, 99999998 }, config.YubiKeySerials);
+    }
+
+    [Fact]
+    public void InitKeyring_FullRoundTrip_AddThenGetRecoversValue()
+    {
+        // The end-to-end proof this issue's verification bar asks for: init --keyring, add a
+        // secret, get it back — through the real CLI dispatch path, not just unit-level pieces.
+        RunTswap("init", "--keyring");
+
+        var (addExit, _, _) = RunTswapWithStdin("hunter2\nhunter2\n", "add", "my-secret");
+        Assert.Equal(0, addExit);
+
+        var (getExit, getStdout, _) = RunTswap("get", "my-secret");
+
+        Assert.Equal(0, getExit);
+        Assert.Contains("hunter2", getStdout);
+    }
+
+    [Fact]
+    public void InitKeyring_Reinit_GeneratesFreshVaultKey_OldSecretNoLongerAccessible()
+    {
+        // Every 'init --keyring' generates a brand-new random K_v (unlike the default flow,
+        // where re-init with the same test key would still decrypt an old vault under some
+        // circumstances) — reinitializing must leave the old secret behind, not silently expose
+        // or destroy data without the documented backup-file dance.
+        RunTswap("init", "--keyring");
+        RunTswapWithStdin("first-value\nfirst-value\n", "add", "first-secret");
+
+        RunTswapWithStdin("yes", "init", "--keyring");
+
+        var (getExit, _, getStderr) = RunTswap("get", "first-secret");
+        Assert.NotEqual(0, getExit);
+        Assert.Contains("not found", getStderr);
+    }
+
     // --- Create ---
 
     [Fact]

--- a/TswapTests/KeyringCodecTests.cs
+++ b/TswapTests/KeyringCodecTests.cs
@@ -1,0 +1,172 @@
+using TswapCore;
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Tests for the Phase 6 keyring/slot fixed-binary encoding (issue #119, see
+/// <see cref="KeyringCodec"/>'s layout doc). Golden-byte tests pin the exact on-disk layout for
+/// known inputs, not just round-tripping — the same rigor <c>SlotPayloadWrapTests</c> and
+/// <c>SecretRecordCodecTests</c> already apply to their own formats, and for the same reason:
+/// this structure's bytes (vaultId, k, slotId) directly feed <see cref="SlotPayloadWrap"/>'s
+/// AAD, so an accidental layout change here would silently brick every keyring vault.
+/// </summary>
+public class KeyringCodecTests
+{
+    private static readonly byte[] VaultId = Convert.FromHexString("000102030405060708090a0b0c0d0e0f");
+    private static readonly byte[] SlotId = Convert.FromHexString("101112131415161718191a1b1c1d1e1f");
+    private static readonly byte[] PublicKey =
+        Convert.FromHexString("202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f");
+    private static readonly byte[] Wrapped = Convert.FromHexString("aabbccdd");
+
+    private static Keyring OneSlotKeyring() =>
+        new(FormatVersion: 1, VaultId, K: 1, Slots: [new Slot(SlotId, PublicKey, Wrapped)]);
+
+    [Fact]
+    public void Encode_MatchesGoldenBytesExactly()
+    {
+        var bytes = KeyringCodec.Encode(OneSlotKeyring());
+
+        const string expectedHex =
+            "01" +                                                                 // formatVersion
+            "000102030405060708090a0b0c0d0e0f" +                                   // vaultId (16)
+            "01" +                                                                 // k
+            "01000000" +                                                           // slotCount = 1 (LE)
+            "101112131415161718191a1b1c1d1e1f" +                                   // slotId (16)
+            "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f" +   // publicKey (32)
+            "04000000" +                                                           // wrappedLength = 4 (LE)
+            "aabbccdd";                                                            // wrapped
+
+        Assert.Equal(78, bytes.Length);
+        Assert.Equal(expectedHex, Convert.ToHexStringLower(bytes));
+    }
+
+    [Fact]
+    public void EncodeDecode_RoundTrips()
+    {
+        var keyring = OneSlotKeyring();
+
+        var decoded = KeyringCodec.Decode(KeyringCodec.Encode(keyring));
+
+        Assert.Equal(keyring.FormatVersion, decoded.FormatVersion);
+        Assert.Equal(keyring.VaultId, decoded.VaultId);
+        Assert.Equal(keyring.K, decoded.K);
+        Assert.Single(decoded.Slots);
+        Assert.Equal(SlotId, decoded.Slots[0].SlotId);
+        Assert.Equal(PublicKey, decoded.Slots[0].PublicKey);
+        Assert.Equal(Wrapped, decoded.Slots[0].Wrapped);
+    }
+
+    [Fact]
+    public void EncodeDecode_RoundTripsEmptyWrapped()
+    {
+        var keyring = new Keyring(1, VaultId, 1, [new Slot(SlotId, PublicKey, [])]);
+
+        var decoded = KeyringCodec.Decode(KeyringCodec.Encode(keyring));
+
+        Assert.Empty(decoded.Slots[0].Wrapped);
+    }
+
+    [Fact]
+    public void EncodeDecode_RoundTripsMultipleSlots()
+    {
+        // v0 always writes exactly one slot, but the format supports more from day one
+        // (#121 appends slots without a format bump) — prove the loop actually handles it.
+        var slotId2 = Convert.FromHexString("303132333435363738393a3b3c3d3e3f");
+        var publicKey2 = Convert.FromHexString("404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f");
+        var keyring = new Keyring(1, VaultId, 1,
+            [new Slot(SlotId, PublicKey, Wrapped), new Slot(slotId2, publicKey2, [1, 2, 3])]);
+
+        var decoded = KeyringCodec.Decode(KeyringCodec.Encode(keyring));
+
+        Assert.Equal(2, decoded.Slots.Count);
+        Assert.Equal(slotId2, decoded.Slots[1].SlotId);
+        Assert.Equal(publicKey2, decoded.Slots[1].PublicKey);
+        Assert.Equal(new byte[] { 1, 2, 3 }, decoded.Slots[1].Wrapped);
+    }
+
+    [Fact]
+    public void Encode_WrongVaultIdLengthThrowsArgumentException()
+    {
+        var keyring = new Keyring(1, new byte[4], 1, [new Slot(SlotId, PublicKey, Wrapped)]);
+
+        Assert.Throws<ArgumentException>(() => KeyringCodec.Encode(keyring));
+    }
+
+    [Fact]
+    public void Encode_WrongSlotIdLengthThrowsArgumentException()
+    {
+        var keyring = new Keyring(1, VaultId, 1, [new Slot(new byte[4], PublicKey, Wrapped)]);
+
+        Assert.Throws<ArgumentException>(() => KeyringCodec.Encode(keyring));
+    }
+
+    [Fact]
+    public void Encode_WrongPublicKeyLengthThrowsArgumentException()
+    {
+        var keyring = new Keyring(1, VaultId, 1, [new Slot(SlotId, new byte[4], Wrapped)]);
+
+        Assert.Throws<ArgumentException>(() => KeyringCodec.Encode(keyring));
+    }
+
+    [Fact]
+    public void Decode_TooShortForHeaderThrowsTswapException()
+    {
+        var ex = Assert.Throws<TswapException>(() => KeyringCodec.Decode(new byte[10]));
+        Assert.Contains("shorter than the header", ex.Message);
+    }
+
+    [Fact]
+    public void Decode_EmptyInputThrowsTswapException()
+    {
+        Assert.Throws<TswapException>(() => KeyringCodec.Decode([]));
+    }
+
+    [Fact]
+    public void Decode_TruncatedSlotHeaderThrowsTswapException()
+    {
+        // A valid header claiming one slot, but far fewer bytes than a slot header needs.
+        var bytes = KeyringCodec.Encode(OneSlotKeyring());
+        var truncated = bytes[..25]; // header(22) + 3 bytes of the first slot, nowhere near enough
+
+        var ex = Assert.Throws<TswapException>(() => KeyringCodec.Decode(truncated));
+        Assert.Contains("truncated slot header", ex.Message);
+    }
+
+    [Fact]
+    public void Decode_WrappedLengthPrefixExceedsAvailableDataThrowsTswapException()
+    {
+        var bytes = KeyringCodec.Encode(OneSlotKeyring());
+        // Overwrite wrappedLength (right after slotId+publicKey, i.e. offset 22+16+32=70) with
+        // an enormous value while leaving the actual trailing bytes unchanged (still just 4).
+        var tampered = (byte[])bytes.Clone();
+        var lengthOffset = 22 + 16 + 32;
+        tampered[lengthOffset] = 0xFF;
+        tampered[lengthOffset + 1] = 0xFF;
+        tampered[lengthOffset + 2] = 0xFF;
+        tampered[lengthOffset + 3] = 0x7F;
+
+        var ex = Assert.Throws<TswapException>(() => KeyringCodec.Decode(tampered));
+        Assert.Contains("wrapped-slot length prefix exceeds available data", ex.Message);
+    }
+
+    [Fact]
+    public void Decode_SlotCountLargerThanDataDoesNotHangOrOverflow()
+    {
+        // A corrupted/hostile slotCount (near uint.MaxValue) must fail fast on the first
+        // iteration's bounds check, not loop for a very long time or overflow an
+        // addition-based bounds check into a false pass (see KeyringCodec.Decode's own comment
+        // on subtraction- vs addition-based bounds checks).
+        var bytes = KeyringCodec.Encode(OneSlotKeyring());
+        var tampered = (byte[])bytes.Clone();
+        var slotCountOffset = 1 + KeyringFormat.VaultIdSize + 1;
+        tampered[slotCountOffset] = 0xFE;
+        tampered[slotCountOffset + 1] = 0xFF;
+        tampered[slotCountOffset + 2] = 0xFF;
+        tampered[slotCountOffset + 3] = 0xFF;
+
+        var ex = Assert.Throws<TswapException>(() => KeyringCodec.Decode(tampered));
+        Assert.Contains("Malformed keyring", ex.Message);
+    }
+}

--- a/TswapTests/ModelsTests.cs
+++ b/TswapTests/ModelsTests.cs
@@ -155,6 +155,45 @@ public class ModelsTests
     }
 
     [Fact]
+    public void Config_NullKeyring_IsOmittedFromJson()
+    {
+        // Same backward-compat guarantee as TpmSealedKey/SecureEnclaveWrappedKey/MasterKeySalt:
+        // a vault that hasn't opted into the Phase 6 keyring format (issue #119) must serialize
+        // with no Keyring field at all, so every existing config.json stays byte-for-byte
+        // unchanged.
+        var config = new Config([1, 2], "aabb", DateTime.UtcNow, RngMode: RngMode.System);
+        var json = JsonSerializer.Serialize(config, TswapJsonContext.Default.Config);
+        Assert.DoesNotContain("Keyring", json);
+        Assert.Null(config.Keyring);
+    }
+
+    [Fact]
+    public void Config_Keyring_RoundTrips()
+    {
+        var config = new Config([1, 2], "aabb", DateTime.UtcNow, Keyring: "a2V5cmluZ2Jsb2I=");
+        var json = JsonSerializer.Serialize(config, TswapJsonContext.Default.Config);
+        Assert.Contains("\"Keyring\": \"a2V5cmluZ2Jsb2I=\"", json);
+        Assert.Equal("a2V5cmluZ2Jsb2I=", JsonSerializer.Deserialize(json, TswapJsonContext.Default.Config)!.Keyring);
+    }
+
+    [Fact]
+    public void Config_LegacyJsonWithoutKeyring_DeserializesAsNull()
+    {
+        // A config from before this field existed (every vault today) has no Keyring key; it
+        // must load with Keyring == null, which VaultUnlocker treats as "not a keyring vault —
+        // use the recovered 32 bytes as the master key directly, unchanged".
+        const string legacy = """
+            {
+              "YubiKeySerials": [11111111, 22222222],
+              "RedundancyXor": "00ff",
+              "Created": "2024-05-01T00:00:00Z"
+            }
+            """;
+        var config = JsonSerializer.Deserialize(legacy, TswapJsonContext.Default.Config)!;
+        Assert.Null(config.Keyring);
+    }
+
+    [Fact]
     public void ExportFile_V1VersionTag_Unchanged()
     {
         // The v1 tag and its (Kdf-less) shape must never change — every export file ever

--- a/TswapTests/SlotSecretPayloadTests.cs
+++ b/TswapTests/SlotSecretPayloadTests.cs
@@ -1,0 +1,68 @@
+using TswapCore;
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Tests for the (K_v, slot private key) payload <see cref="SlotPayloadWrap"/> wraps inside a
+/// slot (issue #119). Golden-byte test pins the exact concatenation order, since
+/// <see cref="SlotSecretPayload"/> relies on both fields being a fixed, pinned width rather than
+/// length-prefixed — see its doc comment for why that's safe here specifically.
+/// </summary>
+public class SlotSecretPayloadTests
+{
+    private static readonly byte[] VaultKey = Convert.FromHexString(
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    private static readonly byte[] SlotPrivateKey = Convert.FromHexString(
+        "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f");
+
+    [Fact]
+    public void Encode_MatchesGoldenBytesExactly()
+    {
+        var encoded = SlotSecretPayload.Encode(VaultKey, SlotPrivateKey);
+
+        const string expectedHex =
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" +
+            "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f";
+
+        Assert.Equal(64, encoded.Length);
+        Assert.Equal(expectedHex, Convert.ToHexStringLower(encoded));
+    }
+
+    [Fact]
+    public void EncodeDecode_RoundTrips()
+    {
+        var encoded = SlotSecretPayload.Encode(VaultKey, SlotPrivateKey);
+
+        var (vaultKey, slotPrivateKey) = SlotSecretPayload.Decode(encoded);
+
+        Assert.Equal(VaultKey, vaultKey);
+        Assert.Equal(SlotPrivateKey, slotPrivateKey);
+    }
+
+    [Fact]
+    public void Encode_WrongVaultKeyLengthThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => SlotSecretPayload.Encode(new byte[16], SlotPrivateKey));
+    }
+
+    [Fact]
+    public void Encode_WrongSlotPrivateKeyLengthThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => SlotSecretPayload.Encode(VaultKey, new byte[16]));
+    }
+
+    [Fact]
+    public void Decode_WrongLengthThrowsTswapException()
+    {
+        var ex = Assert.Throws<TswapException>(() => SlotSecretPayload.Decode(new byte[10]));
+        Assert.Contains("Malformed slot payload", ex.Message);
+    }
+
+    [Fact]
+    public void Decode_EmptyInputThrowsTswapException()
+    {
+        Assert.Throws<TswapException>(() => SlotSecretPayload.Decode([]));
+    }
+}

--- a/TswapTests/VaultUnlockerTests.cs
+++ b/TswapTests/VaultUnlockerTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using TswapCore;
+using TswapCore.Keyring;
 using TswapCore.Vault;
 using Xunit;
 
@@ -280,5 +281,137 @@ public class VaultUnlockerTests
         var ex = Assert.Throws<ArgumentException>(
             () => new VaultUnlocker(yubi, additionalBackends: [first, second]));
         Assert.Contains("Duplicate", ex.Message);
+    }
+
+    // --- Phase 6 keyring vault (issue #119) ---
+
+    /// <summary>
+    /// Builds a single-slot, k = 1 keyring vault exactly the way <c>InitCommand</c>'s
+    /// <c>--keyring</c> path does: KEK_slot recovered via the ordinary YubiKey challenge/XOR
+    /// dance (no <see cref="Crypto.DeriveKey"/> step — that value <b>is</b> KEK_slot here, not
+    /// the master key), a fresh slot X25519 keypair, K_v and the slot private key concatenated
+    /// via <see cref="SlotSecretPayload"/> and wrapped via <see cref="SlotPayloadWrap"/>.
+    /// </summary>
+    private static (FakeYubiKeys Yubi, Config Config, byte[] VaultKey) MakeKeyringVault()
+    {
+        var k1 = RandomNumberGenerator.GetBytes(20);
+        var k2 = RandomNumberGenerator.GetBytes(20);
+        var masterKeySalt = RandomNumberGenerator.GetBytes(32);
+        var kekSlot = Crypto.DeriveKey(k1, k2, masterKeySalt);
+
+        var vaultKey = RandomNumberGenerator.GetBytes(32);
+        var slotKeyPair = SlotKeyPair.Generate();
+        var vaultId = RandomNumberGenerator.GetBytes(KeyringFormat.VaultIdSize);
+        var slotId = RandomNumberGenerator.GetBytes(KeyringFormat.SlotIdSize);
+
+        var payload = SlotSecretPayload.Encode(vaultKey, slotKeyPair.PrivateKey);
+        var wrapped = SlotPayloadWrap.Wrap(payload, kekSlot, KeyringFormat.KeyringFormatVersion, vaultId, k: 1, slotId);
+        var keyring = new Keyring(KeyringFormat.KeyringFormatVersion, vaultId, K: 1,
+            [new Slot(slotId, slotKeyPair.PublicKey, wrapped)]);
+
+        var config = new Config(
+            [11111111, 22222222],
+            Convert.ToHexString(Crypto.XorBytes(k1, k2)),
+            DateTime.UtcNow,
+            UnlockChallenge: "aabbcc",
+            MasterKeySalt: Convert.ToBase64String(masterKeySalt),
+            Keyring: Convert.ToBase64String(KeyringCodec.Encode(keyring)));
+
+        var yubi = new FakeYubiKeys { Responses = { [11111111] = k1, [22222222] = k2 } };
+        return (yubi, config, vaultKey);
+    }
+
+    [Fact]
+    public void Unlock_KeyringVault_RecoversOriginalVaultKey()
+    {
+        var (yubi, config, vaultKey) = MakeKeyringVault();
+        yubi.Connected = [11111111];
+
+        var unlocked = new VaultUnlocker(yubi).Unlock(config, NoSelection);
+
+        Assert.Equal(vaultKey, unlocked);
+    }
+
+    [Fact]
+    public void Unlock_KeyringVault_EitherEnrolledYubiKeyRecoversSameVaultKey()
+    {
+        // The YubiKey pair's own 1-of-2 redundancy still applies one layer down: either key
+        // reconstructs KEK_slot via the XOR share, which then unwraps the identical K_v.
+        var (yubi, config, vaultKey) = MakeKeyringVault();
+
+        yubi.Connected = [11111111];
+        var viaFirst = new VaultUnlocker(yubi).Unlock(config, NoSelection);
+
+        yubi.Connected = [22222222];
+        var viaSecond = new VaultUnlocker(yubi).Unlock(config, NoSelection);
+
+        Assert.Equal(vaultKey, viaFirst);
+        Assert.Equal(vaultKey, viaSecond);
+    }
+
+    [Fact]
+    public void Unlock_LegacyVaultWithoutKeyringField_IsByteForByteUnaffected()
+    {
+        // The hard requirement from issue #119: every vault that predates the keyring field
+        // (Config.Keyring == null) must keep unlocking exactly as before — no extra unwrap step.
+        var (yubi, config, k1, k2) = MakeVault();
+        yubi.Connected = [11111111];
+        Assert.Null(config.Keyring);
+
+        var key = new VaultUnlocker(yubi).Unlock(config, NoSelection);
+
+        Assert.Equal(Crypto.DeriveKey(k1, k2), key);
+    }
+
+    [Fact]
+    public void Unlock_KeyringNotValidBase64_ThrowsClearTswapException()
+    {
+        var (yubi, config, _) = MakeKeyringVault();
+        yubi.Connected = [11111111];
+        var corrupted = config with { Keyring = "not-valid-base64!!!" };
+
+        var ex = Assert.Throws<TswapException>(() => new VaultUnlocker(yubi).Unlock(corrupted, NoSelection));
+        Assert.Contains("not valid base64", ex.Message);
+    }
+
+    [Fact]
+    public void Unlock_KeyringBinaryTooShort_ThrowsClearTswapException()
+    {
+        var (yubi, config, _) = MakeKeyringVault();
+        yubi.Connected = [11111111];
+        var corrupted = config with { Keyring = Convert.ToBase64String(new byte[5]) };
+
+        var ex = Assert.Throws<TswapException>(() => new VaultUnlocker(yubi).Unlock(corrupted, NoSelection));
+        Assert.Contains("Malformed keyring", ex.Message);
+    }
+
+    [Fact]
+    public void Unlock_KeyringWithNoSlots_ThrowsClearTswapException()
+    {
+        var (yubi, config, _) = MakeKeyringVault();
+        yubi.Connected = [11111111];
+        var emptyKeyring = new Keyring(KeyringFormat.KeyringFormatVersion,
+            RandomNumberGenerator.GetBytes(KeyringFormat.VaultIdSize), K: 1, []);
+        var corrupted = config with { Keyring = Convert.ToBase64String(KeyringCodec.Encode(emptyKeyring)) };
+
+        var ex = Assert.Throws<TswapException>(() => new VaultUnlocker(yubi).Unlock(corrupted, NoSelection));
+        Assert.Contains("no slots", ex.Message);
+    }
+
+    [Fact]
+    public void Unlock_KeyringSlotWrappedUnderDifferentKekSlot_FailsAuthenticationCleanly()
+    {
+        // Simulates a config.json hand-edited to point at the wrong YubiKey pair's keyring
+        // entry (or a bit-flip in the wrapped bytes): must surface as a clean TswapException
+        // from the AEAD layer, not a raw crash.
+        var (yubi, config, _) = MakeKeyringVault();
+        yubi.Connected = [11111111];
+
+        var keyringBytes = Convert.FromBase64String(config.Keyring!);
+        keyringBytes[^1] ^= 0xFF; // flip a byte inside the wrapped slot payload
+        var corrupted = config with { Keyring = Convert.ToBase64String(keyringBytes) };
+
+        var ex = Assert.Throws<TswapException>(() => new VaultUnlocker(yubi).Unlock(corrupted, NoSelection));
+        Assert.Contains("authentication", ex.Message);
     }
 }


### PR DESCRIPTION
## Summary

Implements issue #119 — `MULTI_MACHINE_KEYING.md` §Implementation ordering, **step 1 only**:
"Random `K_v` + single-slot keyring, `k = 1`, YubiKey only." Adds `tswap init --keyring`, which
generates a random 256-bit `K_v` and wraps it (via a two-layer scheme) under a single YubiKey
pair's slot, instead of deriving `K_v` directly from the two YubiKeys' challenge responses the
way the default `init` does today.

Out of scope (per the issue and design doc, not attempted here):
- A TPM or Secure Enclave keyring variant (design doc v0 step 2, separate PR).
- `slot request`/`approve`/`accept` — multi-machine enrollment (#121).
- The per-secret record format (`SecretRecordCodec` et al., #111-#115/#137/#118) — a parallel,
  orthogonal Phase 6 sub-system. **Secrets stay in the existing single-blob `secrets.json.enc`
  format** even for a keyring vault; this PR is only about how the vault master key is protected.
- #120 (recovery keypair), #122 (fingerprint display), #123 (slots listing).

## Design judgement call: additive `Config` field, not a new `IVaultStore`

The design doc says the eventual keyring "belongs" behind a new `IVaultStore` implementation.
Building one now would be more than this step needs, so — per the issue's own recommended
default — the keyring is a new **optional field on the existing `Config` record**
(`Config.Keyring`, base64 blob), following the exact same additive pattern as
`TpmSealedKey`/`SecureEnclaveWrappedKey`/`MasterKeySalt`. `secrets.json.enc` and the
`Storage`/`config.json` file layout are completely unchanged. This keeps a `k=1` keyring vault
as "the same file layout, richer `Config` content," and defers the real `IVaultStore` question
to whenever the per-secret record format and the keyring actually need to merge.

**Hard requirement satisfied:** every vault that exists today (`Config.Backend` =
null/yubikey/tpm/secure-enclave, `Config.Keyring` unset) is byte-for-byte unaffected — verified
by `VaultUnlockerTests.Unlock_LegacyVaultWithoutKeyringField_IsByteForByteUnaffected` and the
`ModelsTests` golden-file tests for `Config.Keyring` being omitted when null.

### `Config.Backend` is left alone; `Config.Keyring`'s presence is the sole discriminator

A keyring vault still sets `Config.Backend = null` (YubiKey) and populates
`YubiKeySerials`/`RedundancyXor`/`UnlockChallenge`/`MasterKeySalt` exactly like the default
flow — `YubiKeyHardwareService.Unlock` recovers the same 32 bytes from those fields completely
unchanged (confirmed: no changes to `IHardwareKeyService` or `YubiKeyHardwareService` at all).
`VaultUnlocker.Unlock` now does:

```csharp
var recovered = service.Unlock(config, chooseSerial);
return config.Keyring == null ? recovered : UnlockKeyring(config, recovered);
```

This check is deliberately **backend-agnostic** and sits *after* backend dispatch: whichever
backend recovered the 32 bytes, a keyring vault always needs the same extra unwrap step, so
design doc v0 step 2 (a second, non-YubiKey backend under the keyring format) needs no change
here at all when it lands.

### No per-slot `hwBlob` field (yet)

The design doc's slot sketch includes `hwBlob: backendWrap(KEK_slot)` per slot. For this PR
(YubiKey only), that role is already filled by `Config`'s existing YubiKey fields at the
vault level — there's exactly one backend and one slot, so a redundant per-slot blob would just
duplicate what `Config` already carries. A real per-slot `hwBlob` becomes necessary once a
second backend exists (no vault-wide TPM/SE-wrapped-KEK_slot field to reuse) — deliberately
deferred, documented in `Slot`'s doc comment, not overlooked.

## Byte layout (for #121 and any future work building on this)

### `Keyring`/`Slot` (`TswapCore/Keyring/Keyring.cs`, `KeyringCodec`)

Fixed-binary, length-prefixed, explicitly ordered — not JSON — same reasoning as
`SecretRecordCodec`/`KeyringFormat`: this structure's bytes (`vaultId`, `k`, `slotId`) directly
feed `SlotPayloadWrap`'s AAD, so a JSON reordering would silently brick every keyring vault.

```
formatVersion   1 byte    KeyringFormat.KeyringFormatVersion (new constant, = 1, distinct
                          from KeyringFormat.RecordFormatVersion which versions the unrelated
                          per-secret record envelope)
vaultId         16 bytes  KeyringFormat.VaultIdSize
k               1 byte    always 1 in this PR
slotCount       4 bytes   little-endian; always 1 today, but the loop is general —
                          #121 appends slots without a format bump
slots[slotCount]:
  slotId          16 bytes  KeyringFormat.SlotIdSize
  publicKey       32 bytes  SlotKeyPair.KeySize (X25519 public key, kept in the clear)
  wrappedLength   4 bytes   little-endian
  wrapped         wrappedLength bytes  SlotPayloadWrap.Wrap output (nonce(12)||tag(16)||ciphertext)
```

Stored as `Convert.ToBase64String(...)` in the new `Config.Keyring` field.

### Slot payload (`TswapCore/Keyring/SlotSecretPayload.cs`)

The plaintext `SlotPayloadWrap.Wrap`/`Unwrap` protects — one AEAD call, not two, per the
issue's suggested judgement call (both values share the same `KEK_slot` and AAD, so splitting
them would just double the bookkeeping for no isolation gain):

```
vaultKey(32)        K_v — KeyringFormat.VaultKeySize (new constant)
slotPrivateKey(32)  this slot's X25519 private key — SlotKeyPair.KeySize
```

No length prefixes needed: both fields are fixed, pinned-width 32 bytes, so the concatenation
has exactly one decomposition.

## CLI flag: `--keyring`

Chose `--keyring` over `--fleet` (both suggested in the issue) because this step only changes
*how the vault master key is protected* — it does not yet enable multi-machine sharing (no
`slot request/approve/accept` yet), and "fleet" would overstate what's delivered here. `init`'s
mutual-exclusion check now covers all three optional flags (`--secure-enclave|--tpm|--keyring`).

## What was built

1. `TswapCore/Keyring/Keyring.cs` — `Slot`/`Keyring` records + `KeyringCodec` (encode/decode).
2. `TswapCore/Keyring/SlotSecretPayload.cs` — the `(K_v, slot private key)` payload codec.
3. `TswapCore/Keyring/KeyringFormat.cs` — new `KeyringFormatVersion` and `VaultKeySize` constants.
4. `TswapCore/Models.cs` — new additive `Config.Keyring` field.
5. `TswapCore/Vault/VaultUnlocker.cs` — the new backend-agnostic keyring-unwrap branch.
6. `TswapCli/Commands/InitCommand.cs` — `init --keyring`, following the existing
   `--secure-enclave`/`--tpm` variants' shape (backup-before-reinit via `IFileVaultStore`,
   completion banner, XOR-share backup notice since KEK_slot recovery still needs the pair).

## Verification

- `./runtests.sh --unit` — 482 tests pass (up from the pre-existing baseline).
- `dotnet publish -c Release TswapCli/TswapCli.csproj` — NativeAOT publish still succeeds.
- Golden-byte tests: `KeyringCodecTests` (keyring/slot layout), `SlotSecretPayloadTests`
  (payload layout).
- Full CLI-level round trip: `CommandTests.InitKeyring_FullRoundTrip_AddThenGetRecoversValue`
  (`init --keyring` → `add` → `get`, through the real `CliRunner` dispatch path).
- Legacy-vault-unaffected proof: `VaultUnlockerTests.Unlock_LegacyVaultWithoutKeyringField_IsByteForByteUnaffected`
  plus the `ModelsTests` golden-file tests for `Config.Keyring` being omitted when null.
- Malformed-blob robustness: `VaultUnlockerTests.Unlock_KeyringNotValidBase64_ThrowsClearTswapException`,
  `Unlock_KeyringBinaryTooShort_ThrowsClearTswapException`, `Unlock_KeyringWithNoSlots_ThrowsClearTswapException`,
  `Unlock_KeyringSlotWrappedUnderDifferentKekSlot_FailsAuthenticationCleanly`, plus
  `KeyringCodecTests`' own truncated/oversized-length-prefix tests (subtraction-based bounds
  checks, matching `SecretRecordCodec.Decode`'s established pattern) — all throw
  `TswapException`, never a raw crash.

Closes #119.
