### PR TITLE
Phase 6 v0: hand-carried multi-machine enrollment (slot request/approve/accept + fingerprint)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,17 @@ There is no linter configured.
 Commands are split by whether they require sudo:
 
 - **No sudo**: `init`, `create <name>`, `ingest <name>`, `names`, `run <cmd>`, `burn <name>`, `burned`, `check <path>`, `redact <file>`, `tocomment <file>`, `apply <file>`, `prompt`, `prompt-hash`, `completion <shell>`, `migrate` — safe for AI agents
-- **Requires sudo**: `add <name>`, `get <name>`, `list`, `delete <name>`, `export <path>`, `import <path>` — exposes secret values
+- **Requires sudo**: `add <name>`, `get <name>`, `list`, `delete <name>`, `export <path>`, `import <path>`, `slot approve <request-file> <approve-file>` — exposes secret values
+
+`slot approve` specifically: it unlocks an *existing* vault and writes out an artifact that
+decrypts that vault's master key for whoever holds the matching private key — the same
+sensitivity class as `export`. `slot`'s other two subcommands, `slot request <file>` and
+`slot accept <file>`, do *not* require sudo — they run on a machine with no existing usable
+vault yet (mirroring `init`) and never touch an existing vault's secrets. Because
+`ICliCommand.RequiresSudo` is a single per-command flag and this codebase has no "sometimes
+sudo" precedent, the `slot` command as a whole is bucketed under `[sudo]` on the `--help`
+screen and in this list; the runtime `RequireSudo` check itself only actually fires inside
+`slot approve`.
 
 This enforces that AI agents can use secrets (`run`) but cannot read or enumerate values.
 
@@ -114,7 +124,7 @@ The `TswapCli/` project is the executable (assembly name `tswap`):
 3. **`IConsole` / `SystemConsole`** — console seam (output, masked password input) so commands are testable in-process
 4. **`CommandContext`** — services handed to every command (console, storage, YubiKey service, vault unlocker, sudo enforcement)
 5. **`CommandRegistry`** — name → command dispatch; the help screen is generated from command metadata
-6. **`Commands/`** — one class per command implementing `ICliCommand` (init, create, ingest, names, burn, burned, prompt, prompt-hash, run, check, redact, tocomment, apply, migrate, add, get, list, delete, export, import, installscript, completion)
+6. **`Commands/`** — one class per command implementing `ICliCommand` (init, slot, create, ingest, names, burn, burned, prompt, prompt-hash, run, check, redact, tocomment, apply, migrate, add, get, list, delete, export, import, installscript, completion)
 
 YubiKey hardware access is abstracted behind `TswapCore.Vault.IYubiKeyService` (`YkmanYubiKeyService` shells out to ykman; `TestKeyYubiKeyService` simulates for tests). Vault unlock goes through `IHardwareKeyService` — `YubiKeyHardwareService` holds the challenge/XOR/PBKDF2 logic, and `VaultUnlocker` selects the backend from `Config.Backend` (null ⇒ YubiKey). This is the seam for adding TPM (Windows/Linux) and Apple Secure Enclave (macOS) backends; see `HARDWARE_BACKENDS.md`.
 

--- a/TswapCli/CommandContext.cs
+++ b/TswapCli/CommandContext.cs
@@ -33,6 +33,15 @@ public sealed record CommandContext(
         return Unlocker.Unlock(config, ChooseSerial);
     }
 
+    /// <summary>
+    /// Recovers this machine's hardware-backed key material without any keyring unwrap or
+    /// pending-enrollment guard — used by <c>slot accept</c> (issue #121) to recompute its own
+    /// <c>KEK_slot</c> from a still-pending config (<see cref="Config.Keyring"/> is null at that
+    /// point by design), where the ordinary <see cref="Unlock"/> would otherwise refuse to
+    /// proceed. See <see cref="TswapCore.Vault.VaultUnlocker.UnlockHardware"/>.
+    /// </summary>
+    public byte[] UnlockHardwareOnly(Config config) => Unlocker.UnlockHardware(config, ChooseSerial);
+
     /// <summary>Loads the secrets database, surfacing recoverable-vault warnings on stderr.</summary>
     public TswapCore.SecretsDb LoadSecrets(byte[] key)
         => Storage.LoadSecrets(key, Console.Error);

--- a/TswapCli/CommandRegistry.cs
+++ b/TswapCli/CommandRegistry.cs
@@ -13,6 +13,7 @@ public static class CommandRegistry
     private static readonly ICliCommand[] Commands =
     [
         new InitCommand(),
+        new SlotCommand(),
         new MigrateCommand(),
         new CreateCommand(),
         new IngestCommand(),

--- a/TswapCli/Commands/InitCommand.cs
+++ b/TswapCli/Commands/InitCommand.cs
@@ -446,9 +446,12 @@ public sealed class InitCommand : ICliCommand
         var slotId = RandomNumberGenerator.GetBytes(KeyringFormat.SlotIdSize);
         const byte k = 1;
 
-        var payload = SlotSecretPayload.Encode(vaultKey, slotKeyPair.PrivateKey);
-        var wrapped = SlotPayloadWrap.Wrap(payload, kekSlot, KeyringFormat.KeyringFormatVersion, vaultId, k, slotId);
-        var machineSlot = new Slot(slotId, slotKeyPair.PublicKey, wrapped);
+        // Issue #121: extracted into MachineSlotWrap so 'slot accept' (functionally "the
+        // enrollment half of init --keyring" for a second machine) builds its own final slot with
+        // the exact same construction, not a re-derived copy.
+        var machineSlot = MachineSlotWrap.Wrap(
+            vaultKey, slotKeyPair.PrivateKey, slotKeyPair.PublicKey, slotId, kekSlot,
+            KeyringFormat.KeyringFormatVersion, vaultId, k);
 
         var slots = new List<Slot> { machineSlot };
         byte[]? recoveryPrivateKey = null;
@@ -473,7 +476,11 @@ public sealed class InitCommand : ICliCommand
             rngMode,
             unlockChallenge,
             MasterKeySalt: Convert.ToBase64String(masterKeySalt),
-            Keyring: keyringBlob
+            Keyring: keyringBlob,
+            // Issue #121: records which of Keyring's slots is this machine's own, so
+            // VaultUnlocker can still find it unambiguously once a second machine's slot is
+            // appended via 'slot accept' — see Config.KeyringSlotId's doc comment.
+            KeyringSlotId: Convert.ToBase64String(slotId)
         );
 
         return (config, vaultKey, recoveryPrivateKey);

--- a/TswapCli/Commands/SlotCommand.cs
+++ b/TswapCli/Commands/SlotCommand.cs
@@ -21,21 +21,41 @@ namespace TswapCli.Commands;
 /// which is the same shape this type follows, keyed on a subcommand word
 /// (<c>request</c>/<c>approve</c>/<c>accept</c>) instead of a flag.</para>
 ///
-/// <para><b>Non-sudo (judgement call, mirrors <c>init</c>).</b> None of these three subcommands
-/// expose a stored secret's *value* — the thing <c>RequiresSudo</c> gates elsewhere in this
-/// codebase (see AGENTS.md's privilege-boundary section). <c>slot request</c>/<c>accept</c> run on
-/// a machine with no vault yet; <c>slot approve</c> unlocks the vault the same way non-sudo
-/// commands like <c>create</c>/<c>run</c> already do, and its output file carries a wrapped
-/// <c>K_v</c>, not any named secret's plaintext — the same category of sensitive-but-not-a-value
-/// material <c>init --keyring</c> already prints to stdout in the clear (the XOR share, the
-/// recovery private key) without requiring sudo.</para>
+/// <para><b><c>approve</c> is sudo-gated; <c>request</c>/<c>accept</c> are not (corrected after
+/// security review).</b> The original judgement call here reasoned that <c>slot approve</c>'s
+/// output carries a wrapped <c>K_v</c>, not any named secret's plaintext, and so didn't need
+/// sudo — that was wrong: unlike <c>init --keyring</c>'s XOR share/recovery private key (which are
+/// only ever useful together with hardware nobody but this machine's operator possesses),
+/// <c>approve</c>'s output file, given only an attacker-suppliable request file, is a
+/// self-contained artifact that decrypts the *existing* vault's <c>K_v</c> for whoever holds the
+/// matching private key — exactly the same sensitivity class as <see cref="ExportCommand"/>, which
+/// is <c>RequiresSudo</c> for precisely this reason. <c>slot approve</c> therefore calls
+/// <c>ctx.RequireSudo("slot approve")</c> as the first thing it does, before reading the request
+/// file or unlocking anything. <c>slot request</c>/<c>accept</c> remain non-sudo: they run on a
+/// machine with no existing usable vault (mirroring <c>init</c>) and never touch an *existing*
+/// vault's secrets — see <see cref="RequiresSudo"/>'s doc comment for how that mixed reality maps
+/// onto this type's single <c>RequiresSudo</c> flag.</para>
 /// </summary>
 public sealed class SlotCommand : ICliCommand
 {
     public string Name => "slot";
     public string HelpUsage => "slot request <file> | slot approve <request-file> <approve-file> | slot accept <file>";
     public string Description => "Enroll a second machine into an existing --keyring vault via hand-carried files";
-    public bool RequiresSudo => false;
+
+    /// <summary>
+    /// <c>true</c> even though only <c>approve</c> actually calls <c>ctx.RequireSudo</c>
+    /// (security-review correction: <c>approve</c> unlocks an *existing* vault and produces a
+    /// vault-decrypting artifact — the same category export/get gate — while <c>request</c>/
+    /// <c>accept</c> genuinely don't touch an existing vault's secrets and would be fine as
+    /// non-sudo on their own). <see cref="ICliCommand.RequiresSudo"/> is a single per-command
+    /// flag with no "sometimes sudo" precedent in this codebase, and <see cref="CommandRegistry"/>
+    /// only ever reads it to bucket a command onto the help screen — so erring toward
+    /// <c>true</c> here costs nothing at runtime (the real enforcement is the
+    /// <c>ctx.RequireSudo("slot approve")</c> call inside <see cref="ExecuteApprove"/>) while
+    /// correctly flagging to humans and AI agents reading `--help`/AGENTS.md that `slot` touches
+    /// the sudo boundary, rather than under-representing it as fully agent-safe.
+    /// </summary>
+    public bool RequiresSudo => true;
 
     public int Execute(CommandContext ctx, string[] args)
     {
@@ -219,6 +239,12 @@ public sealed class SlotCommand : ICliCommand
         var requestPath = args[0];
         var approvePath = args[1];
         var c = ctx.Console;
+
+        // Security-critical: this unlocks the *existing* vault and produces an artifact that
+        // decrypts K_v for whoever holds the private key matching the (attacker-suppliable)
+        // request file's public key — exactly export's threat model. Must run before anything
+        // else: reading the request file, unlocking, and writing output are all gated on this.
+        ctx.RequireSudo("slot approve");
 
         if (!File.Exists(requestPath))
             throw new TswapException($"Slot request file not found: {requestPath}");

--- a/TswapCli/Commands/SlotCommand.cs
+++ b/TswapCli/Commands/SlotCommand.cs
@@ -1,0 +1,375 @@
+using System.Security.Cryptography;
+using TswapCore;
+using TswapCore.Keyring;
+using TswapCore.Vault;
+
+namespace TswapCli.Commands;
+
+/// <summary>
+/// Hand-carried multi-machine enrollment (issues #121/#122, <c>MULTI_MACHINE_KEYING.md</c>
+/// §Hand-carried enrollment): three subcommands, all dispatched through this one
+/// <see cref="ICliCommand"/> — <c>slot request</c> (on the new, not-yet-enrolled machine),
+/// <c>slot approve</c> (on an already-enrolled machine), and <c>slot accept</c> (back on the new
+/// machine). No network protocol: the user physically moves the two files themselves (scp, USB,
+/// paste into a terminal) — see <see cref="SlotRequestFile"/>/<see cref="SlotApproveFile"/> for
+/// the exact shape of what gets carried.
+///
+/// <para><b>One command, not three (judgement call #1).</b> <see cref="CommandRegistry"/>
+/// dispatches on a single top-level token (<c>args[0]</c>) with no multi-word/hyphenated-
+/// subcommand precedent elsewhere in this codebase — <c>InitCommand</c> already inspects its own
+/// <c>args</c> internally to choose between <c>--secure-enclave</c>/<c>--tpm</c>/<c>--keyring</c>,
+/// which is the same shape this type follows, keyed on a subcommand word
+/// (<c>request</c>/<c>approve</c>/<c>accept</c>) instead of a flag.</para>
+///
+/// <para><b>Non-sudo (judgement call, mirrors <c>init</c>).</b> None of these three subcommands
+/// expose a stored secret's *value* — the thing <c>RequiresSudo</c> gates elsewhere in this
+/// codebase (see AGENTS.md's privilege-boundary section). <c>slot request</c>/<c>accept</c> run on
+/// a machine with no vault yet; <c>slot approve</c> unlocks the vault the same way non-sudo
+/// commands like <c>create</c>/<c>run</c> already do, and its output file carries a wrapped
+/// <c>K_v</c>, not any named secret's plaintext — the same category of sensitive-but-not-a-value
+/// material <c>init --keyring</c> already prints to stdout in the clear (the XOR share, the
+/// recovery private key) without requiring sudo.</para>
+/// </summary>
+public sealed class SlotCommand : ICliCommand
+{
+    public string Name => "slot";
+    public string HelpUsage => "slot request <file> | slot approve <request-file> <approve-file> | slot accept <file>";
+    public string Description => "Enroll a second machine into an existing --keyring vault via hand-carried files";
+    public bool RequiresSudo => false;
+
+    public int Execute(CommandContext ctx, string[] args)
+    {
+        if (args.Length == 0)
+            throw new UsageException(Usage(ctx));
+
+        var sub = args[0].ToLowerInvariant();
+        var rest = args.Skip(1).ToArray();
+
+        return sub switch
+        {
+            "request" => ExecuteRequest(ctx, rest),
+            "approve" => ExecuteApprove(ctx, rest),
+            "accept" => ExecuteAccept(ctx, rest),
+            _ => throw new UsageException(Usage(ctx)),
+        };
+    }
+
+    private static string Usage(CommandContext ctx) =>
+        $"{ctx.Prefix} slot request <file> | {ctx.Prefix} slot approve <request-file> <approve-file> | {ctx.Prefix} slot accept <file>";
+
+    // --- slot request (runs on the new, not-yet-enrolled machine) ---
+
+    /// <summary>
+    /// Design decision #2 (this issue's PR body): enrolls this machine's own hardware
+    /// immediately — the identical YubiKey challenge/XOR/salt dance <c>InitCommand.ExecuteKeyring</c>
+    /// already runs — and saves a real, working <see cref="Config"/> (so this machine can already
+    /// recompute its own <c>KEK_slot</c> later), but with no <see cref="Config.Keyring"/> yet.
+    /// Instead it stashes the freshly-generated X25519 keypair and chosen slot id in
+    /// <see cref="Config.PendingSlotId"/>/<see cref="Config.PendingSlotPublicKey"/>/
+    /// <see cref="Config.PendingSlotPrivateKey"/> until <c>slot accept</c> finalizes things —
+    /// possibly much later, after the files are physically carried. No secrets vault is created
+    /// here at all: there is nothing to encrypt yet, and <see cref="VaultUnlocker"/>'s
+    /// pending-enrollment guard refuses ordinary use of this config until <c>slot accept</c> runs.
+    /// </summary>
+    private static int ExecuteRequest(CommandContext ctx, string[] args)
+    {
+        if (args.Length != 1)
+            throw new UsageException($"{ctx.Prefix} slot request <file>");
+        var path = args[0];
+        var c = ctx.Console;
+
+        var fileStore = ctx.Storage as IFileVaultStore;
+        if (fileStore != null && File.Exists(fileStore.ConfigFile))
+        {
+            c.Out.Write("This machine already has a config. Overwrite and start a new slot request? (yes/no): ");
+            if (c.ReadLine()?.ToLower() != "yes")
+                return 0;
+        }
+
+        var slotKeyPair = SlotKeyPair.Generate();
+        var slotId = RandomNumberGenerator.GetBytes(KeyringFormat.SlotIdSize);
+
+        if (ctx.TestKey != null)
+        {
+            // Test mode: bypass YubiKey entirely, same idea as InitCommand's test branches.
+            var testConfig = new Config(
+                new List<int> { TestKeyYubiKeyService.Serial1, TestKeyYubiKeyService.Serial2 },
+                new string('0', 40),
+                DateTime.UtcNow,
+                null,
+                RngMode.System,
+                Convert.ToHexString(RandomNumberGenerator.GetBytes(32)),
+                MasterKeySalt: Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)),
+                PendingSlotId: Convert.ToBase64String(slotId),
+                PendingSlotPublicKey: Convert.ToBase64String(slotKeyPair.PublicKey),
+                PendingSlotPrivateKey: Convert.ToBase64String(slotKeyPair.PrivateKey));
+            ctx.Storage.SaveConfig(testConfig);
+            WriteRequestFile(path, slotId, slotKeyPair.PublicKey);
+            c.Out.WriteLine("Slot request created (test mode)");
+            PrintFingerprint(c, "This machine's slot", slotKeyPair.PublicKey);
+            c.Out.WriteLine($"\nRequest file written to: {path}");
+            return 0;
+        }
+
+        c.Out.WriteLine("\n╔════════════════════════════════════════╗");
+        c.Out.WriteLine("║  tswap - Slot Request (new machine)    ║");
+        c.Out.WriteLine("╚════════════════════════════════════════╝\n");
+        c.Out.WriteLine("Enrolling this machine's own hardware (same YubiKey pair dance as 'init");
+        c.Out.WriteLine("--keyring'), then generating this slot's X25519 keypair. Nothing is shared");
+        c.Out.WriteLine("or usable as a vault yet — carry the request file this produces to an");
+        c.Out.WriteLine("already-enrolled machine and run 'slot approve' there.\n");
+
+        var unlockChallenge = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+
+        c.Out.WriteLine("Insert YubiKey #1 and press Enter...");
+        if (!c.IsInputRedirected) c.ReadLine();
+        var serial1 = ctx.SelectSerial();
+        var k1 = ctx.YubiKeys.Challenge(serial1, unlockChallenge);
+
+        c.Out.WriteLine("\nRemove YubiKey #1, insert YubiKey #2, press Enter...");
+        if (!c.IsInputRedirected) c.ReadLine();
+        var serial2 = ctx.SelectSerial();
+
+        if (serial1 == serial2)
+            throw new TswapException("Same YubiKey detected. Please use two different YubiKeys.");
+
+        var k2 = ctx.YubiKeys.Challenge(serial2, unlockChallenge);
+
+        c.Out.WriteLine("\nDetecting YubiKey slot configuration...");
+        var touch1 = ctx.YubiKeys.DetectTouchRequirement(serial1);
+        var touch2 = ctx.YubiKeys.DetectTouchRequirement(serial2);
+        bool? requiresTouch = touch1.HasValue && touch2.HasValue ? touch1.Value && touch2.Value : null;
+
+        c.Out.WriteLine("\nPassword generation entropy source:");
+        c.Out.WriteLine("  [1] System RNG  — one YubiKey touch per create (default)");
+        c.Out.WriteLine("  [2] YubiKey     — two YubiKey touches per create; hardware-primary, immune to OS RNG compromise");
+        c.Out.Write("Choose [1/2, default 1]: ");
+        var rngChoice = c.ReadLine()?.Trim();
+        var rngMode = rngChoice == "2" ? RngMode.YubiKey : RngMode.System;
+
+        var xorShare = Crypto.XorBytes(k1, k2);
+        var masterKeySalt = RandomNumberGenerator.GetBytes(32);
+
+        var config = new Config(
+            new List<int> { serial1, serial2 },
+            Convert.ToHexString(xorShare),
+            DateTime.UtcNow,
+            requiresTouch,
+            rngMode,
+            unlockChallenge,
+            MasterKeySalt: Convert.ToBase64String(masterKeySalt),
+            PendingSlotId: Convert.ToBase64String(slotId),
+            PendingSlotPublicKey: Convert.ToBase64String(slotKeyPair.PublicKey),
+            PendingSlotPrivateKey: Convert.ToBase64String(slotKeyPair.PrivateKey));
+
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'");
+        if (fileStore != null && File.Exists(fileStore.ConfigFile))
+        {
+            var configBackup = fileStore.ConfigFile + ".bak-" + timestamp;
+            File.Copy(fileStore.ConfigFile, configBackup);
+        }
+        ctx.Storage.SaveConfig(config);
+        // No SaveSecrets call: there is no vault yet — 'slot accept' is what first creates one,
+        // once it has a real K_v to encrypt an empty database under.
+
+        WriteRequestFile(path, slotId, slotKeyPair.PublicKey);
+
+        c.Out.WriteLine("\n╔════════════════════════════════════════╗");
+        c.Out.WriteLine("║  ✓ SLOT REQUEST CREATED                ║");
+        c.Out.WriteLine("╚════════════════════════════════════════╝\n");
+        PrintFingerprint(c, "This machine's slot", slotKeyPair.PublicKey);
+        c.Out.WriteLine($"\nRequest file written to: {path}");
+        c.Out.WriteLine("Move this file to an already-enrolled machine yourself (scp/USB/paste) —");
+        c.Out.WriteLine("do not drop it in a sync folder. There, run:");
+        c.Out.WriteLine($"  {ctx.Prefix} slot approve <this-file> <approve-file>");
+        c.Out.WriteLine("then bring the resulting approve file back here and run:");
+        c.Out.WriteLine($"  {ctx.Prefix} slot accept <approve-file>");
+        return 0;
+    }
+
+    private static void WriteRequestFile(string path, byte[] slotId, byte[] publicKey)
+    {
+        var file = new SlotRequestFile(
+            SlotRequestFile.CurrentFormatVersion,
+            Convert.ToBase64String(slotId),
+            Convert.ToBase64String(publicKey));
+        File.WriteAllText(path, SlotEnrollmentFileCodec.SerializeRequest(file));
+    }
+
+    // --- slot approve (runs on an already-enrolled machine) ---
+
+    /// <summary>
+    /// Unlocks this machine's own keyring vault to recover <c>K_v</c>, then wraps it to the
+    /// requesting machine's public key using the exact same construction as the recovery slot
+    /// (issue #120, <see cref="RecoverySlotWrap"/>) — an ephemeral X25519 keypair, ECDH against
+    /// the recipient's public key, HKDF into a KEK, <see cref="SlotPayloadWrap.Wrap"/>. That type
+    /// already wraps an arbitrary 32-byte payload to an arbitrary X25519 public key with no
+    /// assumption it's specifically a "recovery" key, so it is reused wholesale here rather than
+    /// duplicated.
+    ///
+    /// <para>Design decision #3 (this issue's PR body): the approve file carries this machine's
+    /// <em>entire</em> current slot list, not just the new slot's material, so the accepting
+    /// machine's local keyring ends up a complete (if manually-propagated) picture of the fleet.
+    /// </para>
+    /// </summary>
+    private static int ExecuteApprove(CommandContext ctx, string[] args)
+    {
+        if (args.Length != 2)
+            throw new UsageException($"{ctx.Prefix} slot approve <request-file> <approve-file>");
+        var requestPath = args[0];
+        var approvePath = args[1];
+        var c = ctx.Console;
+
+        if (!File.Exists(requestPath))
+            throw new TswapException($"Slot request file not found: {requestPath}");
+
+        var request = SlotEnrollmentFileCodec.DeserializeRequest(File.ReadAllText(requestPath));
+        var requesterPublicKey = SlotEnrollmentFileCodec.DecodeFixed(request.PublicKey, SlotKeyPair.KeySize, "slot request file's public key");
+        var newSlotId = SlotEnrollmentFileCodec.DecodeFixed(request.SlotId, KeyringFormat.SlotIdSize, "slot request file's slot id");
+
+        c.Out.WriteLine($"Read slot request from: {requestPath}");
+        PrintFingerprint(c, "Requesting machine's slot", requesterPublicKey);
+        c.Out.WriteLine("Compare this against the fingerprint shown on the requesting machine before continuing.\n");
+
+        var config = ctx.Storage.LoadConfig();
+        if (config.Keyring == null)
+            throw new TswapException(
+                "This machine has no keyring vault to approve from. Run 'tswap init --keyring' here first " +
+                "(a classic, non-keyring vault has no K_v to share — see MULTI_MACHINE_KEYING.md).");
+
+        var vaultKey = ctx.Unlock(config);
+        var keyring = KeyringCodec.Decode(Convert.FromBase64String(config.Keyring));
+
+        var (ephemeralPublicKey, wrapped) = RecoverySlotWrap.Wrap(
+            vaultKey, requesterPublicKey, keyring.FormatVersion, keyring.VaultId, keyring.K, newSlotId);
+
+        var approveFile = new SlotApproveFile(
+            SlotApproveFile.CurrentFormatVersion,
+            keyring.FormatVersion,
+            Convert.ToBase64String(keyring.VaultId),
+            keyring.K,
+            keyring.Slots.Select(s => new SlotDto(
+                Convert.ToBase64String(s.SlotId),
+                Convert.ToBase64String(s.PublicKey),
+                Convert.ToBase64String(s.Wrapped),
+                s.Kind)).ToList(),
+            request.SlotId,
+            request.PublicKey,
+            Convert.ToBase64String(ephemeralPublicKey),
+            Convert.ToBase64String(wrapped));
+
+        File.WriteAllText(approvePath, SlotEnrollmentFileCodec.SerializeApprove(approveFile));
+
+        c.Out.WriteLine($"✓ Approved. Approve file written to: {approvePath}");
+        c.Out.WriteLine("Carry this file back to the requesting machine yourself (scp/USB/paste) —");
+        c.Out.WriteLine("do not drop it in a sync folder — then run 'slot accept' there.");
+        return 0;
+    }
+
+    // --- slot accept (runs back on the new machine) ---
+
+    /// <summary>
+    /// Recovers <c>K_v</c> from the approve file (via <see cref="RecoverySlotWrap.Unwrap"/>,
+    /// mirroring <see cref="ExecuteApprove"/>'s wrap), then builds this machine's own real
+    /// <see cref="SlotKind.Machine"/> slot exactly the way <c>InitCommand.BuildKeyringConfig</c>
+    /// does for a fresh vault (via <see cref="MachineSlotWrap"/>) — this is functionally "the
+    /// enrollment half of <c>init --keyring</c>," not a new primitive. The finalized
+    /// <see cref="Keyring"/> is the approve file's <see cref="SlotApproveFile.ExistingSlots"/>
+    /// plus this new slot (design decision #3), and <see cref="Config.PendingSlotId"/>/
+    /// <see cref="Config.PendingSlotPublicKey"/>/<see cref="Config.PendingSlotPrivateKey"/> are
+    /// cleared now that they're baked into the real keyring.
+    /// </summary>
+    private static int ExecuteAccept(CommandContext ctx, string[] args)
+    {
+        if (args.Length != 1)
+            throw new UsageException($"{ctx.Prefix} slot accept <file>");
+        var path = args[0];
+        var c = ctx.Console;
+
+        if (!File.Exists(path))
+            throw new TswapException($"Slot approve file not found: {path}");
+
+        var config = ctx.Storage.LoadConfig();
+        if (config.PendingSlotId == null || config.PendingSlotPublicKey == null || config.PendingSlotPrivateKey == null)
+            throw new TswapException("No pending 'slot request' found on this machine. Run 'tswap slot request <file>' first.");
+
+        var approve = SlotEnrollmentFileCodec.DeserializeApprove(File.ReadAllText(path));
+
+        var pendingSlotId = Convert.FromBase64String(config.PendingSlotId);
+        var pendingPublicKey = Convert.FromBase64String(config.PendingSlotPublicKey);
+        var pendingPrivateKey = Convert.FromBase64String(config.PendingSlotPrivateKey);
+
+        var approveSlotId = SlotEnrollmentFileCodec.DecodeFixed(approve.NewSlotId, KeyringFormat.SlotIdSize, "approve file's slot id");
+        if (!approveSlotId.AsSpan().SequenceEqual(pendingSlotId))
+            throw new TswapException(
+                "This approve file targets a different slot id than this machine's pending request. " +
+                "Make sure you're pairing the right approve file with this machine's own 'slot request' output.");
+
+        var approvePublicKey = SlotEnrollmentFileCodec.DecodeFixed(approve.NewSlotPublicKey, SlotKeyPair.KeySize, "approve file's public key");
+        if (!approvePublicKey.AsSpan().SequenceEqual(pendingPublicKey))
+            throw new TswapException(
+                "This approve file's echoed public key does not match this machine's pending request. " +
+                "Make sure you're pairing the right approve file with this machine's own 'slot request' output.");
+
+        var vaultId = SlotEnrollmentFileCodec.DecodeFixed(approve.VaultId, KeyringFormat.VaultIdSize, "approve file's vault id");
+        var ephemeralPublicKey = SlotEnrollmentFileCodec.DecodeFixed(approve.NewSlotEphemeralPublicKey, SlotKeyPair.KeySize, "approve file's ephemeral public key");
+        var wrapped = SlotEnrollmentFileCodec.DecodeVariable(approve.NewSlotWrapped, "approve file's wrapped slot payload");
+
+        var vaultKey = RecoverySlotWrap.Unwrap(
+            wrapped, ephemeralPublicKey, pendingPrivateKey,
+            approve.KeyringFormatVersion, vaultId, approve.K, approveSlotId);
+
+        // Recompute this machine's own KEK_slot from the hardware fields 'slot request' already
+        // saved — UnlockHardwareOnly bypasses VaultUnlocker's pending-enrollment guard, which
+        // would otherwise refuse this exact still-pending config.
+        var kekSlot = ctx.UnlockHardwareOnly(config);
+
+        var machineSlot = MachineSlotWrap.Wrap(
+            vaultKey, pendingPrivateKey, pendingPublicKey, pendingSlotId, kekSlot,
+            approve.KeyringFormatVersion, vaultId, approve.K);
+
+        var existingSlots = approve.ExistingSlots.Select(dto => new Slot(
+            SlotEnrollmentFileCodec.DecodeFixed(dto.SlotId, KeyringFormat.SlotIdSize, "approve file's existing slot id"),
+            SlotEnrollmentFileCodec.DecodeFixed(dto.PublicKey, SlotKeyPair.KeySize, "approve file's existing slot public key"),
+            SlotEnrollmentFileCodec.DecodeVariable(dto.Wrapped, "approve file's existing slot wrapped bytes"),
+            dto.Kind)).ToList();
+
+        var finalKeyring = new TswapCore.Keyring.Keyring(
+            approve.KeyringFormatVersion, vaultId, approve.K,
+            existingSlots.Append(machineSlot).ToList());
+
+        var finalConfig = config with
+        {
+            Keyring = Convert.ToBase64String(KeyringCodec.Encode(finalKeyring)),
+            // Records which of finalKeyring's (now possibly several Machine-kind) slots is this
+            // machine's own — see Config.KeyringSlotId's doc comment on why this stopped being
+            // optional once a keyring can hold more than one machine's slot.
+            KeyringSlotId = Convert.ToBase64String(pendingSlotId),
+            PendingSlotId = null,
+            PendingSlotPublicKey = null,
+            PendingSlotPrivateKey = null,
+        };
+
+        ctx.Storage.SaveConfig(finalConfig);
+
+        var fileStore = ctx.Storage as IFileVaultStore;
+        if (fileStore == null || !File.Exists(fileStore.SecretsFile))
+            ctx.Storage.SaveSecrets(new SecretsDb(new Dictionary<string, Secret>()), vaultKey);
+
+        c.Out.WriteLine("\n✓ Slot accepted — this machine is now enrolled in the vault's keyring.");
+        c.Out.WriteLine($"Slots in this machine's local keyring copy: {finalKeyring.Slots.Count}");
+        return 0;
+    }
+
+    /// <summary>
+    /// Prints the fingerprint (issue #122, <see cref="SlotFingerprint"/>) of a public key shown
+    /// during enrollment. Not load-bearing in v0 — see that type's doc comment — so this is
+    /// purely informational, not a gated confirmation prompt.
+    /// </summary>
+    private static void PrintFingerprint(IConsole c, string label, byte[] publicKey)
+    {
+        c.Out.WriteLine($"{label} fingerprint: {SlotFingerprint.Compute(publicKey)}");
+        c.Out.WriteLine("(Not load-bearing in v0 — hand-carrying this file yourself is the trust");
+        c.Out.WriteLine(" boundary — but worth reading aloud/comparing for extra assurance.)");
+    }
+}

--- a/TswapCore/Keyring/MachineSlotWrap.cs
+++ b/TswapCore/Keyring/MachineSlotWrap.cs
@@ -1,0 +1,37 @@
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// Builds a <see cref="SlotKind.Machine"/> slot: wraps <c>(K_v || slot private key)</c>
+/// (<see cref="SlotSecretPayload"/>) under this device's own hardware-recovered
+/// <c>KEK_slot</c> via <see cref="SlotPayloadWrap"/>.
+///
+/// <para><b>Extracted from <c>InitCommand.BuildKeyringConfig</c> (issue #119) so <c>slot
+/// accept</c> (issue #121) can reuse the exact same construction</b> rather than re-deriving it.
+/// Per this issue's PR body: <c>slot accept</c>'s final step — producing the new machine's own
+/// real <see cref="SlotKind.Machine"/> slot once it has recovered <c>K_v</c> from another
+/// machine's <c>slot approve</c> file — is functionally identical to what <c>init --keyring</c>
+/// already does for a fresh vault's first slot. The only difference is where <c>vaultKey</c> and
+/// the slot's own X25519 keypair come from (freshly random for <c>init</c>; recovered from a
+/// hand-carried file, and generated at <c>slot request</c> time respectively, for <c>slot
+/// accept</c>) — this type doesn't need to know or care which.</para>
+/// </summary>
+public static class MachineSlotWrap
+{
+    /// <summary>
+    /// Encodes <paramref name="vaultKey"/> and <paramref name="slotPrivateKey"/> into a
+    /// <see cref="SlotSecretPayload"/>, wraps it under <paramref name="kekSlot"/> with AAD built
+    /// from <paramref name="formatVersion"/>/<paramref name="vaultId"/>/<paramref name="k"/>/
+    /// <paramref name="slotId"/>, and returns the resulting <see cref="SlotKind.Machine"/>
+    /// <see cref="Slot"/> (whose <see cref="Slot.PublicKey"/> is <paramref name="slotPublicKey"/>,
+    /// the slot's own long-lived X25519 public key — never an ephemeral one, unlike
+    /// <see cref="RecoverySlotWrap"/>'s repurposed <see cref="Slot.PublicKey"/> meaning).
+    /// </summary>
+    public static Slot Wrap(
+        byte[] vaultKey, byte[] slotPrivateKey, byte[] slotPublicKey, byte[] slotId,
+        byte[] kekSlot, byte formatVersion, byte[] vaultId, byte k)
+    {
+        var payload = SlotSecretPayload.Encode(vaultKey, slotPrivateKey);
+        var wrapped = SlotPayloadWrap.Wrap(payload, kekSlot, formatVersion, vaultId, k, slotId);
+        return new Slot(slotId, slotPublicKey, wrapped, SlotKind.Machine);
+    }
+}

--- a/TswapCore/Keyring/SlotEnrollmentFile.cs
+++ b/TswapCore/Keyring/SlotEnrollmentFile.cs
@@ -1,0 +1,194 @@
+using System.Text.Json;
+
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// Wire format for <c>tswap slot request</c>'s output file (issue #121). Hand-carried by the
+/// user (scp/USB/paste) to an already-enrolled machine, which reads it in <c>tswap slot
+/// approve</c>.
+///
+/// <para><b>Encoding: JSON, not fixed-binary — a deliberate departure from
+/// <see cref="KeyringCodec"/>/<see cref="SlotPayloadWrap"/>'s AAD, and worth explaining.</b> Those
+/// formats are fixed-binary because their own bytes directly feed an AEAD's associated data or
+/// are stored indefinitely on disk, where an incidental JSON reordering could silently corrupt
+/// every derived computation with no diagnosable cause (see <see cref="KeyringFormat"/>'s doc
+/// comment). This file is neither: it is a small, transient, one-shot, human-handled artifact
+/// (the user looks at it, moves it, and discards it) that never itself feeds an AAD computation —
+/// its *fields*, once parsed into plain byte arrays, are what feed <see cref="SlotPayloadWrap"/>'s
+/// AAD, identically regardless of whether they arrived via JSON or a bespoke binary layout. JSON
+/// keeps this format easy to inspect, debug, and hand-edit if something goes wrong mid-enrollment,
+/// at zero cost to the actual cryptographic binding. <see cref="SlotEnrollmentFileCodec"/> still
+/// version-checks this format explicitly (see <see cref="CurrentFormatVersion"/>) — the "add a
+/// version-compatibility check for any new persisted wire format" bar applies regardless of
+/// encoding choice.</para>
+///
+/// <para><b>Fields:</b> <see cref="SlotId"/> (base64, <see cref="KeyringFormat.SlotIdSize"/>
+/// bytes) is chosen here, at request time, by the new machine — not by the approving machine —
+/// specifically so it can be persisted locally (see <c>Config.PendingSlotId</c>) and carried
+/// through unchanged into the finalized <see cref="SlotKind.Machine"/> slot that <c>slot
+/// accept</c> eventually writes. <see cref="PublicKey"/> (base64, <see cref="SlotKeyPair.KeySize"/>
+/// bytes) is that same slot's long-lived X25519 public key (<see cref="SlotKeyPair.Generate"/>) —
+/// the private half never leaves the requesting machine in this file.</para>
+/// </summary>
+public sealed record SlotRequestFile(int FormatVersion, string SlotId, string PublicKey)
+{
+    /// <summary>Current format version this build writes and requires on read.</summary>
+    public const int CurrentFormatVersion = 1;
+}
+
+/// <summary>
+/// One existing keyring slot, verbatim, as carried inside a <see cref="SlotApproveFile"/> (design
+/// decision: the approve file propagates the *entire* current slot list, not just the new slot's
+/// material — see this issue's PR body). Every field here is the base64/raw form of the
+/// corresponding <see cref="Slot"/> field; <see cref="SlotEnrollmentFileCodec"/> round-trips
+/// these back into real <see cref="Slot"/> instances at <c>slot accept</c> time.
+/// </summary>
+public sealed record SlotDto(string SlotId, string PublicKey, string Wrapped, SlotKind Kind);
+
+/// <summary>
+/// Wire format for <c>tswap slot approve</c>'s output file (issue #121). Hand-carried back to the
+/// requesting machine, which reads it in <c>tswap slot accept</c>.
+///
+/// <para>Carries everything <see cref="SlotPayloadWrap.BuildAad"/> needs to be reconstructed
+/// identically on the accepting machine (<see cref="KeyringFormatVersion"/>,
+/// <see cref="VaultId"/>, <see cref="K"/>, <see cref="NewSlotId"/> — the last echoed straight from
+/// the <see cref="SlotRequestFile"/> this approve file answers), plus:</para>
+/// <list type="bullet">
+/// <item><see cref="ExistingSlots"/> — the approving machine's <em>entire</em> current slot list
+/// (design decision, this issue's PR body §3: keeps every machine's local keyring a reasonably
+/// accurate, if manually-propagated, picture of the fleet — "no merge engine, no revocation/sync
+/// in v0" is an accepted limitation, not a data-loss risk, since nothing here is ever destructive
+/// to the approving machine's own copy).</item>
+/// <item><see cref="NewSlotPublicKey"/> — the requester's long-term public key, echoed back so
+/// <c>slot accept</c> can cross-check it against what this machine itself generated at <c>slot
+/// request</c> time (<c>Config.PendingSlotPublicKey</c>), catching a mismatched/wrong-pair file
+/// before any cryptography is attempted.</item>
+/// <item><see cref="NewSlotEphemeralPublicKey"/>/<see cref="NewSlotWrapped"/> — the output of
+/// <see cref="RecoverySlotWrap.Wrap"/>, called with the requester's long-term public key as the
+/// "recovery" recipient. This is the same ephemeral-ECDH-then-AEAD construction issue #120 already
+/// built and tests, reused wholesale rather than re-implemented (see this issue's PR body for why
+/// a second, near-identical construction would not be justified here).</item>
+/// </list>
+/// </summary>
+public sealed record SlotApproveFile(
+    int FormatVersion,
+    byte KeyringFormatVersion,
+    string VaultId,
+    byte K,
+    List<SlotDto> ExistingSlots,
+    string NewSlotId,
+    string NewSlotPublicKey,
+    string NewSlotEphemeralPublicKey,
+    string NewSlotWrapped)
+{
+    /// <summary>Current format version this build writes and requires on read.</summary>
+    public const int CurrentFormatVersion = 1;
+}
+
+/// <summary>
+/// Serializes/deserializes <see cref="SlotRequestFile"/>/<see cref="SlotApproveFile"/> to/from
+/// JSON, with explicit version checks on both this small format's own version and (for the
+/// approve file) the embedded <see cref="KeyringFormat.KeyringFormatVersion"/> — see
+/// <see cref="SlotRequestFile"/>'s doc comment for why JSON was chosen over fixed-binary here, and
+/// <c>MULTI_MACHINE_KEYING.md</c>'s implementation notes on this module's history of
+/// version-check gaps (never skip this check for a new persisted format).
+/// </summary>
+public static class SlotEnrollmentFileCodec
+{
+    public static string SerializeRequest(SlotRequestFile file) =>
+        JsonSerializer.Serialize(file, TswapJsonContext.Default.SlotRequestFile);
+
+    /// <summary>
+    /// Parses a <see cref="SlotRequestFile"/> previously produced by
+    /// <see cref="SerializeRequest"/>. Throws <see cref="TswapException"/> — never a raw
+    /// exception — for invalid JSON, a null/empty result, or an unsupported
+    /// <see cref="SlotRequestFile.FormatVersion"/>.
+    /// </summary>
+    public static SlotRequestFile DeserializeRequest(string json)
+    {
+        SlotRequestFile? file;
+        try
+        {
+            file = JsonSerializer.Deserialize(json, TswapJsonContext.Default.SlotRequestFile);
+        }
+        catch (JsonException ex)
+        {
+            throw new TswapException($"Slot request file is not valid JSON: {ex.Message}");
+        }
+
+        if (file == null)
+            throw new TswapException("Slot request file is empty or invalid.");
+        if (file.FormatVersion != SlotRequestFile.CurrentFormatVersion)
+            throw new TswapException(
+                $"Unsupported slot request file format version {file.FormatVersion} " +
+                $"(this build supports {SlotRequestFile.CurrentFormatVersion}). Use a matching tswap version on both machines.");
+
+        return file;
+    }
+
+    public static string SerializeApprove(SlotApproveFile file) =>
+        JsonSerializer.Serialize(file, TswapJsonContext.Default.SlotApproveFile);
+
+    /// <summary>
+    /// Parses a <see cref="SlotApproveFile"/> previously produced by
+    /// <see cref="SerializeApprove"/>. Throws <see cref="TswapException"/> — never a raw
+    /// exception — for invalid JSON, a null/empty result, an unsupported
+    /// <see cref="SlotApproveFile.FormatVersion"/>, or an unsupported embedded
+    /// <see cref="SlotApproveFile.KeyringFormatVersion"/> (this build's <c>slot accept</c> would
+    /// otherwise silently reconstruct the wrong AAD and fail the AEAD unwrap with a confusing
+    /// "authentication failed" message instead of a clear version error).
+    /// </summary>
+    public static SlotApproveFile DeserializeApprove(string json)
+    {
+        SlotApproveFile? file;
+        try
+        {
+            file = JsonSerializer.Deserialize(json, TswapJsonContext.Default.SlotApproveFile);
+        }
+        catch (JsonException ex)
+        {
+            throw new TswapException($"Slot approve file is not valid JSON: {ex.Message}");
+        }
+
+        if (file == null)
+            throw new TswapException("Slot approve file is empty or invalid.");
+        if (file.FormatVersion != SlotApproveFile.CurrentFormatVersion)
+            throw new TswapException(
+                $"Unsupported slot approve file format version {file.FormatVersion} " +
+                $"(this build supports {SlotApproveFile.CurrentFormatVersion}). Use a matching tswap version on both machines.");
+        if (file.KeyringFormatVersion != KeyringFormat.KeyringFormatVersion)
+            throw new TswapException(
+                $"Unsupported keyring format version {file.KeyringFormatVersion} in approve file " +
+                $"(this build supports {KeyringFormat.KeyringFormatVersion}).");
+
+        return file;
+    }
+
+    /// <summary>
+    /// Decodes a base64 field to exactly <paramref name="expectedLength"/> bytes. Throws
+    /// <see cref="TswapException"/> — never a raw <see cref="FormatException"/> or silent
+    /// truncation — for invalid base64 or a wrong-length result, naming
+    /// <paramref name="what"/> in the error so a corrupted enrollment file points at the actual
+    /// offending field rather than a generic decode failure.
+    /// </summary>
+    public static byte[] DecodeFixed(string base64, int expectedLength, string what)
+    {
+        var bytes = DecodeVariable(base64, what);
+        if (bytes.Length != expectedLength)
+            throw new TswapException($"Malformed enrollment file: {what} must be {expectedLength} bytes, got {bytes.Length}.");
+        return bytes;
+    }
+
+    /// <summary>Decodes a base64 field of any length. Throws <see cref="TswapException"/> for invalid base64.</summary>
+    public static byte[] DecodeVariable(string base64, string what)
+    {
+        try
+        {
+            return Convert.FromBase64String(base64);
+        }
+        catch (FormatException)
+        {
+            throw new TswapException($"Malformed enrollment file: {what} is not valid base64.");
+        }
+    }
+}

--- a/TswapCore/Keyring/SlotFingerprint.cs
+++ b/TswapCore/Keyring/SlotFingerprint.cs
@@ -1,0 +1,37 @@
+using System.Security.Cryptography;
+
+namespace TswapCore.Keyring;
+
+/// <summary>
+/// A short, human-comparable fingerprint of an X25519 public key (issue #122), displayed on both
+/// machines during hand-carried enrollment: <c>slot request</c> shows a fingerprint of its own
+/// freshly-generated public key, <c>slot approve</c> shows one of the public key it just read
+/// from the request file. A user who wants extra assurance can read both aloud and compare.
+///
+/// <para><b>Not load-bearing in v0.</b> The hand-carried file exchange itself is the trust
+/// boundary (see <c>MULTI_MACHINE_KEYING.md</c> §Hand-carried enrollment) — there is no network
+/// path for a MITM to substitute a different public key on, so this fingerprint is defense in
+/// depth, not a required verification step. It is, however, the seam v1's transport-borne
+/// enrollment builds on, where substitution again becomes possible and this fingerprint becomes
+/// the *primary* defense — hence adding it now, cheaply, while this file format is being
+/// designed, rather than retrofitting it later (see <c>MULTI_MACHINE_KEYING.md</c> §Deferred to
+/// v1).</para>
+///
+/// <para><b>Construction:</b> SHA-256 the public key, keep the first <see cref="DisplayBytes"/>
+/// bytes (64 bits — small enough to read aloud, large enough that an accidental or malicious
+/// substitution is essentially certain to change it), render as hyphen-separated 4-hex-digit
+/// groups — the same spirit as an SSH host key fingerprint, just shorter since this isn't (yet)
+/// a security boundary.</para>
+/// </summary>
+public static class SlotFingerprint
+{
+    private const int DisplayBytes = 8;
+
+    /// <summary>Computes the fingerprint, e.g. <c>"A1B2-C3D4-E5F6-0718"</c>.</summary>
+    public static string Compute(byte[] publicKey)
+    {
+        var hash = SHA256.HashData(publicKey);
+        var hex = Convert.ToHexString(hash, 0, DisplayBytes);
+        return string.Join('-', Enumerable.Range(0, hex.Length / 4).Select(i => hex.Substring(i * 4, 4)));
+    }
+}

--- a/TswapCore/Models.cs
+++ b/TswapCore/Models.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using TswapCore.Keyring;
 
 namespace TswapCore;
 
@@ -88,7 +89,39 @@ public record Config(List<int> YubiKeySerials, string RedundancyXor, DateTime Cr
     // unwrap K_v from the keyring, rather than use it as the master key directly (see
     // VaultUnlocker.Unlock). Null (omitted from config.json) for every vault that predates this
     // field or never opts in — those are completely unaffected.
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Keyring = null);
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Keyring = null,
+    // Phase 6 hand-carried enrollment only (issue #121, 'tswap slot request'/'slot accept'): set
+    // on the NEW, not-yet-enrolled machine between 'slot request' (which enrolls this machine's
+    // own hardware immediately — same YubiKey challenge/XOR/salt dance as 'init --keyring' — but
+    // has no K_v yet to build a real Keyring above from) and 'slot accept' (which recovers K_v
+    // from another machine's 'slot approve' file and finalizes Keyring, clearing these three
+    // fields back to null). PendingSlotId/PendingSlotPublicKey are this slot's identity, chosen
+    // at request time and carried unchanged into the finalized Machine slot 'slot accept'
+    // eventually writes (see MachineSlotWrap). PendingSlotPrivateKey is that slot's own X25519
+    // private key, held here in the clear until accept hardware-wraps it into the real keyring —
+    // the same plaintext-in-local-config custody model this file already uses for the XOR share
+    // above. VaultUnlocker.Unlock refuses ordinary use of a vault with Keyring == null and
+    // PendingSlotId != null (see that type's pending-enrollment guard), so an incomplete
+    // enrollment can never be silently mistaken for a working, derived-key vault. All three are
+    // omitted from config.json when null — every vault that predates this flow, or completes it,
+    // or never uses it, is completely unaffected.
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? PendingSlotId = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? PendingSlotPublicKey = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? PendingSlotPrivateKey = null,
+    // Issue #121: base64 of this machine's own slot id within Config.Keyring. #119/#120 never
+    // needed this — a keyring held at most one Machine-kind slot (plus an optional Recovery
+    // slot), so VaultUnlocker.UnlockKeyring could safely assume "the first Machine-kind slot" was
+    // this machine's own. Once 'slot accept' can append a second machine's Machine-kind slot to
+    // the same keyring, that assumption breaks: an accepting machine's local keyring copy holds
+    // *both* machines' slots, and "first Machine slot" would silently pick whichever one happens
+    // to sort first, unwrapping with the wrong slot's AAD and failing (or, worse in a
+    // differently-shaped future format, succeeding against the wrong slot). Every keyring vault
+    // created from here on (init --keyring's single slot, or slot accept's finalized slot) sets
+    // this to its own slot id; VaultUnlocker looks it up by id when present and falls back to the
+    // old "first Machine slot" heuristic only when null — i.e. only for a keyring predating this
+    // field, which is guaranteed single-machine-slot anyway, so the fallback is exact, not a
+    // guess. Omitted from config.json when null.
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? KeyringSlotId = null);
 public record Secret(string Value, DateTime Created, DateTime Modified, DateTime? BurnedAt = null, string? BurnReason = null);
 public record SecretsDb(Dictionary<string, Secret> Secrets);
 
@@ -151,6 +184,9 @@ public record ExportFile(string Version, DateTime Created, string Salt, string C
 [JsonSerializable(typeof(SecretsDb))]
 [JsonSerializable(typeof(ExportFile))]
 [JsonSerializable(typeof(KdfParams))]
+[JsonSerializable(typeof(SlotRequestFile))]
+[JsonSerializable(typeof(SlotApproveFile))]
+[JsonSerializable(typeof(SlotDto))]
 [JsonSourceGenerationOptions(WriteIndented = true)]
 public partial class TswapJsonContext : JsonSerializerContext { }
 

--- a/TswapCore/Vault/VaultUnlocker.cs
+++ b/TswapCore/Vault/VaultUnlocker.cs
@@ -63,13 +63,21 @@ public sealed class VaultUnlocker
     /// </param>
     public byte[] Unlock(Config config, Func<IReadOnlyList<int>, int> chooseSerial)
     {
-        var backend = config.Backend ?? HardwareBackend.YubiKey;
-        if (!_backends.TryGetValue(backend, out var service))
+        // Issue #121 pending-enrollment guard: a machine that has run 'slot request' but not yet
+        // 'slot accept' has real, working hardware fields (YubiKeySerials/RedundancyXor/etc.) but
+        // no finalized Keyring — its hardware-recovered bytes are a KEK_slot with nothing real to
+        // unwrap yet, not a usable vault key. Without this check that KEK_slot would silently be
+        // treated as the vault master key directly (the same code path a legacy non-keyring vault
+        // uses), letting a command write secrets under a key that 'slot accept' is about to make
+        // permanently unrecoverable once it recovers the *real* K_v from another machine's
+        // approve file and overwrites Config.Keyring. See Config.PendingSlotId's doc comment.
+        if (config.Keyring == null && config.PendingSlotId != null)
             throw new TswapException(
-                $"This vault uses the '{backend.DisplayName()}' hardware backend, which this build of tswap does not support. " +
-                "Use a build that includes it, or restore a vault created with a supported backend.");
+                "This machine has a pending 'slot request' enrollment that has not been completed yet. " +
+                "Run 'tswap slot accept <approve-file>' (using the approve file from an already-enrolled " +
+                "machine) before using this vault.");
 
-        var recovered = service.Unlock(config, chooseSerial);
+        var recovered = UnlockHardware(config, chooseSerial);
 
         // A keyring vault (issue #119, 'tswap init --keyring'): `recovered` is this machine's
         // slot key-encryption key (KEK_slot), not the vault master key directly — unwrap K_v
@@ -78,6 +86,26 @@ public sealed class VaultUnlocker
         // same extra unwrap step (see MULTI_MACHINE_KEYING.md §Two-layer slot wrap), so a future
         // second backend (v0 step 2) needs no change here at all.
         return config.Keyring == null ? recovered : UnlockKeyring(config, recovered);
+    }
+
+    /// <summary>
+    /// Recovers this machine's hardware-backed key material — <c>KEK_slot</c> for a keyring
+    /// vault, or the vault master key directly for a classic non-keyring vault — without
+    /// attempting any keyring unwrap and without the pending-enrollment guard <see cref="Unlock"/>
+    /// applies. Exposed publicly for <c>slot accept</c> (issue #121), which needs to recompute its
+    /// own <c>KEK_slot</c> from a still-pending config (<see cref="Config.Keyring"/> is still null
+    /// at that point by design — see <see cref="Config.PendingSlotId"/>) precisely in the
+    /// situation <see cref="Unlock"/> refuses to proceed for every other caller.
+    /// </summary>
+    public byte[] UnlockHardware(Config config, Func<IReadOnlyList<int>, int> chooseSerial)
+    {
+        var backend = config.Backend ?? HardwareBackend.YubiKey;
+        if (!_backends.TryGetValue(backend, out var service))
+            throw new TswapException(
+                $"This vault uses the '{backend.DisplayName()}' hardware backend, which this build of tswap does not support. " +
+                "Use a build that includes it, or restore a vault created with a supported backend.");
+
+        return service.Unlock(config, chooseSerial);
     }
 
     /// <summary>
@@ -91,14 +119,22 @@ public sealed class VaultUnlocker
     ///
     /// <para><b>Issue #120:</b> a keyring can now hold more than one slot kind (a
     /// <see cref="SlotKind.Recovery"/> slot alongside the machine slot), so this method looks up
-    /// the <see cref="SlotKind.Machine"/> slot explicitly rather than assuming the keyring's
+    /// a <see cref="SlotKind.Machine"/> slot explicitly rather than assuming the keyring's
     /// first entry is always this machine's, the way #119's single-slot-only version did.</para>
+    ///
+    /// <para><b>Issue #121:</b> a keyring can now hold <em>more than one</em>
+    /// <see cref="SlotKind.Machine"/> slot (a second machine's, appended via <c>slot accept</c>),
+    /// so "the first Machine slot" is no longer necessarily this device's own. When
+    /// <see cref="Config.KeyringSlotId"/> is set, this method looks up that exact slot by id;
+    /// only when it is null (a keyring predating this field, which is guaranteed to hold at most
+    /// one Machine slot) does it fall back to #120's original "first Machine slot" heuristic —
+    /// exact in that case, not a guess, since there is only ever one candidate.</para>
     ///
     /// <para>Throws <see cref="TswapException"/> — never a raw crash — for a non-base64
     /// <see cref="Config.Keyring"/>, a malformed keyring blob (<see cref="KeyringCodec.Decode"/>),
-    /// an empty slot list, a keyring with no machine slot, or a slot that fails to unwrap
-    /// (<see cref="SlotPayloadWrap.Unwrap"/>: wrong KEK_slot, tampered ciphertext, or a tampered
-    /// AAD-bound field).</para>
+    /// an empty slot list, a keyring with no matching machine slot, or a slot that fails to
+    /// unwrap (<see cref="SlotPayloadWrap.Unwrap"/>: wrong KEK_slot, tampered ciphertext, or a
+    /// tampered AAD-bound field).</para>
     /// </summary>
     private static byte[] UnlockKeyring(Config config, byte[] kekSlot)
     {
@@ -119,9 +155,30 @@ public sealed class VaultUnlocker
             throw new TswapException(
                 "Config is corrupted: keyring has no slots. Restore config.json from backup or re-run 'tswap init --keyring'.");
 
-        var slot = keyring.Slots.FirstOrDefault(s => s.Kind == SlotKind.Machine)
-            ?? throw new TswapException(
-                "Config is corrupted: keyring has no machine slot. Restore config.json from backup or re-run 'tswap init --keyring'.");
+        Slot? slot;
+        if (config.KeyringSlotId != null)
+        {
+            byte[] ownSlotId;
+            try
+            {
+                ownSlotId = Convert.FromBase64String(config.KeyringSlotId);
+            }
+            catch (FormatException)
+            {
+                throw new TswapException(
+                    "Config is corrupted: KeyringSlotId is not valid base64. Restore config.json from backup or re-run 'tswap init --keyring'.");
+            }
+            slot = keyring.Slots.FirstOrDefault(s => s.Kind == SlotKind.Machine && s.SlotId.AsSpan().SequenceEqual(ownSlotId));
+        }
+        else
+        {
+            slot = keyring.Slots.FirstOrDefault(s => s.Kind == SlotKind.Machine);
+        }
+
+        if (slot == null)
+            throw new TswapException(
+                "Config is corrupted: keyring has no machine slot matching this machine. Restore config.json from backup or re-run 'tswap init --keyring'.");
+
         var payload = SlotPayloadWrap.Unwrap(slot.Wrapped, kekSlot, keyring.FormatVersion, keyring.VaultId, keyring.K, slot.SlotId);
         var (vaultKey, _slotPrivateKey) = SlotSecretPayload.Decode(payload);
         return vaultKey;

--- a/TswapTests/SlotCommandTests.cs
+++ b/TswapTests/SlotCommandTests.cs
@@ -351,4 +351,83 @@ public class SlotCommandTests : IDisposable
         Assert.Equal(1, exit);
         Assert.Contains("Usage:", stderr);
     }
+
+    // --- Sudo enforcement (security fix: 'slot approve' must require sudo) ---
+    //
+    // Every 'Run(...)' helper above hardcodes SudoBypass: true (like the rest of this codebase's
+    // command tests), so it cannot exercise real sudo enforcement. These two tests build a
+    // CommandContext directly with SudoBypass: false instead — there is no existing precedent for
+    // that in this codebase, so this is deliberately minimal and mirrors RequireSudo's own shape.
+    //
+    // This asserts against the *real* CommandContext.RequireSudo, which falls through to
+    // Environment.IsPrivilegedProcess — there is no test seam around that BCL property, so these
+    // tests only exercise genuine enforcement when the test process itself is unprivileged (true
+    // for this repo's CI, which runs on ordinary GitHub-hosted runners, not root containers, and
+    // for an ordinary developer/agent shell). If a test runner is ever itself privileged, both
+    // tests self-skip rather than pass or fail meaninglessly.
+
+    private static (int exitCode, string stdout, string stderr) RunWithoutSudoBypass(
+        string dir, byte[] testKey, string stdin, params string[] args)
+    {
+        var console = new FakeConsole(stdin);
+        var env = new CliEnvironment { Prefix = "tswap", ConfigDir = dir, Verbose = false, CommandArgs = args };
+        var storage = new Storage(dir);
+        var yubiKeys = new TestKeyYubiKeyService(testKey);
+        var unlocker = new VaultUnlocker(yubiKeys, overrideKey: testKey);
+        var ctx = new CommandContext(console, env, storage, yubiKeys, unlocker, testKey, SudoBypass: false);
+
+        var exit = CliRunner.Run(ctx, args);
+        return (exit, console.OutText, console.ErrorText);
+    }
+
+    [Fact]
+    public void Approve_WithoutSudo_FailsBeforeEvenReadingTheRequestFile()
+    {
+        if (Environment.IsPrivilegedProcess)
+            return; // see file header note: only meaningful when this process is unprivileged.
+
+        var dirA = NewTempDir();
+        Run(dirA, _keyA, "", "init", "--keyring"); // a real, existing vault to (not) unlock
+
+        // Deliberately a request file that doesn't exist: if RequireSudo ran *after* the
+        // file-existence check (or not at all, as in the pre-fix bug), this would instead fail
+        // with "Slot request file not found" — proving the sudo check fires first, not just
+        // eventually, is the whole point of this test.
+        var missingRequestFile = Path.Combine(dirA, "does-not-exist-request.json");
+        var apprFile = Path.Combine(dirA, "approve.json");
+
+        var (exit, _, stderr) = RunWithoutSudoBypass(dirA, _keyA, "", "slot", "approve", missingRequestFile, apprFile);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("slot approve", stderr);
+        Assert.Contains("requires", stderr);
+        Assert.DoesNotContain("not found", stderr);
+        Assert.False(File.Exists(apprFile));
+    }
+
+    [Fact]
+    public void Approve_WithoutSudo_ProducesNoVaultDecryptingArtifactEvenForALegitimateRequest()
+    {
+        if (Environment.IsPrivilegedProcess)
+            return; // see file header note: only meaningful when this process is unprivileged.
+
+        // This is the actual vulnerability from the security review, reproduced directly: given a
+        // perfectly well-formed request file and an already-enrolled vault, an unprivileged
+        // process must not be able to walk away with a vault-decrypting approve file. Before the
+        // fix, this entire round trip succeeded with exit 0 and wrote apprFile.
+        var dirA = NewTempDir();
+        var dirB = NewTempDir();
+
+        Run(dirA, _keyA, "", "init", "--keyring");
+        var reqFile = Path.Combine(dirB, "request.json");
+        Run(dirB, _keyB, "", "slot", "request", reqFile); // fine: request never touches an existing vault
+
+        var apprFile = Path.Combine(dirA, "approve.json");
+        var (exit, _, stderr) = RunWithoutSudoBypass(dirA, _keyA, "", "slot", "approve", reqFile, apprFile);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("slot approve", stderr);
+        Assert.Contains("requires", stderr);
+        Assert.False(File.Exists(apprFile));
+    }
 }

--- a/TswapTests/SlotCommandTests.cs
+++ b/TswapTests/SlotCommandTests.cs
@@ -1,0 +1,354 @@
+using System.Text.Json;
+using TswapCli;
+using TswapCore;
+using TswapCore.Keyring;
+using TswapCore.Vault;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// In-process tests for hand-carried multi-machine enrollment (issues #121/#122): 'slot request'
+/// on a fresh, independently-configured "machine B", 'slot approve' on an already-enrolled
+/// "machine A", 'slot accept' back on B. Each machine is its own (temp config dir, TestKeyYubiKeyService)
+/// pair with a *different* test key, so their hardware-recovered KEK_slot values genuinely
+/// differ — the same "two independently-configured IYubiKeyService/config-directory pairs"
+/// simulation this issue's test bar calls for.
+/// </summary>
+public class SlotCommandTests : IDisposable
+{
+    private readonly List<string> _tempDirs = [];
+
+    private readonly byte[] _keyA =
+        Convert.FromHexString("A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1");
+    private readonly byte[] _keyB =
+        Convert.FromHexString("B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2");
+
+    private string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "tswap-slot-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        _tempDirs.Add(dir);
+        return dir;
+    }
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, true);
+    }
+
+    private static (int exitCode, string stdout, string stderr) Run(string dir, byte[] testKey, string stdin, params string[] args)
+    {
+        var console = new FakeConsole(stdin);
+        var env = new CliEnvironment { Prefix = "tswap", ConfigDir = dir, Verbose = false, CommandArgs = args };
+        var storage = new Storage(dir);
+        var yubiKeys = new TestKeyYubiKeyService(testKey);
+        var unlocker = new VaultUnlocker(yubiKeys, overrideKey: testKey);
+        var ctx = new CommandContext(console, env, storage, yubiKeys, unlocker, testKey, SudoBypass: true);
+
+        var exit = CliRunner.Run(ctx, args);
+        return (exit, console.OutText, console.ErrorText);
+    }
+
+    private static byte[] UnlockDirectly(string dir, byte[] testKey)
+    {
+        var storage = new Storage(dir);
+        var yubiKeys = new TestKeyYubiKeyService(testKey);
+        var unlocker = new VaultUnlocker(yubiKeys, overrideKey: testKey);
+        var ctx = new CommandContext(new FakeConsole(""), new CliEnvironment { Prefix = "tswap", ConfigDir = dir, Verbose = false, CommandArgs = [] }, storage, yubiKeys, unlocker, testKey, SudoBypass: true);
+        return ctx.Unlock(storage.LoadConfig());
+    }
+
+    private static Config LoadConfig(string dir) =>
+        JsonSerializer.Deserialize(File.ReadAllText(Path.Combine(dir, "config.json")), TswapJsonContext.Default.Config)!;
+
+    // --- Full round trip ---
+
+    [Fact]
+    public void RoundTrip_NewMachineRecoversIdenticalVaultKey()
+    {
+        var dirA = NewTempDir();
+        var dirB = NewTempDir();
+
+        var (initExit, _, _) = Run(dirA, _keyA, "", "init", "--keyring");
+        Assert.Equal(0, initExit);
+        var vaultKeyA = UnlockDirectly(dirA, _keyA);
+
+        var reqFile = Path.Combine(dirB, "request.json");
+        var (reqExit, _, _) = Run(dirB, _keyB, "", "slot", "request", reqFile);
+        Assert.Equal(0, reqExit);
+        Assert.True(File.Exists(reqFile));
+
+        var apprFile = Path.Combine(dirA, "approve.json");
+        var (apprExit, _, _) = Run(dirA, _keyA, "", "slot", "approve", reqFile, apprFile);
+        Assert.Equal(0, apprExit);
+        Assert.True(File.Exists(apprFile));
+
+        var (accExit, _, _) = Run(dirB, _keyB, "", "slot", "accept", apprFile);
+        Assert.Equal(0, accExit);
+
+        var vaultKeyB = UnlockDirectly(dirB, _keyB);
+        Assert.Equal(vaultKeyA, vaultKeyB);
+    }
+
+    [Fact]
+    public void RoundTrip_NewMachineCanUseVaultAfterAccept()
+    {
+        var dirA = NewTempDir();
+        var dirB = NewTempDir();
+
+        Run(dirA, _keyA, "", "init", "--keyring");
+        var reqFile = Path.Combine(dirB, "request.json");
+        Run(dirB, _keyB, "", "slot", "request", reqFile);
+        var apprFile = Path.Combine(dirA, "approve.json");
+        Run(dirA, _keyA, "", "slot", "approve", reqFile, apprFile);
+        Run(dirB, _keyB, "", "slot", "accept", apprFile);
+
+        var (addExit, _, _) = Run(dirB, _keyB, "hunter2\nhunter2\n", "add", "my-secret");
+        Assert.Equal(0, addExit);
+
+        var (getExit, getStdout, _) = Run(dirB, _keyB, "", "get", "my-secret");
+        Assert.Equal(0, getExit);
+        Assert.Contains("hunter2", getStdout);
+    }
+
+    [Fact]
+    public void RoundTrip_OriginalMachineUnlockUnaffected()
+    {
+        // Enrolling a second machine must not disturb the first machine's own slot/unlock path.
+        var dirA = NewTempDir();
+        var dirB = NewTempDir();
+
+        Run(dirA, _keyA, "", "init", "--keyring");
+        Run(dirA, _keyA, "hunter1\nhunter1\n", "add", "already-here");
+        var vaultKeyBefore = UnlockDirectly(dirA, _keyA);
+
+        var reqFile = Path.Combine(dirB, "request.json");
+        Run(dirB, _keyB, "", "slot", "request", reqFile);
+        var apprFile = Path.Combine(dirA, "approve.json");
+        Run(dirA, _keyA, "", "slot", "approve", reqFile, apprFile);
+        Run(dirB, _keyB, "", "slot", "accept", apprFile);
+
+        var vaultKeyAfter = UnlockDirectly(dirA, _keyA);
+        Assert.Equal(vaultKeyBefore, vaultKeyAfter);
+
+        var (getExit, getStdout, _) = Run(dirA, _keyA, "", "get", "already-here");
+        Assert.Equal(0, getExit);
+        Assert.Contains("hunter1", getStdout);
+    }
+
+    [Fact]
+    public void RoundTrip_ExistingRecoverySlotPropagatedIntoNewMachinesKeyring()
+    {
+        // Design decision #3: the approve file carries the entire current slot list, so the new
+        // machine's local keyring also gets the recovery slot A already had, not just the new
+        // machine slot.
+        var dirA = NewTempDir();
+        var dirB = NewTempDir();
+
+        Run(dirA, _keyA, "", "init", "--keyring"); // default-on recovery slot
+        var reqFile = Path.Combine(dirB, "request.json");
+        Run(dirB, _keyB, "", "slot", "request", reqFile);
+        var apprFile = Path.Combine(dirA, "approve.json");
+        Run(dirA, _keyA, "", "slot", "approve", reqFile, apprFile);
+        Run(dirB, _keyB, "", "slot", "accept", apprFile);
+
+        var keyringB = KeyringCodec.Decode(Convert.FromBase64String(LoadConfig(dirB).Keyring!));
+        Assert.Equal(3, keyringB.Slots.Count); // A's machine slot, A's recovery slot, B's machine slot
+        Assert.Equal(2, keyringB.Slots.Count(s => s.Kind == SlotKind.Machine));
+        Assert.Single(keyringB.Slots, s => s.Kind == SlotKind.Recovery);
+    }
+
+    // --- Fingerprint (#122) ---
+
+    [Fact]
+    public void RequestAndApprove_DisplaySameFingerprintForSamePublicKey()
+    {
+        var dirA = NewTempDir();
+        var dirB = NewTempDir();
+
+        Run(dirA, _keyA, "", "init", "--keyring");
+        var reqFile = Path.Combine(dirB, "request.json");
+        var (_, reqStdout, _) = Run(dirB, _keyB, "", "slot", "request", reqFile);
+
+        var apprFile = Path.Combine(dirA, "approve.json");
+        var (_, apprStdout, _) = Run(dirA, _keyA, "", "slot", "approve", reqFile, apprFile);
+
+        var request = SlotEnrollmentFileCodec.DeserializeRequest(File.ReadAllText(reqFile));
+        var expectedFingerprint = SlotFingerprint.Compute(Convert.FromBase64String(request.PublicKey));
+
+        Assert.Contains(expectedFingerprint, reqStdout);
+        Assert.Contains(expectedFingerprint, apprStdout);
+    }
+
+    // --- Preconditions ---
+
+    [Fact]
+    public void Approve_WithoutKeyringVault_FailsCleanly()
+    {
+        var dirA = NewTempDir();
+        var dirB = NewTempDir();
+
+        Run(dirA, _keyA, "", "init"); // classic, non-keyring vault
+        var reqFile = Path.Combine(dirB, "request.json");
+        Run(dirB, _keyB, "", "slot", "request", reqFile);
+
+        var apprFile = Path.Combine(dirA, "approve.json");
+        var (exit, _, stderr) = Run(dirA, _keyA, "", "slot", "approve", reqFile, apprFile);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("no keyring vault", stderr);
+    }
+
+    [Fact]
+    public void Accept_WithoutPendingRequest_FailsCleanly()
+    {
+        var dirA = NewTempDir();
+        var dirB = NewTempDir();
+
+        Run(dirA, _keyA, "", "init", "--keyring");
+        Run(dirB, _keyB, "", "init"); // B never ran 'slot request'
+
+        var reqFile = Path.Combine(dirA, "unused-request.json"); // never used by B
+        var apprFile = Path.Combine(dirA, "approve.json");
+        File.WriteAllText(apprFile, "{}"); // placeholder; accept should fail before even parsing it meaningfully
+
+        var (exit, _, stderr) = Run(dirB, _keyB, "", "slot", "accept", apprFile);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("No pending 'slot request'", stderr);
+    }
+
+    [Fact]
+    public void Accept_MissingFile_FailsCleanly()
+    {
+        var dirB = NewTempDir();
+        var reqFile = Path.Combine(dirB, "request.json");
+        Run(dirB, _keyB, "", "slot", "request", reqFile);
+
+        var (exit, _, stderr) = Run(dirB, _keyB, "", "slot", "accept", Path.Combine(dirB, "does-not-exist.json"));
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("not found", stderr);
+    }
+
+    [Fact]
+    public void PendingConfig_RefusesOrdinaryUnlockBeforeAccept()
+    {
+        // VaultUnlocker's pending-enrollment guard: a machine that has requested but not yet
+        // accepted must not be usable as if it were an ordinary vault.
+        var dirB = NewTempDir();
+        var reqFile = Path.Combine(dirB, "request.json");
+        Run(dirB, _keyB, "", "slot", "request", reqFile);
+
+        var (exit, _, stderr) = Run(dirB, _keyB, "hunter2\nhunter2\n", "add", "too-early");
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("pending 'slot request'", stderr);
+    }
+
+    // --- Tamper resistance ---
+
+    [Fact]
+    public void Accept_TamperedApproveFileCiphertext_FailsCleanlyWithTswapException()
+    {
+        var dirA = NewTempDir();
+        var dirB = NewTempDir();
+
+        Run(dirA, _keyA, "", "init", "--keyring");
+        var reqFile = Path.Combine(dirB, "request.json");
+        Run(dirB, _keyB, "", "slot", "request", reqFile);
+        var apprFile = Path.Combine(dirA, "approve.json");
+        Run(dirA, _keyA, "", "slot", "approve", reqFile, apprFile);
+
+        var approve = SlotEnrollmentFileCodec.DeserializeApprove(File.ReadAllText(apprFile));
+        var wrapped = Convert.FromBase64String(approve.NewSlotWrapped);
+        wrapped[^1] ^= 0xFF;
+        var tampered = approve with { NewSlotWrapped = Convert.ToBase64String(wrapped) };
+        File.WriteAllText(apprFile, SlotEnrollmentFileCodec.SerializeApprove(tampered));
+
+        var (exit, _, stderr) = Run(dirB, _keyB, "", "slot", "accept", apprFile);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("authentication", stderr);
+    }
+
+    [Fact]
+    public void Accept_ApproveFileForWrongPendingSlot_FailsCleanlyWithTswapException()
+    {
+        // Simulates pairing the wrong approve file (targeting a different slot id than this
+        // machine's own pending request) with 'slot accept' — must fail with a clear error
+        // rather than silently producing an inconsistent, unusable keyring.
+        var dirA = NewTempDir();
+        var dirB = NewTempDir();
+
+        Run(dirA, _keyA, "", "init", "--keyring");
+        var reqFile = Path.Combine(dirB, "request.json");
+        Run(dirB, _keyB, "", "slot", "request", reqFile);
+        var apprFile = Path.Combine(dirA, "approve.json");
+        Run(dirA, _keyA, "", "slot", "approve", reqFile, apprFile);
+
+        var approve = SlotEnrollmentFileCodec.DeserializeApprove(File.ReadAllText(apprFile));
+        var wrongSlotId = Convert.ToBase64String(new byte[TswapCore.Keyring.KeyringFormat.SlotIdSize]);
+        var tampered = approve with { NewSlotId = wrongSlotId };
+        File.WriteAllText(apprFile, SlotEnrollmentFileCodec.SerializeApprove(tampered));
+
+        var (exit, _, stderr) = Run(dirB, _keyB, "", "slot", "accept", apprFile);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("different slot id", stderr);
+    }
+
+    [Fact]
+    public void Accept_CorruptedJsonApproveFile_FailsCleanlyNotACrash()
+    {
+        var dirB = NewTempDir();
+        var reqFile = Path.Combine(dirB, "request.json");
+        Run(dirB, _keyB, "", "slot", "request", reqFile);
+
+        var apprFile = Path.Combine(dirB, "approve.json");
+        File.WriteAllText(apprFile, "{ this is not valid json");
+
+        var (exit, _, stderr) = Run(dirB, _keyB, "", "slot", "accept", apprFile);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("not valid JSON", stderr);
+    }
+
+    [Fact]
+    public void Approve_MissingRequestFile_FailsCleanly()
+    {
+        var dirA = NewTempDir();
+        Run(dirA, _keyA, "", "init", "--keyring");
+
+        var (exit, _, stderr) = Run(dirA, _keyA, "", "slot", "approve",
+            Path.Combine(dirA, "does-not-exist.json"), Path.Combine(dirA, "approve.json"));
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("not found", stderr);
+    }
+
+    // --- CLI dispatch shape ---
+
+    [Fact]
+    public void Slot_NoSubcommand_IsUsageError()
+    {
+        var dir = NewTempDir();
+        var (exit, _, stderr) = Run(dir, _keyA, "", "slot");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Usage:", stderr);
+    }
+
+    [Fact]
+    public void Slot_UnknownSubcommand_IsUsageError()
+    {
+        var dir = NewTempDir();
+        var (exit, _, stderr) = Run(dir, _keyA, "", "slot", "bogus");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Usage:", stderr);
+    }
+}

--- a/TswapTests/SlotEnrollmentFileCodecTests.cs
+++ b/TswapTests/SlotEnrollmentFileCodecTests.cs
@@ -1,0 +1,156 @@
+using System.Security.Cryptography;
+using TswapCore;
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Tests for the request/approve wire format (issue #121): JSON encoding (see
+/// <see cref="SlotRequestFile"/>'s doc comment for why JSON rather than fixed-binary), with
+/// explicit version checks on both this format's own version and the embedded
+/// <see cref="KeyringFormat.KeyringFormatVersion"/> — this module's established bar after two
+/// prior version-check gaps (#146, #148).
+/// </summary>
+public class SlotEnrollmentFileCodecTests
+{
+    [Fact]
+    public void RequestFile_RoundTrips()
+    {
+        var slotId = RandomNumberGenerator.GetBytes(KeyringFormat.SlotIdSize);
+        var publicKey = SlotKeyPair.Generate().PublicKey;
+        var file = new SlotRequestFile(SlotRequestFile.CurrentFormatVersion, Convert.ToBase64String(slotId), Convert.ToBase64String(publicKey));
+
+        var json = SlotEnrollmentFileCodec.SerializeRequest(file);
+        var decoded = SlotEnrollmentFileCodec.DeserializeRequest(json);
+
+        Assert.Equal(file, decoded);
+    }
+
+    [Fact]
+    public void RequestFile_ContainsDocumentedFieldNames()
+    {
+        // Not a byte-pinned golden test (this format is deliberately JSON, not fixed-binary —
+        // see SlotRequestFile's doc comment) but the field names are still a documented contract
+        // a reviewer or future reader should be able to see stay stable.
+        var file = new SlotRequestFile(1, "c2xvdA==", "cHVia2V5");
+        var json = SlotEnrollmentFileCodec.SerializeRequest(file);
+
+        Assert.Contains("\"FormatVersion\"", json);
+        Assert.Contains("\"SlotId\"", json);
+        Assert.Contains("\"PublicKey\"", json);
+    }
+
+    [Fact]
+    public void RequestFile_UnsupportedFormatVersion_ThrowsCleanTswapException()
+    {
+        var json = """{"FormatVersion":999,"SlotId":"AAAA","PublicKey":"AAAA"}""";
+
+        var ex = Assert.Throws<TswapException>(() => SlotEnrollmentFileCodec.DeserializeRequest(json));
+        Assert.Contains("Unsupported slot request file format version", ex.Message);
+    }
+
+    [Fact]
+    public void RequestFile_InvalidJson_ThrowsCleanTswapException()
+    {
+        Assert.Throws<TswapException>(() => SlotEnrollmentFileCodec.DeserializeRequest("not json at all"));
+    }
+
+    [Fact]
+    public void RequestFile_NullJson_ThrowsCleanTswapException()
+    {
+        Assert.Throws<TswapException>(() => SlotEnrollmentFileCodec.DeserializeRequest("null"));
+    }
+
+    private static SlotApproveFile MakeApproveFile() => new(
+        SlotApproveFile.CurrentFormatVersion,
+        KeyringFormat.KeyringFormatVersion,
+        Convert.ToBase64String(RandomNumberGenerator.GetBytes(KeyringFormat.VaultIdSize)),
+        1,
+        new List<SlotDto>
+        {
+            new(Convert.ToBase64String(RandomNumberGenerator.GetBytes(KeyringFormat.SlotIdSize)),
+                Convert.ToBase64String(SlotKeyPair.Generate().PublicKey),
+                Convert.ToBase64String(RandomNumberGenerator.GetBytes(48)),
+                SlotKind.Machine),
+        },
+        Convert.ToBase64String(RandomNumberGenerator.GetBytes(KeyringFormat.SlotIdSize)),
+        Convert.ToBase64String(SlotKeyPair.Generate().PublicKey),
+        Convert.ToBase64String(SlotKeyPair.Generate().PublicKey),
+        Convert.ToBase64String(RandomNumberGenerator.GetBytes(48)));
+
+    [Fact]
+    public void ApproveFile_RoundTrips()
+    {
+        // Compared field-by-field (rather than via record Equals) because ExistingSlots is a
+        // List<SlotDto>, and List<T> has no structural Equals of its own — the record-generated
+        // Equals would compare list references, not contents, and always report "different" for
+        // a freshly-deserialized list even when every element matches.
+        var file = MakeApproveFile();
+
+        var json = SlotEnrollmentFileCodec.SerializeApprove(file);
+        var decoded = SlotEnrollmentFileCodec.DeserializeApprove(json);
+
+        Assert.Equal(file.FormatVersion, decoded.FormatVersion);
+        Assert.Equal(file.KeyringFormatVersion, decoded.KeyringFormatVersion);
+        Assert.Equal(file.VaultId, decoded.VaultId);
+        Assert.Equal(file.K, decoded.K);
+        Assert.Equal(file.ExistingSlots, decoded.ExistingSlots);
+        Assert.Equal(file.NewSlotId, decoded.NewSlotId);
+        Assert.Equal(file.NewSlotPublicKey, decoded.NewSlotPublicKey);
+        Assert.Equal(file.NewSlotEphemeralPublicKey, decoded.NewSlotEphemeralPublicKey);
+        Assert.Equal(file.NewSlotWrapped, decoded.NewSlotWrapped);
+    }
+
+    [Fact]
+    public void ApproveFile_UnsupportedFormatVersion_ThrowsCleanTswapException()
+    {
+        var file = MakeApproveFile() with { FormatVersion = 999 };
+        var json = SlotEnrollmentFileCodec.SerializeApprove(file);
+
+        var ex = Assert.Throws<TswapException>(() => SlotEnrollmentFileCodec.DeserializeApprove(json));
+        Assert.Contains("Unsupported slot approve file format version", ex.Message);
+    }
+
+    [Fact]
+    public void ApproveFile_UnsupportedKeyringFormatVersion_ThrowsCleanTswapException()
+    {
+        // The version-check-gap class this module has hit before (#146, #148): the embedded
+        // keyring format version must be checked explicitly, not just this file's own version.
+        var file = MakeApproveFile() with { KeyringFormatVersion = 255 };
+        var json = SlotEnrollmentFileCodec.SerializeApprove(file);
+
+        var ex = Assert.Throws<TswapException>(() => SlotEnrollmentFileCodec.DeserializeApprove(json));
+        Assert.Contains("Unsupported keyring format version", ex.Message);
+    }
+
+    [Fact]
+    public void ApproveFile_InvalidJson_ThrowsCleanTswapException()
+    {
+        Assert.Throws<TswapException>(() => SlotEnrollmentFileCodec.DeserializeApprove("{ not json"));
+    }
+
+    [Fact]
+    public void DecodeFixed_WrongLength_ThrowsCleanTswapException()
+    {
+        var tooShort = Convert.ToBase64String(new byte[4]);
+
+        var ex = Assert.Throws<TswapException>(() => SlotEnrollmentFileCodec.DecodeFixed(tooShort, 16, "test field"));
+        Assert.Contains("test field", ex.Message);
+        Assert.Contains("16 bytes", ex.Message);
+    }
+
+    [Fact]
+    public void DecodeFixed_InvalidBase64_ThrowsCleanTswapException()
+    {
+        var ex = Assert.Throws<TswapException>(() => SlotEnrollmentFileCodec.DecodeFixed("not-base64!!!", 16, "test field"));
+        Assert.Contains("test field", ex.Message);
+        Assert.Contains("base64", ex.Message);
+    }
+
+    [Fact]
+    public void DecodeVariable_InvalidBase64_ThrowsCleanTswapException()
+    {
+        Assert.Throws<TswapException>(() => SlotEnrollmentFileCodec.DecodeVariable("not-base64!!!", "test field"));
+    }
+}

--- a/TswapTests/SlotFingerprintTests.cs
+++ b/TswapTests/SlotFingerprintTests.cs
@@ -1,0 +1,55 @@
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
+using TswapCore.Keyring;
+using Xunit;
+
+namespace TswapTests;
+
+/// <summary>
+/// Tests for the fingerprint display (issue #122): a short, deterministic, human-comparable
+/// digest of an X25519 public key shown on both machines during hand-carried enrollment.
+/// </summary>
+public class SlotFingerprintTests
+{
+    [Fact]
+    public void Compute_IsDeterministic()
+    {
+        var publicKey = SlotKeyPair.Generate().PublicKey;
+
+        Assert.Equal(SlotFingerprint.Compute(publicKey), SlotFingerprint.Compute(publicKey));
+    }
+
+    [Fact]
+    public void Compute_DifferentKeysProduceDifferentFingerprints()
+    {
+        var key1 = SlotKeyPair.Generate().PublicKey;
+        var key2 = SlotKeyPair.Generate().PublicKey;
+
+        Assert.NotEqual(SlotFingerprint.Compute(key1), SlotFingerprint.Compute(key2));
+    }
+
+    [Fact]
+    public void Compute_MatchesExpectedFormat()
+    {
+        var publicKey = SlotKeyPair.Generate().PublicKey;
+
+        var fingerprint = SlotFingerprint.Compute(publicKey);
+
+        Assert.Matches(new Regex("^[0-9A-F]{4}(-[0-9A-F]{4}){3}$"), fingerprint);
+    }
+
+    [Fact]
+    public void Compute_KnownAnswer_MatchesFirst8BytesOfSha256()
+    {
+        // Pins the exact construction (SHA-256, first 8 bytes, uppercase hex, dash-grouped every
+        // 4 chars) so a future accidental change is caught rather than silently shipped.
+        var publicKey = new byte[32];
+        for (var i = 0; i < 32; i++) publicKey[i] = (byte)i;
+
+        var expectedHash = SHA256.HashData(publicKey);
+        var expectedHex = Convert.ToHexString(expectedHash, 0, 8);
+        var expected = string.Join('-', new[] { expectedHex[..4], expectedHex[4..8], expectedHex[8..12], expectedHex[12..16] });
+
+        Assert.Equal(expected, SlotFingerprint.Compute(publicKey));
+    }
+}


### PR DESCRIPTION
Closes #121, closes #122.

## What this adds

Three subcommands under one `tswap slot` command, enrolling a **second machine** into an
existing `k=1` keyring vault via hand-carried files (scp/USB/paste — no network protocol,
no MITM to defend against):

- `tswap slot request <file>` — run on the new, not-yet-enrolled machine. Enrolls this
  machine's own hardware (same YubiKey challenge/XOR/salt dance as `init --keyring`),
  generates this slot's X25519 keypair, writes a request file, and prints a fingerprint
  of its own public key.
- `tswap slot approve <request-file> <approve-file>` — run on an already-enrolled machine.
  Reads the request, prints a fingerprint of the requester's public key (compare against
  what request printed), unlocks its own vault to recover `K_v`, wraps it to the
  requester's public key, and writes an approve file.
- `tswap slot accept <approve-file>` — run again on the new machine. Recovers `K_v` from
  the approve file, builds this machine's own real `Machine`-kind slot under its own
  hardware `KEK_slot`, and finalizes `Config.Keyring`.

Fingerprint display (#122) is `SlotFingerprint.Compute`: SHA-256 the public key, keep the
first 8 bytes, render as 4 dash-separated hex groups (e.g. `A1B2-C3D4-E5F6-0718`). Shown at
both `slot request` and `slot approve`. Explicitly **not load-bearing in v0** — the
hand-carried file exchange is the trust boundary — but it's the seam v1's transport-borne
enrollment builds on.

## Reuse, not reinvention

- **`slot approve`'s wrap step is `RecoverySlotWrap.Wrap`/`Unwrap`, called directly, unmodified.**
  That type already does "ephemeral X25519 keypair, ECDH against an arbitrary recipient
  public key, HKDF into a KEK, `SlotPayloadWrap.Wrap` the payload" with no assumption the
  recipient is specifically a "recovery" key. No second ECIES-style construction was
  introduced.
- **`slot accept`'s final step (building this machine's own `Machine`-kind slot) reuses
  `InitCommand.BuildKeyringConfig`'s construction**, extracted into a new
  `TswapCore/Keyring/MachineSlotWrap.cs` (`MachineSlotWrap.Wrap`) so both `init --keyring`
  and `slot accept` call the same code instead of two copies. `InitCommand.BuildKeyringConfig`
  was refactored to call it too — behavior is unchanged (covered by the existing
  `BuildKeyringConfig_*` tests, which still pass).

## The five judgement calls

**1. CLI dispatch shape.** One `SlotCommand : ICliCommand` (`Name => "slot"`) with internal
dispatch on `args[0]` (`request`/`approve`/`accept`), mirroring how `InitCommand` already
inspects its own `args` for `--secure-enclave`/`--tpm`/`--keyring`. Not three top-level
commands — no precedent in this codebase for a hyphenated/multi-word top-level command name.

**2. New-machine state between `request` and `accept`.** `slot request` performs the same
hardware enrollment `init --keyring` does and saves a **real, working** `Config`
(`YubiKeySerials`/`RedundancyXor`/`UnlockChallenge`/`MasterKeySalt`) immediately, but with
`Config.Keyring` still `null`. Three new additive `Config` fields hold the pending state:
`PendingSlotId`, `PendingSlotPublicKey` (both echoed into the request file) and
`PendingSlotPrivateKey` (kept in the clear locally — same custody model this file already
uses for the XOR share — until `accept` hardware-wraps it into the real keyring). All three
are cleared back to `null` once `accept` finalizes `Config.Keyring`.

  To stop this pending state from being silently misused as a working vault,
  `VaultUnlocker.Unlock` now refuses to proceed when `Config.Keyring == null &&
  Config.PendingSlotId != null` (a machine mid-enrollment), with a clear error pointing at
  `slot accept`. A new `VaultUnlocker.UnlockHardware`/`CommandContext.UnlockHardwareOnly`
  bypasses that guard so `slot accept` itself can still recompute its own `KEK_slot` from
  the still-pending config. No existing vault (no `PendingSlotId`) is affected.

**3. Approve file carries the full slot list.** `SlotApproveFile.ExistingSlots` is the
approving machine's *entire* current keyring slot list, verbatim, plus the new slot's
material — not just enough to unlock the new slot alone. `slot accept` writes that complete
list (existing slots + its own new slot) as its own local `Config.Keyring`. This keeps every
machine's local copy a reasonably accurate (if manually-propagated — no merge engine, no
revocation/sync in v0) picture of the fleet. `SlotsCommand.cs` (#123) did not exist in this
tree at the time of writing; no attempt was made to build on an assumed shape for it.

**4. `k` stays 1**, unchanged, carried through from the existing keyring into every AAD
computation and the finalized keyring. No `k >= 2` logic touched.

**5. Fingerprint**: SHA-256 truncated to 8 bytes, hex, dash-grouped every 4 chars — short
enough to read aloud, similar in spirit to an SSH host key fingerprint. `SlotFingerprint.cs`,
~30 lines including doc comments, matching the issue's own estimate. Not gated behind an
interactive confirmation prompt — printed for the user's own out-of-band comparison, per
#122's explicit "not load-bearing" framing.

## A sixth thing this surfaced (not one of the five, but necessary)

Multi-machine keyrings expose a latent assumption in `VaultUnlocker.UnlockKeyring`
(#119/#120): it picked "the first `Machine`-kind slot" in the keyring, which only worked
because a keyring never held more than one. Once `slot accept` can append a second
machine's `Machine` slot to the same keyring, an accepting machine's local copy holds
*both* machines' slots, and "first Machine slot" can silently pick the wrong one. Fixed by
adding `Config.KeyringSlotId` (base64 slot id, additive, set by `BuildKeyringConfig` and by
`slot accept`), which `UnlockKeyring` looks up by id when present. When absent (any keyring
predating this field), it falls back to the old "first Machine slot" heuristic — which is
*exact*, not approximate, in that case, since such a keyring is guaranteed to hold at most
one. Existing vaults are unaffected either way. Caught by the round-trip test in
`SlotCommandTests.cs` before it ever shipped.

## Wire format

Both files are small, transient, one-shot, hand-carried artifacts — never stored long-term,
never fed into an AEAD's AAD directly (their *parsed fields* are, identically regardless of
encoding). Per the task's own guidance this doesn't need fixed-binary rigor, so both are
**JSON**, via the existing NativeAOT source-gen `TswapJsonContext`. Both carry an explicit
`FormatVersion` checked on read (`SlotEnrollmentFileCodec`), plus (for the approve file) an
explicit check of the embedded `KeyringFormatVersion` against `KeyringFormat.KeyringFormatVersion`
— this module's two prior version-check gaps (#146, #148) don't get a third repeat here.

**`SlotRequestFile`** (`TswapCore/Keyring/SlotEnrollmentFile.cs`):
```jsonc
{
  "FormatVersion": 1,
  "SlotId":    "<base64, 16 bytes>",  // chosen at request time; carried through to the final Machine slot
  "PublicKey": "<base64, 32 bytes>"   // this slot's long-lived X25519 public key
}
```

**`SlotApproveFile`**:
```jsonc
{
  "FormatVersion": 1,
  "KeyringFormatVersion": 2,          // KeyringFormat.KeyringFormatVersion — feeds every AAD reconstruction
  "VaultId": "<base64, 16 bytes>",
  "K": 1,
  "ExistingSlots": [                  // the approving machine's entire current slot list, verbatim
    { "SlotId": "<base64,16>", "PublicKey": "<base64,32>", "Wrapped": "<base64>", "Kind": 0 }
  ],
  "NewSlotId":                 "<base64, 16 bytes>",  // echoes SlotRequestFile.SlotId
  "NewSlotPublicKey":          "<base64, 32 bytes>",  // echoes SlotRequestFile.PublicKey (cross-checked at accept)
  "NewSlotEphemeralPublicKey": "<base64, 32 bytes>",  // RecoverySlotWrap.Wrap's ephemeral output
  "NewSlotWrapped":            "<base64>"             // RecoverySlotWrap.Wrap's wrapped K_v
}
```
`Kind` is `SlotKind`'s raw numeric value (0 = Machine, 1 = Recovery) — System.Text.Json's
default enum encoding, same as every other JSON-serialized enum in this codebase that
doesn't opt into `JsonStringEnumConverter`.

`slot accept` cross-checks `NewSlotId`/`NewSlotPublicKey` against this machine's own
`Config.PendingSlotId`/`PendingSlotPublicKey` before touching any cryptography, so a
mismatched or wrong-pair approve file fails with a clear, specific error rather than a
generic AEAD authentication failure.

## Tests

- `SlotCommandTests.cs`: full `request -> approve -> accept` round trip across two
  independently-configured `(config dir, TestKeyYubiKeyService)` pairs (simulating two
  separate machines), proving the new machine recovers the identical `K_v`; the original
  machine's own unlock is unaffected; the new machine can `add`/`get` its own secrets after
  accept; the approving machine's existing recovery slot propagates into the new machine's
  local keyring; both sides print the same fingerprint for the same public key; tamper
  tests (corrupted ciphertext, wrong/mismatched slot id, corrupted JSON) all fail cleanly
  with `TswapException`, never a crash; precondition tests (`approve` on a non-keyring
  vault, `accept` with no pending request, `accept` on a missing file, ordinary commands
  refused mid-enrollment).
- `SlotEnrollmentFileCodecTests.cs`: round-trip + version-check tests for both file formats
  (unsupported `FormatVersion`, unsupported embedded `KeyringFormatVersion`, invalid JSON,
  invalid/wrong-length base64 fields).
- `SlotFingerprintTests.cs`: determinism, distinctness, format, and a known-answer test
  pinning the exact construction.
- Existing `BuildKeyringConfig_*`/`InitKeyring_*`/`VaultUnlocker*` tests all still pass
  unchanged, confirming `init`/`init --keyring`/`init --keyring --no-recovery`/recovery
  slots/legacy non-keyring vaults are unaffected.

## Verification

- `./runtests.sh --unit`: 532/532 passed.
- `./runtests.sh --e2e`: 16/16 passed.
- `dotnet publish -c Release TswapCli/TswapCli.csproj`: succeeds (NativeAOT tripwire).
- Sandbox only has .NET SDK 10.0.301; `global.json` (pinned to 10.0.302) was temporarily
  edited to build/test locally and reverted before this commit — no diff on `global.json`
  in this PR.

## Scope notes

- Does not implement #123 (slots listing) — no `SlotsCommand.cs` existed in this tree.
- Does not implement any v1 item (transport-borne enrollment, revocation, rotation,
  `k >= 2`) — v0, hand-carried files only, `k` stays 1, per the design doc.
