### PR TITLE
Add read-only 'slots' command listing keyring slots and honest protection (#123)

### DIFF
--- a/TswapCli/CommandRegistry.cs
+++ b/TswapCli/CommandRegistry.cs
@@ -17,6 +17,7 @@ public static class CommandRegistry
         new CreateCommand(),
         new IngestCommand(),
         new NamesCommand(),
+        new SlotsCommand(),
         new RunCommand(),
         new CheckCommand(),
         new RedactCommand(),

--- a/TswapCli/Commands/SlotsCommand.cs
+++ b/TswapCli/Commands/SlotsCommand.cs
@@ -1,0 +1,152 @@
+using System.Text;
+using TswapCore;
+using TswapCore.Keyring;
+
+namespace TswapCli.Commands;
+
+/// <summary>
+/// Read-only keyring inspection (issue #123, Phase 6): lists a keyring vault's
+/// (<see cref="Config.Keyring"/>) enrolled slots and, honestly, what actually protects each
+/// one. Requires no hardware and no unlock — <see cref="Slot"/>/<see cref="Keyring"/> metadata
+/// lives in plaintext in <c>config.json</c> (only <see cref="Slot.Wrapped"/> is encrypted, and
+/// this command never touches it), so this never prompts for a YubiKey the way <c>names</c>/
+/// <c>get</c> do to decrypt the secrets database itself.
+///
+/// <para><b>The core requirement this issue calls out by name:</b> a no-touch YubiKey machine
+/// slot must never be reported as a bare "unprotected"/"insecure" — see
+/// <c>MULTI_MACHINE_KEYING.md</c> §Why not k &gt;= 2 (yet), which documents custody (physically
+/// controlling who has the key at all) as a real, if unusual, control distinct from no
+/// protection whatsoever. See <see cref="DescribeMachineProtection"/> and
+/// <see cref="DescribeRecoveryProtection"/> for how each slot kind's actual guarantee is
+/// surfaced.</para>
+///
+/// <para><b>Known limitation, not an oversight:</b> a <see cref="Slot"/> carries no
+/// backend/label/enrolledAt field yet (see that type's doc comment) — v0 keyrings are YubiKey-only
+/// (issue #119), so every <see cref="SlotKind.Machine"/> slot is implicitly YubiKey-backed and
+/// its touch requirement is read off <see cref="Config.RequiresTouch"/> (vault-wide, since v0
+/// has exactly one machine slot). Nothing here invents per-slot backend/presence data that
+/// doesn't exist; a future multi-backend keyring (design doc's v0 step 2) would need real
+/// per-slot metadata for this to stay accurate once a keyring can mix backends. Likewise, if a
+/// keyring ever holds more than one <see cref="SlotKind.Machine"/> slot (possible today per
+/// <see cref="KeyringCodec"/>'s format even though only #121's hand-carried enrollment, not yet
+/// landed, would produce one), there is no data available to say which slot is "this machine's
+/// own" without attempting an actual hardware unwrap per slot — this command deliberately does
+/// not do that (it would turn a passive listing into a hardware-touching operation), so it lists
+/// every machine slot on equal footing and says so when more than one is present.</para>
+/// </summary>
+public sealed class SlotsCommand : ICliCommand
+{
+    public string Name => "slots";
+    public string HelpUsage => "slots";
+    public string Description => "List a keyring vault's enrolled slots and what protects each one";
+    public bool RequiresSudo => false;
+
+    public int Execute(CommandContext ctx, string[] args)
+    {
+        var config = ctx.Storage.LoadConfig();
+        ctx.Console.Out.WriteLine(Format(config));
+        return 0;
+    }
+
+    /// <summary>
+    /// Pure formatting, factored out from <see cref="Execute"/> so it's unit-testable without
+    /// spinning up a full <see cref="CommandContext"/>. Never returns a bare "unprotected" or
+    /// "insecure" for a no-touch machine slot — see this class's doc comment.
+    /// </summary>
+    internal static string Format(Config config)
+    {
+        if (config.Keyring == null)
+        {
+            return "This vault has no keyring — it's a single derived-key or hardware-wrapped\n" +
+                   "vault with no multi-slot concept (see 'tswap init --keyring' to create a\n" +
+                   "keyring vault instead).";
+        }
+
+        byte[] keyringBytes;
+        try
+        {
+            keyringBytes = Convert.FromBase64String(config.Keyring);
+        }
+        catch (FormatException)
+        {
+            throw new TswapException(
+                "Config is corrupted: Keyring is not valid base64. Restore config.json from backup.");
+        }
+
+        var keyring = KeyringCodec.Decode(keyringBytes);
+
+        if (keyring.Slots.Count == 0)
+            return "This vault has a keyring but no enrolled slots — it is not usable as-is; " +
+                   "restore config.json from backup or re-run 'tswap init --keyring'.";
+
+        var machineSlotCount = keyring.Slots.Count(s => s.Kind == SlotKind.Machine);
+
+        var sb = new StringBuilder();
+        sb.Append($"Keyring slots ({keyring.Slots.Count}, k = {keyring.K}):\n");
+
+        const int slotColumnWidth = 10;
+        const int kindColumnWidth = 10;
+        sb.Append($"{"SLOT".PadRight(slotColumnWidth)}  {"KIND".PadRight(kindColumnWidth)}  PROTECTION\n");
+        sb.Append(new string('-', slotColumnWidth + 2 + kindColumnWidth + 2 + 40) + "\n");
+
+        foreach (var slot in keyring.Slots)
+        {
+            var shortId = AbbreviateSlotId(slot.SlotId);
+            var kindLabel = slot.Kind == SlotKind.Machine ? "machine" : "recovery";
+            var protection = slot.Kind == SlotKind.Machine
+                ? DescribeMachineProtection(config)
+                : DescribeRecoveryProtection();
+            sb.Append($"{shortId.PadRight(slotColumnWidth)}  {kindLabel.PadRight(kindColumnWidth)}  {protection}\n");
+        }
+
+        if (machineSlotCount > 1)
+        {
+            sb.Append(
+                "\nNote: this keyring has more than one machine slot. Slot data alone (no\n" +
+                "per-slot label yet) can't tell you which one is this machine's own without an\n" +
+                "actual hardware unlock, which this listing deliberately doesn't attempt.");
+        }
+
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>
+    /// The first 8 hex characters of <see cref="Slot.SlotId"/>, lowercase — the same
+    /// abbreviate-a-long-identifier convention as a git short hash. Slots have no human label
+    /// yet (see <see cref="Slot"/>'s doc comment); this is the best available stand-in.
+    /// </summary>
+    private static string AbbreviateSlotId(byte[] slotId)
+    {
+        var hex = Convert.ToHexString(slotId);
+        return (hex.Length <= 8 ? hex : hex[..8]).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Honest per-machine-slot protection description. v0 keyrings are YubiKey-only (issue
+    /// #119), and the only hardware fact available is <see cref="Config.RequiresTouch"/>
+    /// (vault-wide, not per-slot — see this class's doc comment). This is the exact case the
+    /// issue calls out: <c>false</c> (or <c>null</c>, unknown) must never collapse to a bare
+    /// "unprotected"/"insecure" — a no-touch YubiKey is still only usable by whoever has
+    /// physical custody of it, which is a real, if unusual, control (see
+    /// <c>MULTI_MACHINE_KEYING.md</c> §Why not k &gt;= 2 (yet)).
+    /// </summary>
+    private static string DescribeMachineProtection(Config config) => config.RequiresTouch switch
+    {
+        true => "YubiKey, touch required",
+        false => "YubiKey, no touch required — protected by physical custody of the YubiKey",
+        null => "YubiKey, touch requirement unknown — protected by physical custody of the YubiKey",
+    };
+
+    /// <summary>
+    /// A recovery slot's presence guarantee is not a weaker machine slot — it's a deliberately
+    /// different kind of slot with a different job: a break-glass credential that must work
+    /// offline, with nobody present, potentially years after enrollment (see
+    /// <c>MULTI_MACHINE_KEYING.md</c>'s "The recovery slot" section and its per-backend table,
+    /// where the recovery row is explicitly "none — this is the deliberately presence-free,
+    /// offline-capable break-glass slot"). Custody of the recovery private key is the only real
+    /// control, by design.
+    /// </summary>
+    private static string DescribeRecoveryProtection() =>
+        "break-glass recovery credential — no presence required by design (offline-capable); " +
+        "protected only by custody of the recovery private key";
+}

--- a/TswapTests/CommandTests.cs
+++ b/TswapTests/CommandTests.cs
@@ -296,6 +296,133 @@ public class CommandTests : IDisposable
         Assert.Contains("authentication", ex.Message);
     }
 
+    // --- Slots (Phase 6, issue #123) ---
+
+    [Fact]
+    public void SlotsFormat_TouchRequiredMachineSlot_DescribesTouchRequired()
+    {
+        var (config, _, _) = InitCommand.BuildKeyringConfig(
+            RandomNumberGenerator.GetBytes(32),
+            new List<int> { 11111111, 22222222 },
+            new string('0', 40),
+            requiresTouch: true,
+            RngMode.System,
+            Convert.ToHexString(RandomNumberGenerator.GetBytes(32)),
+            RandomNumberGenerator.GetBytes(32),
+            includeRecovery: false);
+
+        var output = SlotsCommand.Format(config);
+
+        Assert.Contains("touch required", output);
+        Assert.DoesNotContain("no touch", output);
+    }
+
+    [Fact]
+    public void SlotsFormat_NoTouchMachineSlot_DescribesCustodyNotUnprotected()
+    {
+        // The exact failure mode this issue calls out by name: a no-touch YubiKey slot has a
+        // real, if unusual, control (custody) and must never be reduced to a bare
+        // "unprotected"/"insecure" label. See MULTI_MACHINE_KEYING.md §Why not k >= 2 (yet).
+        var (config, _, _) = InitCommand.BuildKeyringConfig(
+            RandomNumberGenerator.GetBytes(32),
+            new List<int> { 11111111, 22222222 },
+            new string('0', 40),
+            requiresTouch: false,
+            RngMode.System,
+            Convert.ToHexString(RandomNumberGenerator.GetBytes(32)),
+            RandomNumberGenerator.GetBytes(32),
+            includeRecovery: false);
+
+        var output = SlotsCommand.Format(config);
+
+        Assert.Contains("custody", output);
+        Assert.Contains("no touch required", output);
+        Assert.DoesNotContain("unprotected", output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("insecure", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SlotsFormat_UnknownTouchMachineSlot_DescribesCustodyHonestly()
+    {
+        // requiresTouch == null (touch detection couldn't determine the answer on both keys) is
+        // distinct from a confirmed "false" — describe it as unknown, not as a confident "no
+        // touch required", while still noting custody applies either way.
+        var (config, _, _) = InitCommand.BuildKeyringConfig(
+            RandomNumberGenerator.GetBytes(32),
+            new List<int> { 11111111, 22222222 },
+            new string('0', 40),
+            requiresTouch: null,
+            RngMode.System,
+            Convert.ToHexString(RandomNumberGenerator.GetBytes(32)),
+            RandomNumberGenerator.GetBytes(32),
+            includeRecovery: false);
+
+        var output = SlotsCommand.Format(config);
+
+        Assert.Contains("unknown", output);
+        Assert.Contains("custody", output);
+        Assert.DoesNotContain("unprotected", output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("insecure", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SlotsFormat_RecoverySlot_DescribesPresenceFreeByDesignNotAsWeakerMachineSlot()
+    {
+        var (config, _, _) = InitCommand.BuildKeyringConfig(
+            RandomNumberGenerator.GetBytes(32),
+            new List<int> { 11111111, 22222222 },
+            new string('0', 40),
+            requiresTouch: true,
+            RngMode.System,
+            Convert.ToHexString(RandomNumberGenerator.GetBytes(32)),
+            RandomNumberGenerator.GetBytes(32),
+            includeRecovery: true);
+
+        var output = SlotsCommand.Format(config);
+
+        Assert.Contains("recovery", output);
+        Assert.Contains("break-glass", output);
+        Assert.Contains("no presence required", output);
+
+        var recoveryLine = output.Split('\n').Single(l => l.Contains("recovery"));
+        Assert.DoesNotContain("touch", recoveryLine);
+    }
+
+    [Fact]
+    public void SlotsFormat_NonKeyringVault_ReturnsHonestMessageNotError()
+    {
+        var config = new Config(new List<int> { 1, 2 }, new string('0', 40), DateTime.UtcNow, RequiresTouch: true);
+
+        var output = SlotsCommand.Format(config);
+
+        Assert.Contains("no keyring", output);
+        Assert.DoesNotContain("Exception", output);
+    }
+
+    [Fact]
+    public void Slots_EndToEnd_InitKeyringThenSlots_ListsMachineAndRecoverySlots()
+    {
+        RunTswap("init", "--keyring");
+
+        var (exit, stdout, _) = RunTswap("slots");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("machine", stdout);
+        Assert.Contains("recovery", stdout);
+        Assert.DoesNotContain("unprotected", stdout, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Slots_NonKeyringVault_ReturnsHonestMessageWithoutError()
+    {
+        RunTswap("init");
+
+        var (exit, stdout, _) = RunTswap("slots");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("no keyring", stdout);
+    }
+
     // --- Create ---
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements #123: a read-only `tswap slots` command that lists a keyring vault's enrolled slots and honestly reports what protects each one, without ever collapsing a no-touch YubiKey into a bare "unprotected"/"insecure" label.

- New `SlotsCommand` (`TswapCli/Commands/SlotsCommand.cs`), registered in `CommandRegistry` next to `names`/`list`.
- No hardware touch, no unlock: slot metadata (`SlotId`, `Kind`) lives in plaintext `config.json`, so `slots` only decodes `Config.Keyring` — it never prompts for a YubiKey the way `names`/`get` do to decrypt the secrets database itself.
- Non-keyring vaults (legacy derived-key, TPM, Secure Enclave) get a short, honest message ("no keyring — no multi-slot concept"), not an error or a confusing empty listing.

## Design judgement calls (per the issue's ask to document these)

**Command name / output format:** `tswap slots`, no arguments. A simple padded table (`SLOT` / `KIND` / `PROTECTION`), matching `ListCommand`'s header+dashes+rows style rather than `NamesCommand`'s bare line-per-item style, since this needs multiple columns.

**Slot identifier:** `SlotId` hex-encoded, truncated to the first 8 hex chars (lowercase), the same abbreviation convention as a git short hash — `Slot` has no `label` field yet (explicitly deferred in its own doc comment).

**The core requirement — honest protection, not a binary flag:**
- Machine slot, `Config.RequiresTouch == true` → `"YubiKey, touch required"`.
- Machine slot, `Config.RequiresTouch == false` → `"YubiKey, no touch required — protected by physical custody of the YubiKey"`.
- Machine slot, `Config.RequiresTouch == null` (touch detection was inconclusive on init) → `"YubiKey, touch requirement unknown — protected by physical custody of the YubiKey"`. I split `false` and `null` into distinct wording (both still say custody) rather than collapsing null into "no touch required" — asserting "no touch required" when it's actually unknown would itself be dishonest, and MULTI_MACHINE_KEYING.md's §Why not k ≥ 2 (yet) is explicit that custody is the fallback control either way.
- Recovery slot → described as a deliberately presence-free, offline-capable break-glass credential ("no presence required by design ... protected only by custody of the recovery private key"), not a weaker machine slot — per the design doc's recovery-slot section and per-backend table.

**"This machine's own" slot, if a keyring ever holds more than one Machine slot** (possible today per `KeyringCodec`'s format, even though only #121's not-yet-landed hand-carried enrollment would produce one): there is no per-slot data to answer this without actually attempting a hardware unwrap per slot, which would turn a passive listing into a hardware-touching operation. This command deliberately doesn't do that — it lists every machine slot on equal footing and appends a note when more than one is present, rather than guessing or silently picking one.

**Known, deliberate limitation (documented in `SlotsCommand`'s doc comment, not worked around):** `Slot` (see `TswapCore/Keyring/Keyring.cs`) has no per-slot backend/label/enrolledAt field yet. Because v0 keyrings are YubiKey-only (#119), a Machine slot's touch requirement is read from the vault-wide `Config.RequiresTouch` — the only hardware fact that exists today. A future multi-backend keyring (design doc's v0 step 2) would need real per-slot metadata for this to stay accurate once a keyring can mix backends. No wire-format or `Slot`/`Keyring`/`VaultUnlocker`/`InitCommand` changes were made, per the issue's constraints.

## Test plan

- [x] `./runtests.sh --unit` passes in full (508/508)
- [x] `dotnet publish -c Release TswapCli/TswapCli.csproj` succeeds (NativeAOT tripwire)
- [x] Unit tests on `SlotsCommand.Format` for touch-required, no-touch (custody), touch-unknown, and recovery slots — including an explicit assertion the no-touch case never contains a bare "unprotected"/"insecure" string, the exact failure mode this issue calls out by name
- [x] Unit test for the non-keyring-vault message (honest, not an error)
- [x] End-to-end test via `CommandTests.RunTswap`: `init --keyring` → `slots` → assert on output
- [x] Manually verified CLI output against a real `init --keyring` + `init` (non-keyring) vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)